### PR TITLE
Upload jar to release

### DIFF
--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -49,3 +49,13 @@ jobs:
           TEST_SERVER_ENDPOINT: staging-internal.trinsic.cloud
           TEST_SERVER_PORT: 443
           TEST_SERVER_USE_TLS: true
+
+      - name: Upload to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./java/build/libs/trinsic-services-${{ steps.setversion.outputs.packageVersion }}.jar
+          asset_name: trinsic-services-${{ steps.setversion.outputs.packageVersion }}.jar
+          tag: ${{ steps.setversion.outputs.releaseVersion }}
+          overwrite: false
+          body: "Trinsic Services JAR File"


### PR DESCRIPTION
The build failure is unrelated to this change, and is being tracked here: https://github.com/trinsic-id/sdk/pull/427