### PR TITLE
represent the error correctly

### DIFF
--- a/python/tests/test_trinsic_services.py
+++ b/python/tests/test_trinsic_services.py
@@ -27,7 +27,7 @@ class TestServices(unittest.TestCase):
     def test_responsestatus_exception(self):
         with self.assertRaises(ResponseStatusException) as rse:
             ResponseStatusException.assert_success(ResponseStatus.UNKNOWN_ERROR, "test should fail")
-        self.assertEqual(f"test should fail failed, status={ResponseStatus.UNKNOWN_ERROR}", str(rse.exception))
+        self.assertEqual(f"test should fail failed, status={repr(ResponseStatus.UNKNOWN_ERROR)}", str(rse.exception))
         ResponseStatusException.assert_success(ResponseStatus.SUCCESS, "This should NOT fail")
 
     @unittest.skip("Ecosystem support not implemented")

--- a/python/trinsic/service_base.py
+++ b/python/trinsic/service_base.py
@@ -95,11 +95,11 @@ class ServiceBase(ABC):
 
 class ResponseStatusException(Exception):
     """
-    Exception raised when an action has a non-success reponse status.
+    Exception raised when an action has a non-success response status.
     """
 
     def __init__(self, action: str, status: ResponseStatus):
-        super().__init__(f"{action} failed, status={status}")
+        super().__init__(f"{action} failed, status={repr(status)}")
         self.status = status
 
     @staticmethod


### PR DESCRIPTION
Representation error so that the *name* of the enumeration value shows up in the error message.