### PR TITLE
Improve build process - run all actions when `devops` changes, only download required binaries

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -9,6 +9,7 @@ on:
       - "dotnet/**"
       - "proto/**"
       - ".github/workflows/*dotnet*"
+      - "devops/**"
   push:
     branches:
       - main
@@ -16,6 +17,7 @@ on:
       - "dotnet/**"
       - "proto/**"
       - ".github/workflows/*dotnet*"
+      - "devops/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-golang.yml
+++ b/.github/workflows/build-golang.yml
@@ -21,20 +21,29 @@ on:
 jobs:
   build-and-test-golang:
     name: Build, Test
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os-artifact[0] }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ] # , macos-latest ] disabled due to macos not allowing us to set the LD_LIBRARY_PATH as a github action
+        os-artifact: [ [ubuntu-latest, linux], [windows-latest, windows-gnu] ] # , macos-latest ] disabled due to macos not allowing us to set the LD_LIBRARY_PATH as a github action
     steps:
       - uses: actions/checkout@v2
-      - name: Download workflow artifact
+      - name: Download ${{ matrix.os-artifact[0] }} binaries
         uses: dawidd6/action-download-artifact@v2.14.0
         with:
           workflow: "build-libs.yml"
-          path: ./libs
+          path: ./libs/${{ matrix.os-artifact[1] }}
           repo: trinsic-id/okapi
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ matrix.os-artifact[1] }}
+      - name: Download C header
+        uses: dawidd6/action-download-artifact@v2.14.0
+        with:
+          workflow: "build-libs.yml"
+          path: ./libs/C_header
+          repo: trinsic-id/okapi
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          name: C_header
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -57,8 +66,6 @@ jobs:
         env:
           API_GITHUB_TOKEN: ${{ secrets.API_GITHUB_TOKEN }}
           LD_LIBRARY_PATH: "${{ github.workspace }}/go/services"
-          DYLD_FALLBACK_LIBRARY_PATH: "${{ github.workspace }}/go/services"
-          DYLD_LIBRARY_PATH: "${{ github.workspace }}/go/services"
           CGO_LDFLAGS: "-L${{ github.workspace }}/go/services"
           CGO_CFLAGS: "-I${{ github.workspace }}/go/services"
           TEST_SERVER_ENDPOINT: staging-internal.trinsic.cloud
@@ -68,7 +75,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: Golang Unit Test Results (${{ matrix.os }})
+          name: Golang Unit Test Results (${{ matrix.os-artifact[0] }})
           path: 'go/services/test_output*.xml'
 
   publish-test-results-golang:

--- a/.github/workflows/build-golang.yml
+++ b/.github/workflows/build-golang.yml
@@ -8,6 +8,7 @@ on:
       - "go/**"
       - "proto/**"
       - ".github/workflows/*golang*"
+      - "devops/**"
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
       - "go/**"
       - "proto/**"
       - ".github/workflows/*golang*"
+      - "devops/**"
 
 jobs:
   build-and-test-golang:

--- a/.github/workflows/build-golang.yml
+++ b/.github/workflows/build-golang.yml
@@ -47,7 +47,7 @@ jobs:
           go version
           go install golang.org/x/lint/golint@latest
           go install github.com/jstemmer/go-junit-report@latest
-          python ../../devops/build_sdks.py
+          python ../../devops/build_sdks.py --language=golang
           go build
           golint
           go test -v | go-junit-report > test_output.xml

--- a/.github/workflows/build-golang.yml
+++ b/.github/workflows/build-golang.yml
@@ -34,6 +34,7 @@ jobs:
           workflow: "build-libs.yml"
           path: ./libs
           repo: trinsic-id/okapi
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -8,6 +8,7 @@ on:
       - "java/**"
       - "proto/**"
       - ".github/workflows/*java*"
+      - "devops/**"
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
       - "java/**"
       - "proto/**"
       - ".github/workflows/*java*"
+      - "devops/**"
 
 jobs:
   build-and-test-java:

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -39,11 +39,13 @@ jobs:
         with:
           python-version: 3.9
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v2.14.0
+        uses: dawidd6/action-download-artifact@v2.16.0
         with:
           workflow: "build-libs.yml"
           path: ./libs
           repo: trinsic-id/okapi
+          github_token: ${{ secrets.GITHUB_TOKEN }} 
+          name: ["windows", "macos", "linux"]
       - name: Build with Gradle
         run: |
           python ../devops/build_sdks.py --language=golang

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -46,7 +46,7 @@ jobs:
           repo: trinsic-id/okapi
       - name: Build with Gradle
         run: |
-          python ../devops/build_sdks.py
+          python ../devops/build_sdks.py --language=golang
           gradle build
         shell: pwsh
         working-directory: java

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -21,11 +21,11 @@ on:
 jobs:
   build-and-test-java:
     name: Build
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os-artifact[0] }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os-artifact: [ [ubuntu-latest, linux], [windows-latest, windows], [macos-latest, macos] ]
 
     steps:
       - uses: actions/checkout@v2
@@ -38,13 +38,22 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Download workflow artifact
+      - name: Download ${{ matrix.os-artifact[0] }} binaries
         uses: dawidd6/action-download-artifact@v2.14.0
         with:
           workflow: "build-libs.yml"
-          path: ./libs
+          path: ./libs/${{ matrix.os-artifact[1] }}
           repo: trinsic-id/okapi
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ matrix.os-artifact[1] }}
+      - name: Download C header
+        uses: dawidd6/action-download-artifact@v2.14.0
+        with:
+          workflow: "build-libs.yml"
+          path: ./libs/C_header
+          repo: trinsic-id/okapi
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          name: C_header
       - name: Build with Gradle
         run: |
           python ../devops/build_sdks.py --language=java

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -39,13 +39,12 @@ jobs:
         with:
           python-version: 3.9
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v2.16.0
+        uses: dawidd6/action-download-artifact@v2.14.0
         with:
           workflow: "build-libs.yml"
           path: ./libs
           repo: trinsic-id/okapi
-          github_token: ${{ secrets.GITHUB_TOKEN }} 
-          name: [windows, macos, linux]
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Gradle
         run: |
           python ../devops/build_sdks.py --language=golang

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -47,7 +47,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Gradle
         run: |
-          python ../devops/build_sdks.py --language=golang
+          python ../devops/build_sdks.py --language=java
           gradle build
         shell: pwsh
         working-directory: java

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -45,7 +45,7 @@ jobs:
           path: ./libs
           repo: trinsic-id/okapi
           github_token: ${{ secrets.GITHUB_TOKEN }} 
-          name: ["windows", "macos", "linux"]
+          name: [windows, macos, linux]
       - name: Build with Gradle
         run: |
           python ../devops/build_sdks.py --language=golang

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -46,14 +46,6 @@ jobs:
           repo: trinsic-id/okapi
           github_token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ matrix.os-artifact[1] }}
-      - name: Download C header
-        uses: dawidd6/action-download-artifact@v2.14.0
-        with:
-          workflow: "build-libs.yml"
-          path: ./libs/C_header
-          repo: trinsic-id/okapi
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          name: C_header
       - name: Build with Gradle
         run: |
           python ../devops/build_sdks.py --language=java

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           python -m pip install pytest pytest-cov
-          python ../devops/build_sdks.py
+          python ../devops/build_sdks.py --language=python
           python -m pytest --cache-clear ./tests --junitxml=test_output.xml --cov=.
         shell: pwsh
         working-directory: python

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -27,17 +27,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os-artifact: [ [ubuntu-latest, linux], [windows-latest, windows], [macos-latest, macos] ]
         python-version: [3.8, 3.9 ]  # '3.10' has issues for now
     steps:
       - uses: actions/checkout@v2
-      - name: Download workflow artifact
+      - name: Download ${{ matrix.os-artifact[0] }} binaries
         uses: dawidd6/action-download-artifact@v2.14.0
         with:
           workflow: "build-libs.yml"
-          path: ./libs
+          path: ./libs/${{ matrix.os-artifact[1] }}
           repo: trinsic-id/okapi
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ matrix.os-artifact[1] }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -37,6 +37,7 @@ jobs:
           workflow: "build-libs.yml"
           path: ./libs
           repo: trinsic-id/okapi
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build-and-test-python:
     name: Test Python code
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os-artifact[0] }}
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +61,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: Python ${{ matrix.python-version }} Unit Test Results (${{ matrix.os }})
+          name: Python ${{ matrix.python-version }} Unit Test Results (${{ matrix.os-artifact[0] }})
           path: 'python/test_output*.xml'
 
   publish-test-results-python:

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -10,6 +10,7 @@ on:
       - "python/**"
       - "proto/**"
       - ".github/workflows/*python*"
+      - "devops/**"
   push:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
       - "python/**"
       - "proto/**"
       - ".github/workflows/*python*"
+      - "devops/**"
 
 jobs:
   build-and-test-python:

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   build-and-test-ruby:
     name: Build, Test
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os-artifact[0] }}
     strategy:
       matrix:
         os-artifact: [ [ubuntu-latest, linux], [windows-latest, windows], [macos-latest, macos] ]
@@ -70,7 +70,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name:  Ruby ${{ matrix.ruby-version }} Unit Test Results (${{ matrix.os }})
+          name:  Ruby ${{ matrix.ruby-version }} Unit Test Results (${{ matrix.os-artifact[0] }})
           path: 'ruby/test/reports/TEST-*.xml'
 
   publish-test-results-ruby:

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -2,11 +2,13 @@ name: Ruby
 
 on:
   workflow_call:
+  workflow_dispatch:
   pull_request:
     paths:
       - "ruby/**"
       - "proto/**"
       - ".github/workflows/*ruby*"
+      - "devops/**"
   push:
     branches:
       - main
@@ -14,6 +16,7 @@ on:
       - "ruby/**"
       - "proto/**"
       - ".github/workflows/*ruby*"
+      - "devops/**"
 
 jobs:
   build-and-test-ruby:

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -44,6 +44,7 @@ jobs:
           workflow: "build-libs.yml"
           path: ./libs
           repo: trinsic-id/okapi
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and run tests
         run: |
           gem install bundler

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -59,10 +59,10 @@ jobs:
         working-directory: ruby
         env:
           API_GITHUB_TOKEN: ${{ secrets.API_GITHUB_TOKEN }}
-          RUBY_DLL_PATH: "${{ github.workspace }}/libs"  # Required for Ruby on Windows
-          DYLD_FALLBACK_LIBRARY_PATH: "${{ github.workspace }}/libs"
-          DYLD_LIBRARY_PATH: "${{ github.workspace }}/libs"
-          LD_LIBRARY_PATH: "${{ github.workspace }}/libs"
+          RUBY_DLL_PATH: "${{ github.workspace }}/libs/${{ matrix.os-artifact[1] }}"  # Required for Ruby on Windows
+          DYLD_FALLBACK_LIBRARY_PATH: "${{ github.workspace }}/libs/${{ matrix.os-artifact[1] }}"
+          DYLD_LIBRARY_PATH: "${{ github.workspace }}/libs/${{ matrix.os-artifact[1] }}"
+          LD_LIBRARY_PATH: "${{ github.workspace }}/libs/${{ matrix.os-artifact[1] }}"
           TEST_SERVER_ENDPOINT: staging-internal.trinsic.cloud
           TEST_SERVER_PORT: 443
           TEST_SERVER_USE_TLS: true

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -49,7 +49,7 @@ jobs:
           gem install bundler
           gem install rspec
           bundle install
-          python ../devops/build_sdks.py
+          python ../devops/build_sdks.py --language=ruby
           bundle exec rake
           rake test
           exit 0

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os-artifact: [ [ubuntu-latest, linux], [windows-latest, windows], [macos-latest, macos] ]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby-version: [ '2.5', '2.6', '2.7', '3.0' ]
 
@@ -38,13 +38,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Download workflow artifact
+      - name: Download ${{ matrix.os-artifact[0] }} binaries
         uses: dawidd6/action-download-artifact@v2.14.0
         with:
           workflow: "build-libs.yml"
-          path: ./libs
+          path: ./libs/${{ matrix.os-artifact[1] }}
           repo: trinsic-id/okapi
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ matrix.os-artifact[1] }}
       - name: Build and run tests
         run: |
           gem install bundler

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -9,6 +9,7 @@ on:
       - "cli/**"
       - "proto/**"
       - ".github/workflows/*rust*"
+      - "devops/**"
   push:
     branches:
       - main
@@ -16,6 +17,7 @@ on:
       - "cli/**"
       - "proto/**"
       - ".github/workflows/*rust*"
+      - "devops/**"
   workflow_dispatch:
     inputs:
       packageVersion:

--- a/.github/workflows/build-typescript.yml
+++ b/.github/workflows/build-typescript.yml
@@ -2,6 +2,7 @@ name: "TypeScript"
 
 on:
   workflow_call:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -10,6 +11,7 @@ on:
       - 'web/**'
       - 'proto/**'
       - '.github/workflows/*typescript*'
+      - "devops/**"
   push:
     branches:
       - main
@@ -18,7 +20,7 @@ on:
       - 'web/**'
       - 'proto/**'
       - '.github/workflows/*typescript*'
-  workflow_dispatch:
+      - "devops/**"
 
 jobs:
   build_test:

--- a/devops/build_sdks.py
+++ b/devops/build_sdks.py
@@ -170,20 +170,28 @@ def build_go_docs(args):
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Process SDK building')
     parser.add_argument('--package-version', help='Manual override package version')
+    parser.add_argument('--language', help='Comma-separated languages to build', default='all')
     return parser.parse_args()
 
 
 def main():
     # Get command line arguments
     args = parse_arguments()
+    langs_to_build = [lang.lower() for lang in (args.language + ',').split(',')]
+    build_all = 'all' in langs_to_build
     # Update version information
-    build_python(args)
-    build_java(args)
-    build_ruby(args)
-    build_golang(args)
-    build_java_docs(args)
-    build_dotnet_docs(args)
-    build_go_docs(args)
+    if build_all or 'python' in langs_to_build:
+        build_python(args)
+    if build_all or 'java' in langs_to_build:
+        build_java(args)
+    if build_all or 'ruby' in langs_to_build:
+        build_ruby(args)
+    if build_all or 'golang' in langs_to_build:
+        build_golang(args)
+    if build_all or 'docs' in langs_to_build:
+        build_java_docs(args)
+        build_dotnet_docs(args)
+        build_go_docs(args)
 
 
 if __name__ == "__main__":

--- a/devops/build_sdks.py
+++ b/devops/build_sdks.py
@@ -14,7 +14,7 @@ from typing import Dict
 try:
     import requests
 except:
-    os.system('pip install -r requests')
+    os.system('pip install requests')
     import requests
 
 

--- a/devops/build_sdks.py
+++ b/devops/build_sdks.py
@@ -11,7 +11,11 @@ from os.path import join, abspath, dirname, isdir, split
 import subprocess
 from typing import Dict
 
-import requests
+try:
+    import requests
+except:
+    os.system('pip install -r requests')
+    import requests
 
 
 def parse_version_tag():

--- a/devops/build_sdks.py
+++ b/devops/build_sdks.py
@@ -86,7 +86,12 @@ def get_language_dir(language_name: str) -> str:
     """
     return abspath(join(dirname(abspath(__file__)), '..', language_name))
 
-  
+
+def get_sdk_dir() -> str:
+    """Get the full path of the root of the sdk repository"""
+    return abspath(join(dirname(abspath(__file__)), '..'))
+
+
 def build_python(args) -> None:
     # Update version in setup.cfg
     python_dir = get_language_dir('python')
@@ -134,18 +139,17 @@ def get_github_version(github_token: str = None) -> str:
 def build_java_docs(args):
     # https://github.com/fchastanet/groovydoc-to-markdown
     # npm install in the root of sdk
-    subprocess.Popen(r'node ../node_modules/groovydoc-to-markdown/src/doc2md.js  ./java java ../docs/reference/java', cwd=dirname(__file__) ).wait()
+    subprocess.Popen(r'node ./node_modules/groovydoc-to-markdown/src/doc2md.js  ./java java ./docs/reference/java', cwd=get_sdk_dir() ).wait()
 
 
 def build_dotnet_docs(args) -> None:
     # https://github.com/Doraku/DefaultDocumentation
     # dotnet tool install DefaultDocumentation.Console -g
-    assembly_file = '../dotnet/Trinsic/bin/Debug/net6.0/Trinsic.dll'
-    output_doc_folder = '../docs/reference/dotnet'
-    current_dir = dirname(__file__)
-    clean_dir(abspath(join(current_dir, output_doc_folder)))
+    assembly_file = './dotnet/Trinsic/bin/Debug/net6.0/Trinsic.dll'
+    output_doc_folder = './docs/reference/dotnet'
+    clean_dir(abspath(join(get_sdk_dir(), output_doc_folder)))
     subprocess.Popen(f"defaultdocumentation --AssemblyFilePath {assembly_file} --OutputDirectoryPath {output_doc_folder} --FileNameMode Name --GeneratedPages Namespaces",
-                     cwd=current_dir).wait()
+                     cwd=get_sdk_dir()).wait()
 
 
 def build_go_docs(args):

--- a/devops/generate_proto_files.py
+++ b/devops/generate_proto_files.py
@@ -5,14 +5,11 @@ import glob
 import itertools
 import logging
 import os
-import subprocess
 from platform import system
-import shutil
 import urllib.request
 from os.path import abspath, join, dirname
 from typing import List, Dict, Union
 
-import importlib.resources
 
 from build_sdks import update_line, clean_dir, get_language_dir
 


### PR DESCRIPTION
This fixes issues with java not building, actions timing out due to artifact download size (ios and android variants are the biggest offenders), not running required actions when devops python scripts change, python script now allows language-specific selection for isolation.