### PR TITLE
remove tags for gitpod env

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,6 @@ markdown_extensions:
   - abbr
 extra_css:
   - _static/extra.css
-plugins:
-  - tags
+
 extra:
   generator: false


### PR DESCRIPTION
Insiders plugins should be backwards compatible, for some reason this one breaks the build. removing it until I can diagnose further
- closes #31 