### PR TITLE
Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+/.github/   @fundthmcalculus @tmarkovski
+/docs/      @michaeldboyd
+/dotnet/    @tmarkovski
+/go/        @fundthmcalculus
+/java/      @fundthmcalculus
+/node/      @tmarkovski
+/proto/     @fundthmcalculus @tmarkovski
+/python/    @fundthmcalculus
+/ruby/      @fundthmcalculus
+/web/      @tmarkovski

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,8 @@
 /dotnet/    @tmarkovski
 /go/        @fundthmcalculus
 /java/      @fundthmcalculus
-/node/      @tmarkovski
+/node/      @tmarkovski @MichaelEdwardBlack
 /proto/     @fundthmcalculus @tmarkovski
 /python/    @fundthmcalculus
 /ruby/      @fundthmcalculus
-/web/      @tmarkovski
+/web/       @tmarkovski @MichaelEdwardBlack


### PR DESCRIPTION
Feel free to edit the proposed codeowners. Alternatives I've considered are:
1. `/docs/` boyd, TM, fundthmcalculus
2. `/go/` fundthmcalc, seth back
3. `/node` TM, Michael Black