### PR TITLE
Push MacOS x86/64 binary release for Rust CLI

### DIFF
--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -17,10 +17,13 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
       - name: Generate Package Version
         run: |
-          $json = Invoke-WebRequest 'https://api.github.com/repos/trinsic-id/sdk/releases/latest' | ConvertFrom-Json
+          $json = Invoke-WebRequest 'https://api.github.com/repos/trinsic-id/okapi/releases/latest' `
+            -Headers @{ "Authorization" = "Token $env:API_GITHUB_TOKEN"} | ConvertFrom-Json
           $version = $json.tag_name.Trim("v")
           echo "PACKAGE_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
         shell: pwsh
+        env:
+          API_GITHUB_TOKEN: ${{ secrets.API_GITHUB_TOKEN }}
       - run: |
           dotnet restore
           dotnet build -c Release

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -15,22 +15,18 @@ jobs:
         working-directory: ./cli
     steps:
       - uses: actions/checkout@v1
-      - run: |
+      - name: Build CLI
+        run: |
           rustup install nightly
           rustup default nightly
           rustup component add rustfmt
           cargo build --release
           cargo test --release
-      - name: Generate Package Version
-        run: |
-          $json = Invoke-WebRequest 'https://api.github.com/repos/trinsic-id/okapi/releases/latest' `
-            -Headers @{ "Authorization" = "Token $env:API_GITHUB_TOKEN"} | ConvertFrom-Json
-          echo "TAG_NAME=$json.tag_name" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
-        shell: pwsh
-      - name: Codesign binary file
+      - name: Codesign Binary File
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE_PWD }}
+          MACOS_CERTIFICATE_IDENTITY: ${{ MACOS_DEVELOPER_ID_CERTIFICATE_IDENTITY }}
         run: |
           $env:TMP_PASS = [Guid]::NewGuid().ToString()
           [System.IO.File]::WriteAllBytes([System.IO.Path]::Combine($pwd.Path, "certificate.p12"), [System.Convert]::FromBase64String("$env:MACOS_CERTIFICATE"))
@@ -40,15 +36,23 @@ jobs:
           security list-keychains -s build.keychain
           security import certificate.p12 -k build.keychain -P $env:MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $env:TMP_PASS build.keychain
-          /usr/bin/codesign --force -s AEFB3DDA9FD6A31D3DD4D7A9398A59FDDA874DCC trinsic -v
+          /usr/bin/codesign --force -s $env:MACOS_CERTIFICATE_IDENTITY trinsic -v
         shell: pwsh
         working-directory: ./cli/target/release
-      - run: |
-          $file = trinsic_cli_macos_x86_64_$env:TAG_NAME.tar.gz
+
+      - name: Generate Archive Version
+        run: |
+          $json = Invoke-WebRequest 'https://api.github.com/repos/trinsic-id/okapi/releases/latest'
+          echo "TAG_NAME=$json.tag_name" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
+        shell: pwsh
+      - name: Build Archive
+        run: |
+          $file = trinsic_cli_$env:TAG_NAME_macos_x86_64.tar.gz
           tar czf $file --directory=./target/release/ trinsic
           echo "ARTIFACT_FILE=$file" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
         shell: pwsh
       - uses: svenstaro/upload-release-action@v2
+        name: Upload Archive
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ env.ARTIFACT_FILE }}

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -1,0 +1,62 @@
+name: "Rust (release)"
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published, prereleased]
+  pull_request:
+
+jobs:
+  homebrew:
+    runs-on: macos-latest
+    environment: homebrew
+    defaults:
+      run:
+        working-directory: ./cli
+    steps:
+      - uses: actions/checkout@v1
+      - run: |
+          rustup install nightly
+          rustup default nightly
+          rustup component add rustfmt
+          cargo build --release
+          cargo test --release
+      - name: Generate Package Version
+        run: |
+          $json = Invoke-WebRequest 'https://api.github.com/repos/trinsic-id/okapi/releases/latest' `
+            -Headers @{ "Authorization" = "Token $env:API_GITHUB_TOKEN"} | ConvertFrom-Json
+          echo "TAG_NAME=$json.tag_name" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
+        shell: pwsh
+      - name: Codesign binary file
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE_PWD }}
+        run: |
+          $env:TMP_PASS = [Guid]::NewGuid().ToString()
+          [System.IO.File]::WriteAllBytes([System.IO.Path]::Combine($pwd.Path, "certificate.p12"), [System.Convert]::FromBase64String("$env:MACOS_CERTIFICATE"))
+          security create-keychain -p $env:TMP_PASS build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p $env:TMP_PASS build.keychain
+          security list-keychains -s build.keychain
+          security import certificate.p12 -k build.keychain -P $env:MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $env:TMP_PASS build.keychain
+          /usr/bin/codesign --force -s AEFB3DDA9FD6A31D3DD4D7A9398A59FDDA874DCC trinsic -v
+        shell: pwsh
+        working-directory: ./cli/target/release
+      - run: |
+          $file = trinsic_cli_macos_x86_64_$env:TAG_NAME.tar.gz
+          tar czf $file --directory=./target/release/ trinsic
+          echo "ARTIFACT_FILE=$file" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
+        shell: pwsh
+      - uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.ARTIFACT_FILE }}
+          asset_name: ${{ env.ARTIFACT_FILE }}
+          tag: ${{ env.TAG_NAME }}
+          overwrite: true
+          body: "Trinsic CLI for MacOS"
+
+
+
+

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -42,9 +42,12 @@ jobs:
 
       - name: Generate Archive Version
         run: |
-          $json = Invoke-WebRequest 'https://api.github.com/repos/trinsic-id/okapi/releases/latest'
+          $json = Invoke-WebRequest 'https://api.github.com/repos/trinsic-id/sdk/releases/latest' `
+            -Headers @{ "Authorization" = "Token $env:API_GITHUB_TOKEN"} | ConvertFrom-Json
           echo "TAG_NAME=$json.tag_name" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
         shell: pwsh
+        env:
+          API_GITHUB_TOKEN: ${{ secrets.API_GITHUB_TOKEN }}
       - name: Build Archive
         run: |
           $file = "trinsic_cli_$env:TAG_NAME_macos_x86_64.tar.gz"

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -47,7 +47,7 @@ jobs:
         shell: pwsh
       - name: Build Archive
         run: |
-          $file = trinsic_cli_$env:TAG_NAME_macos_x86_64.tar.gz
+          $file = "trinsic_cli_$env:TAG_NAME_macos_x86_64.tar.gz"
           tar czf $file --directory=./target/release/ trinsic
           echo "ARTIFACT_FILE=$file" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
         shell: pwsh

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   release:
     types: [published, prereleased]
-  pull_request:
 
 jobs:
   homebrew:
@@ -15,6 +14,15 @@ jobs:
         working-directory: ./cli
     steps:
       - uses: actions/checkout@v1
+        name: Checkout
+      - name: Generate Archive Version
+        run: |
+          $json = Invoke-WebRequest 'https://api.github.com/repos/trinsic-id/sdk/releases/latest' `
+            -Headers @{ "Authorization" = "Token $env:API_GITHUB_TOKEN"} | ConvertFrom-Json
+          echo "TAG_NAME=$($json.tag_name)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
+        shell: pwsh
+        env:
+          API_GITHUB_TOKEN: ${{ secrets.API_GITHUB_TOKEN }}
       - name: Build CLI
         run: |
           rustup install nightly
@@ -39,18 +47,9 @@ jobs:
           /usr/bin/codesign --force -s $env:MACOS_CERTIFICATE_IDENTITY trinsic -v
         shell: pwsh
         working-directory: ./cli/target/release
-
-      - name: Generate Archive Version
-        run: |
-          $json = Invoke-WebRequest 'https://api.github.com/repos/trinsic-id/sdk/releases/latest' `
-            -Headers @{ "Authorization" = "Token $env:API_GITHUB_TOKEN"} | ConvertFrom-Json
-          echo "TAG_NAME=$json.tag_name" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
-        shell: pwsh
-        env:
-          API_GITHUB_TOKEN: ${{ secrets.API_GITHUB_TOKEN }}
       - name: Build Archive
         run: |
-          $file = "trinsic_cli_$env:TAG_NAME_macos_x86_64.tar.gz"
+          $file = "trinsic_cli_$($env:TAG_NAME)_macos_x86_64.tar.gz"
           tar czf $file --directory=./target/release/ trinsic
           echo "ARTIFACT_FILE=$file" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
         shell: pwsh
@@ -58,7 +57,9 @@ jobs:
         name: Upload Archive
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.ARTIFACT_FILE }}
+          # this action doesn't respect job 'defaults' and requires
+          # explicit path
+          file: ./cli/${{ env.ARTIFACT_FILE }}
           asset_name: ${{ env.ARTIFACT_FILE }}
           tag: ${{ env.TAG_NAME }}
           overwrite: true

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE_PWD }}
-          MACOS_CERTIFICATE_IDENTITY: ${{ MACOS_DEVELOPER_ID_CERTIFICATE_IDENTITY }}
+          MACOS_CERTIFICATE_IDENTITY: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE_IDENTITY }}
         run: |
           $env:TMP_PASS = [Guid]::NewGuid().ToString()
           [System.IO.File]::WriteAllBytes([System.IO.Path]::Combine($pwd.Path, "certificate.p12"), [System.Convert]::FromBase64String("$env:MACOS_CERTIFICATE"))

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,6 +2,15 @@
 
 ## Installation
 
+### Using Homebrew
+
+```
+brew tap trinsic-id/trinsic
+brew install trinsic
+```
+
+### Using Cargo
+
 Requires [Rustup](https://www.rust-lang.org/tools/install) nightly toolchain
 
 ```bash

--- a/cli/src/cli.yaml
+++ b/cli/src/cli.yaml
@@ -1,5 +1,5 @@
 name: trinsic
-version: "1.0"
+version: "1.0.1"
 author: Trinsic Technologies Inc.
 about: >-
 


### PR DESCRIPTION
Uploads a signed binary file for MacOS to the release for use with Homebrew