### PR TITLE
Prevent accidental null set bug Python

### DIFF
--- a/python/trinsic/proto/services/provider/v1/__init__.py
+++ b/python/trinsic/proto/services/provider/v1/__init__.py
@@ -148,8 +148,10 @@ class ProviderStub(betterproto.ServiceStub):
         request = InviteRequest()
         request.participant = participant
         request.description = description
-        request.email = email
-        request.phone = phone
+        if email is not None and email != "":
+            request.email = email
+        if phone is not None and phone != "":
+            request.phone = phone
         if didcomm_invitation is not None:
             request.didcomm_invitation = didcomm_invitation
 

--- a/python/trinsic/proto/services/verifiablecredentials/v1/__init__.py
+++ b/python/trinsic/proto/services/verifiablecredentials/v1/__init__.py
@@ -201,8 +201,10 @@ class VerifiableCredentialStub(betterproto.ServiceStub):
     ) -> "SendResponse":
 
         request = SendRequest()
-        request.email = email
-        request.did_uri = did_uri
+        if email is not None and email != "":
+            request.email = email
+        if did_uri is not None and did_uri != "":
+            request.did_uri = did_uri
         if didcomm_invitation is not None:
             request.didcomm_invitation = didcomm_invitation
         if document is not None:


### PR DESCRIPTION
ensure we don't accidentally set null due to a python betterproto bug (which will be fixed in the production version 2.0.0 when it switches to `Request` `Response` format.