### PR TITLE
Python garbage collection cleanup improvements

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [3.7, 3.8, 3.9 ]  # '3.10' has issues for now
+        python-version: [3.8, 3.9, '3.10' ]  # '3.10' has issues for now
     steps:
       - uses: actions/checkout@v2
       - name: Download workflow artifact

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [3.8, 3.9, '3.10' ]  # '3.10' has issues for now
+        python-version: [3.8, 3.9 ]  # '3.10' has issues for now
     steps:
       - uses: actions/checkout@v2
       - name: Download workflow artifact

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [3.8, 3.9 ]  # '3.10' has issues for now
+        python-version: [3.7, 3.8, 3.9 ]  # '3.10' has issues for now
     steps:
       - uses: actions/checkout@v2
       - name: Download workflow artifact
@@ -35,10 +35,10 @@ jobs:
           workflow: "build-libs.yml"
           path: ./libs
           repo: trinsic-id/okapi
-      - name: Set up Python 3.9
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Build, Test, Pack
         run: |
           python -m pip install -r requirements.txt

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -57,7 +57,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: Python Unit Test Results (${{ matrix.os }} / ${{ matrix.python-version }})
+          name: Python ${{ matrix.python-version }} Unit Test Results (${{ matrix.os }})
           path: 'python/test_output*.xml'
 
   publish-test-results-python:

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -57,7 +57,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: Python Unit Test Results (${{ matrix.os }})
+          name: Python Unit Test Results (${{ matrix.os }} / ${{ matrix.python-version }})
           path: 'python/test_output*.xml'
 
   publish-test-results-python:

--- a/python/README.md
+++ b/python/README.md
@@ -1,1 +1,10 @@
 # Python SDK
+
+## Known Issues
+* Python `asyncio` event loop closed bug: https://bugs.python.org/issue36709 emits output like this:
+```diff
+- RuntimeError: Event loop is closed
+- Fatal error on SSL transport
+- protocol: <asyncio.sslproto.SSLProtocol object at 0x0000018C2D5ACA30>
+- transport: <_ProactorSocketTransport fd=-1 read=<_OverlappedFuture cancelled>>
+```

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,3 +3,4 @@ grpclib~=0.4.1
 grpcio-tools
 trinsic-okapi~=1.0.5
 blake3~=0.2.1
+asynctest

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,5 @@
-betterproto~=2.0.0b3
+betterproto~=2.0.0b4
 grpclib~=0.4.1
 grpcio-tools
-trinsic-okapi~=1.0.5
+trinsic-okapi~=1.2.0
 blake3~=0.2.1
-asynctest

--- a/python/samples/ecosystem_demo.py
+++ b/python/samples/ecosystem_demo.py
@@ -1,6 +1,5 @@
 import asyncio
 
-from trinsic.proto.services.provider.v1 import ParticipantType
 from trinsic.services import ProviderService, AccountService
 from trinsic.trinsic_util import trinsic_test_config
 

--- a/python/samples/trustregistry_demo.py
+++ b/python/samples/trustregistry_demo.py
@@ -39,10 +39,6 @@ async def trustregistry_demo():
     assert search_result.items_json is not None
     assert len(search_result.items_json) > 0
 
-    # clean up
-    service.close()
-    account_service.close()
-
 
 if __name__ == "__main__":
     asyncio.run(trustregistry_demo())

--- a/python/samples/trustregistry_demo.py
+++ b/python/samples/trustregistry_demo.py
@@ -39,6 +39,10 @@ async def trustregistry_demo():
     assert search_result.items_json is not None
     assert len(search_result.items_json) > 0
 
+    # clean up
+    service.close()
+    account_service.close()
+
 
 if __name__ == "__main__":
     asyncio.run(trustregistry_demo())

--- a/python/samples/vaccine_demo.py
+++ b/python/samples/vaccine_demo.py
@@ -103,10 +103,6 @@ async def vaccine_demo():
     # assert credential_status.revoked is True
     # }
 
-    # wallet_service.close() - not required, because wallet shares channel with account
-    account_service.close()
-    credentials_service.close()
-
 
 if __name__ == "__main__":
     asyncio.run(vaccine_demo())

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -20,8 +20,8 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     grpclib
-    betterproto>=2.0.0b3
-    trinsic-okapi>=1.0.4
+    betterproto>=2.0.0b4
+    trinsic-okapi>=1.2.0
     blake3>=0.2.1
 
 [options.packages.find]

--- a/python/tests/test_trinsic_services.py
+++ b/python/tests/test_trinsic_services.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 
 import asynctest as asynctest
@@ -10,55 +11,67 @@ from trinsic.services import WalletService, ProviderService, TrustRegistryServic
 from trinsic.trinsic_util import trinsic_test_config
 
 
-class TestServices(asynctest.TestCase):
-    async def test_servicebase_setprofile(self):
-        wallet_service = WalletService(None, trinsic_test_config())
-        with self.assertRaises(Exception) as excep:
-            self.assertIsNotNone(wallet_service.build_metadata(None))
-        self.assertEqual("cannot call authenticated endpoint: profile must be set", excep.exception.args[0].lower())
+# Due to some issues with python and async io test cases, we have to run each sample in a separate asyncio event loop.
+
+class TestServices(unittest.TestCase):
+    def test_servicebase_setprofile(self):
+        async def test_code():
+            wallet_service = WalletService(None, trinsic_test_config())
+            with self.assertRaises(Exception) as excep:
+                self.assertIsNotNone(wallet_service.build_metadata(None))
+            self.assertEqual("cannot call authenticated endpoint: profile must be set", excep.exception.args[0].lower())
+        asyncio.run(test_code())
 
     @unittest.skip("Ecosystem support not implemented")
-    async def test_providerservice_demo(self):
-        await provider_demo()
+    def test_providerservice_demo(self):
+        asyncio.run(provider_demo())
 
-    async def test_vaccine_demo(self):
-        await vaccine_demo()
+    def test_vaccine_demo(self):
+        asyncio.run(vaccine_demo())
 
-    async def test_trustregistry_demo(self):
-        await trustregistry_demo()
+    def test_trustregistry_demo(self):
+        asyncio.run(trustregistry_demo())
 
-    async def test_ecosystem_demo(self):
-        await ecosystem_demo()
+    def test_ecosystem_demo(self):
+        asyncio.run(ecosystem_demo())
 
-    async def test_providerservice_input_validation(self):
-        cred_service = ProviderService(None, trinsic_test_config())
-        with self.assertRaises(ValueError) as ve:
-            await cred_service.invite_participant()
+    def test_providerservice_input_validation(self):
+        async def test_code():
+            cred_service = ProviderService(None, trinsic_test_config())
+            with self.assertRaises(ValueError) as ve:
+                await cred_service.invite_participant()
+            with self.assertRaises(ValueError) as ve:
+                await cred_service.invitation_status()
+            cred_service.close()
 
-        with self.assertRaises(ValueError) as ve:
-            await cred_service.invitation_status()
+        asyncio.run(test_code())
 
-    async def test_trustregistryservice_input_validation(self):
-        cred_service = TrustRegistryService(None, trinsic_test_config())
-        with self.assertRaises(ValueError) as ve:
-            await cred_service.register_governance_framework("", "Invalid framework")
+    def test_trustregistryservice_input_validation(self):
+        async def test_code():
+            cred_service = TrustRegistryService(None, trinsic_test_config())
+            with self.assertRaises(ValueError) as ve:
+                await cred_service.register_governance_framework("", "Invalid framework")
 
-        cred_service.close()
+            cred_service.close()
 
-    async def test_protect_unprotect_account(self):
-        account_service = AccountService(None, trinsic_test_config())
-        my_profile, _ = await account_service.sign_in()
-        await self.print_get_info(account_service, my_profile)
+        asyncio.run(test_code())
 
-        code = b"1234"
-        my_protected_profile = account_service.protect(my_profile, code)
-        with self.assertRaises(ValueError) as ve:
-            await self.print_get_info(account_service, my_protected_profile)
+    def test_protect_unprotect_account(self):
+        async def test_code():
+            account_service = AccountService(None, trinsic_test_config())
+            my_profile, _ = await account_service.sign_in()
+            await self.print_get_info(account_service, my_profile)
 
-        my_unprotected_profile = account_service.unprotect(my_profile, code)
-        await self.print_get_info(account_service, my_unprotected_profile)
+            code = b"1234"
+            my_protected_profile = account_service.protect(my_profile, code)
+            with self.assertRaises(ValueError) as ve:
+                await self.print_get_info(account_service, my_protected_profile)
 
-        account_service.close()
+            my_unprotected_profile = account_service.unprotect(my_profile, code)
+            await self.print_get_info(account_service, my_unprotected_profile)
+
+            account_service.close()
+        asyncio.run(test_code())
 
     @staticmethod
     async def print_get_info(account_service, my_profile):

--- a/python/tests/test_trinsic_services.py
+++ b/python/tests/test_trinsic_services.py
@@ -1,13 +1,11 @@
 import asyncio
 import unittest
 
-import asynctest as asynctest
-
 from samples.ecosystem_demo import ecosystem_demo
 from samples.provider_demo import provider_demo
 from samples.trustregistry_demo import trustregistry_demo
 from samples.vaccine_demo import vaccine_demo
-from trinsic.services import WalletService, ProviderService, TrustRegistryService, AccountService, CredentialsService
+from trinsic.services import WalletService, ProviderService, TrustRegistryService, AccountService
 from trinsic.trinsic_util import trinsic_test_config
 
 
@@ -20,6 +18,7 @@ class TestServices(unittest.TestCase):
             with self.assertRaises(Exception) as excep:
                 self.assertIsNotNone(wallet_service.build_metadata(None))
             self.assertEqual("cannot call authenticated endpoint: profile must be set", excep.exception.args[0].lower())
+
         asyncio.run(test_code())
 
     @unittest.skip("Ecosystem support not implemented")
@@ -42,7 +41,6 @@ class TestServices(unittest.TestCase):
                 await cred_service.invite_participant()
             with self.assertRaises(ValueError) as ve:
                 await cred_service.invitation_status()
-            cred_service.close()
 
         asyncio.run(test_code())
 
@@ -51,8 +49,6 @@ class TestServices(unittest.TestCase):
             cred_service = TrustRegistryService(None, trinsic_test_config())
             with self.assertRaises(ValueError) as ve:
                 await cred_service.register_governance_framework("", "Invalid framework")
-
-            cred_service.close()
 
         asyncio.run(test_code())
 
@@ -70,7 +66,6 @@ class TestServices(unittest.TestCase):
             my_unprotected_profile = account_service.unprotect(my_profile, code)
             await self.print_get_info(account_service, my_unprotected_profile)
 
-            account_service.close()
         asyncio.run(test_code())
 
     @staticmethod

--- a/python/tests/test_trinsic_services.py
+++ b/python/tests/test_trinsic_services.py
@@ -1,5 +1,7 @@
 import unittest
 
+import asynctest as asynctest
+
 from samples.ecosystem_demo import ecosystem_demo
 from samples.provider_demo import provider_demo
 from samples.trustregistry_demo import trustregistry_demo
@@ -8,7 +10,7 @@ from trinsic.services import WalletService, ProviderService, TrustRegistryServic
 from trinsic.trinsic_util import trinsic_test_config
 
 
-class TestServices(unittest.IsolatedAsyncioTestCase):
+class TestServices(asynctest.TestCase):
     async def test_servicebase_setprofile(self):
         wallet_service = WalletService(None, trinsic_test_config())
         with self.assertRaises(Exception) as excep:
@@ -41,6 +43,8 @@ class TestServices(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError) as ve:
             await cred_service.register_governance_framework("", "Invalid framework")
 
+        cred_service.close()
+
     async def test_protect_unprotect_account(self):
         account_service = AccountService(None, trinsic_test_config())
         my_profile, _ = await account_service.sign_in()
@@ -53,6 +57,8 @@ class TestServices(unittest.IsolatedAsyncioTestCase):
 
         my_unprotected_profile = account_service.unprotect(my_profile, code)
         await self.print_get_info(account_service, my_unprotected_profile)
+
+        account_service.close()
 
     @staticmethod
     async def print_get_info(account_service, my_profile):

--- a/python/trinsic/service_base.py
+++ b/python/trinsic/service_base.py
@@ -39,10 +39,16 @@ class ServiceBase(ABC):
         self._channel: Channel = channel or create_channel(server_config)
         self._security_provider: SecurityProvider = OberonSecurityProvider()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     def close(self):
         """Close the underlying channel"""
-        self._channel.close()
-        del self._channel
+        if self._channel is not None:
+            self._channel.close()
 
     def build_metadata(self, request: Message):
         """

--- a/python/trinsic/service_base.py
+++ b/python/trinsic/service_base.py
@@ -45,6 +45,9 @@ class ServiceBase(ABC):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    def __del__(self):
+        self.close()
+
     def close(self):
         """Close the underlying channel"""
         if self._channel is not None:

--- a/python/trinsic/services.py
+++ b/python/trinsic/services.py
@@ -454,8 +454,7 @@ class TrustRegistryService(ServiceBase):
         return await self.client.search_registry(query=query, options=RequestOptions(
             response_json_format=JsonFormat.Protobuf))
 
-    async def fetch_data(self, governance_framework_uri: str = None, query: str = None) -> AsyncIterator[
-        FetchDataResponse]:
+    async def fetch_data(self, governance_framework_uri: str = None, query: str = None) -> AsyncIterator[FetchDataResponse]:
         return self.client.fetch_data(governance_framework_uri=governance_framework_uri, query=query)
 
 

--- a/python/trinsic/services.py
+++ b/python/trinsic/services.py
@@ -5,7 +5,7 @@ Trinsic Service wrappers
 import datetime
 import json
 import urllib.parse
-from typing import List, Tuple, SupportsBytes, Union, Optional, AsyncIterator
+from typing import List, Tuple, SupportsBytes, Union, Optional, AsyncIterator, Dict
 
 from grpclib.client import Channel
 from trinsicokapi import oberon
@@ -204,7 +204,7 @@ class CredentialTemplatesService(ServiceBase):
         super().__init__(profile, server_config, channel)
         self.client: CredentialTemplatesStub = self.stub_with_metadata(CredentialTemplatesStub)
 
-    async def create(self, name: str, fields: Optional[dict[str, TemplateField]],
+    async def create(self, name: str, fields: Optional[Dict[str, TemplateField]],
                      allow_additional_fields: bool) -> CreateCredentialTemplateResponse:
         return await self.client.create(name=name, fields=fields, allow_additional_fields=allow_additional_fields)
 

--- a/python/trinsic/services.py
+++ b/python/trinsic/services.py
@@ -41,8 +41,7 @@ class AccountService(ServiceBase):
         super().__init__(profile, server_config, channel)
         self.client: AccountStub = self.stub_with_metadata(AccountStub)
 
-    async def sign_in(self, details: AccountDetails = AccountDetails(email='')) -> Tuple[
-        AccountProfile, ConfirmationMethod]:
+    async def sign_in(self, details: AccountDetails = AccountDetails(email='')) -> Tuple[AccountProfile, ConfirmationMethod]:
         """
         Perform a sign-in to obtain an account profile. If the `AccountDetails` are specified, they will be used to associate
         Args:
@@ -455,7 +454,8 @@ class TrustRegistryService(ServiceBase):
         return await self.client.search_registry(query=query, options=RequestOptions(
             response_json_format=JsonFormat.Protobuf))
 
-    async def fetch_data(self, governance_framework_uri: str = None, query: str = None) -> AsyncIterator[FetchDataResponse]:
+    async def fetch_data(self, governance_framework_uri: str = None, query: str = None) -> AsyncIterator[
+        FetchDataResponse]:
         return self.client.fetch_data(governance_framework_uri=governance_framework_uri, query=query)
 
 


### PR DESCRIPTION
Reduces the impact of the python `asyncio` cleanup bug.
Properly sets up 3.8 on GHA.
Enables automatic garbage collection to close channels via `__del__` and `with` support.