### PR TITLE
[cli] API hardening, eliminate panics, results display, missing features

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3,27 +3,12 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -37,18 +22,18 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.45"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayref"
@@ -85,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -96,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686d748538a32325b28d6411dd8a939e7ad5128e5d0023cc4fd3573db456042"
+checksum = "ee6adc1648f03fbc1bc1b5cf0f2fdfb5edbc96215b711edcfe6ce2641ef9b347"
 dependencies = [
  "critical-section",
  "riscv-target",
@@ -117,24 +102,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "backtrace"
-version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bare-metal"
@@ -162,24 +132,6 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
-name = "bbs"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e24ff98879bedb7fe7b3ce0c86268baca8468e8ce405d44459dbaf0b26ac9ca"
-dependencies = [
- "arrayref",
- "blake2",
- "failure",
- "ff-zeroize",
- "hex",
- "hkdf 0.8.0",
- "pairing-plus",
- "rand 0.7.3",
- "serde",
- "zeroize",
-]
 
 [[package]]
 name = "bit_field"
@@ -212,29 +164,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
-dependencies = [
- "byte-tools",
- "crypto-mac 0.7.0",
- "digest 0.8.1",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
 name = "blake3"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526c210b4520e416420759af363083471656e819a75e831b8d2c9d5a584f2413"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "digest 0.9.0",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -244,7 +184,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding",
- "generic-array 0.14.4",
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -255,18 +204,35 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bls12_381_plus"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29fb62df98b3994d31d6ebb80607e75f784bc814bb801b4c75d6a595fcead26"
+checksum = "14072e323786a34a18e1bf1ef8940fff0537cc45f1f35ad96d4921008c18a88a"
 dependencies = [
  "digest 0.9.0",
- "ff",
- "group",
+ "ff 0.10.1",
+ "group 0.10.0",
  "heapless",
- "pairing",
+ "pairing 0.20.0",
  "rand_core 0.6.3",
  "serde",
- "subtle 2.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "bls12_381_plus"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9ca230350e9fa6d2bcbf2eec0dd805a8aa0996ee8884da282097ca7e50a29b"
+dependencies = [
+ "digest 0.9.0",
+ "ff 0.11.0",
+ "group 0.11.0",
+ "heapless",
+ "pairing 0.21.0",
+ "rand_core 0.6.3",
+ "serde",
+ "subtle",
  "zeroize",
 ]
 
@@ -284,15 +250,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byteorder"
@@ -308,9 +268,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cbindgen"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38728c31b994e4b849cf59feefb4a8bf26acd299ee0b92c9fb35bd14ad4b8dfa"
+checksum = "51e3973b165dc0f435831a9e426de67e894de532754ff7a3f307c03ee5dec7dc"
 dependencies = [
  "clap",
  "heck",
@@ -327,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -379,14 +339,14 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -423,9 +383,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -439,9 +399,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cortex-m"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
+checksum = "37ff967e867ca14eba0c34ac25cd71ea98c678e741e3915d923999bb2fe7c826"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
@@ -484,24 +444,24 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "8658c15c5d921ddf980f7fe25b1e82f4b7a4083b2c4985fea4922edb8e43e07d"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
  "rand_core 0.6.3",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.7.0"
+name = "crypto-common"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -510,8 +470,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -520,8 +480,8 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -533,40 +493,40 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "der"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
+checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
 dependencies = [
  "const-oid",
 ]
 
 [[package]]
 name = "did-key"
-version = "0.0.15"
-source = "git+https://github.com/decentralized-identity/did-key.rs?branch=main#a9e6c7231512565f04890b907becdcbaea94cddd"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3722614aaa48b0b34489aa86a59d0dfa365d7b9448a24bc6d10ae361c7a2b49c"
 dependencies = [
  "arrayref",
  "base64 0.13.0",
- "bbs",
+ "bls12_381_plus 0.6.0",
  "bs58 0.4.0",
  "curve25519-dalek",
  "did_url",
  "ed25519-dalek",
- "generic-array 0.12.4",
- "getrandom 0.2.3",
- "hkdf 0.11.0",
+ "getrandom 0.2.5",
+ "hkdf",
  "libsecp256k1",
  "p256",
- "pairing-plus",
  "serde",
  "serde_json",
  "sha2",
+ "signature_bls",
  "x25519-dalek",
 ]
 
@@ -581,20 +541,22 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -631,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
+checksum = "eed12bbf7b5312f8da1c2722bc06d8c6b12c2d86a7fb35a194c7f3e6fc2bbe39"
 dependencies = [
  "signature",
 ]
@@ -660,50 +622,37 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+checksum = "83e5c176479da93a0983f0a6fdc3c1b8e7d5be0d7fe3fe05a99f15b96582b9a8"
 dependencies = [
  "crypto-bigint",
- "ff",
- "generic-array 0.14.4",
- "group",
+ "ff 0.10.1",
+ "generic-array",
+ "group 0.10.0",
  "pkcs8",
  "rand_core 0.6.3",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "embedded-hal"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
 dependencies = [
  "nb 0.1.3",
  "void",
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
+name = "fastrand"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+ "instant",
 ]
 
 [[package]]
@@ -714,33 +663,18 @@ checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
  "bitvec",
  "rand_core 0.6.3",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
-name = "ff-zeroize"
-version = "0.6.3"
+name = "ff"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02169a2e8515aa316ce516eaaf6318a76617839fbf904073284bc2576b029ee"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
 dependencies = [
- "byteorder",
- "ff_derive-zeroize",
- "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "ff_derive-zeroize"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24d4059bc0d0a0bf26b740aa21af1f96a984f0ab7a21356d00b32475388b53a"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn",
+ "bitvec",
+ "rand_core 0.6.3",
+ "subtle",
 ]
 
 [[package]]
@@ -761,9 +695,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "fnv"
@@ -782,12 +716,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,38 +723,37 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "autocfg",
  "futures-core",
  "futures-task",
  "pin-project-lite",
@@ -835,18 +762,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -865,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -877,28 +795,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
-
-[[package]]
 name = "group"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "byteorder",
- "ff",
+ "ff 0.10.1",
  "rand_core 0.6.3",
- "subtle 2.4.1",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+dependencies = [
+ "byteorder",
+ "ff 0.11.0",
+ "rand_core 0.6.3",
+ "subtle",
 ]
 
 [[package]]
 name = "h2"
-version = "0.3.7"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
  "bytes",
  "fnv",
@@ -909,7 +833,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -930,9 +854,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heapless"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1ad878e07405df82b695089e63d278244344f80e764074d0bdfe99b89460f3"
+checksum = "d076121838e03f862871315477528debffdb7462fb229216ecef91b1a3eb31eb"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -966,32 +890,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa08a006102488bd9cd5b8013aabe84955cf5ae22e304c2caf655b633aefae3"
-dependencies = [
- "digest 0.8.1",
- "hmac 0.7.1",
-]
-
-[[package]]
-name = "hkdf"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
 dependencies = [
  "digest 0.9.0",
  "hmac 0.11.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
 ]
 
 [[package]]
@@ -1021,15 +925,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
- "generic-array 0.14.4",
+ "generic-array",
  "hmac 0.8.1",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
@@ -1049,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -1061,9 +965,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.15"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1097,34 +1001,43 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.1"
+name = "instant"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1143,9 +1056,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libsecp256k1"
@@ -1174,7 +1087,7 @@ checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -1197,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -1226,25 +1139,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1280,22 +1184,11 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -1319,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1329,66 +1222,53 @@ dependencies = [
 
 [[package]]
 name = "oberon"
-version = "1.0.0-pre3"
-source = "git+https://github.com/mikelodder7/oberon?branch=main#c12812be6f575ff2340694733a7e622a41a11cca"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b528f5cced41e52f873d3fc1cd86eb8b2d4abd91a25d62b344de9bfd8d23e56"
 dependencies = [
- "bls12_381_plus",
+ "bls12_381_plus 0.5.2",
  "digest 0.9.0",
- "ff",
- "group",
+ "ff 0.10.1",
+ "group 0.10.0",
  "rand_core 0.6.3",
  "serde",
  "sha3",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
 name = "okapi"
 version = "0.1.0"
-source = "git+https://github.com/trinsic-id/okapi?branch=main#3e80174071c40a20c074cd4ede2b2bde7defa0a6"
+source = "git+https://github.com/trinsic-id/okapi?branch=main#273bdf219ce1e99e12afe2a39a6f1757f9ce1074"
 dependencies = [
  "base64 0.13.0",
+ "blake3",
  "bs58 0.3.1",
  "cbindgen",
  "chacha20poly1305",
  "did-key",
  "ffi-support",
- "getrandom 0.2.3",
+ "getrandom 0.2.5",
  "hex",
  "oberon",
  "prost 0.8.0",
  "prost-build 0.8.0",
  "prost-types 0.8.0",
- "rand 0.8.4",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_jcs",
  "serde_json",
  "sha2",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
-
-[[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"
@@ -1398,9 +1278,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "p256"
@@ -1419,22 +1299,16 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
- "group",
+ "group 0.10.0",
 ]
 
 [[package]]
-name = "pairing-plus"
-version = "0.19.0"
+name = "pairing"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cda4f22e8e6720f3c254049960c8cc4f93cb82b5ade43bddd2622b5f39ea62"
+checksum = "f2e415e349a3006dd7d9482cdab1c980a845bed1377777d768cb693a44540b42"
 dependencies = [
- "byteorder",
- "digest 0.8.1",
- "ff-zeroize",
- "rand 0.4.6",
- "rand_core 0.5.1",
- "rand_xorshift",
- "zeroize",
+ "group 0.11.0",
 ]
 
 [[package]]
@@ -1459,24 +1333,24 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
- "fixedbitset 0.4.0",
+ "fixedbitset 0.4.1",
  "indexmap",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1485,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -1517,15 +1391,15 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -1636,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1651,19 +1525,6 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -1672,19 +1533,18 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -1709,21 +1569,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -1737,7 +1582,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.5",
 ]
 
 [[package]]
@@ -1750,37 +1595,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -1791,15 +1609,15 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.5",
  "redox_syscall",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1858,12 +1676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,15 +1711,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "ryu-js"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26864181681b29144524f5856471a3c8dbe1a02f4fdd6f6f74d5e2528d96f42"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
 name = "schannel"
@@ -1937,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.4.2"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1950,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1975,18 +1787,28 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.130"
+name = "serde-big-array"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "18b20e7752957bbe9661cff4e0bb04d183d0948cdab2ea58cdb9df36a61dfe62"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2006,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.71"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
@@ -2017,15 +1839,15 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2034,10 +1856,10 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "digest 0.9.0",
  "keccak",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2051,6 +1873,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature_bls"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b7cca12d2cd1d6d2fffa0375cfc94485acc2a871fc82ac77393487132b5456"
+dependencies = [
+ "bls12_381_plus 0.5.2",
+ "ff 0.10.1",
+ "group 0.10.0",
+ "hkdf",
+ "pairing 0.20.0",
+ "rand_core 0.6.3",
+ "serde",
+ "sha2",
+ "subtle",
+ "vsss-rs",
+ "zeroize",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,9 +1899,9 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -2104,21 +1945,15 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-
-[[package]]
-name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2145,13 +1980,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -2178,26 +2013,26 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.14.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
 
 [[package]]
 name = "tokio-io-timeout"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
  "pin-project-lite",
  "tokio",
@@ -2205,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2251,6 +2086,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24203b79cf2d68909da91178db3026e77054effba0c5d93deb870d3ca7b35afa"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2284,7 +2133,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2294,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88358bb1dcfeb62dcce85c63006cafb964b7be481d522b7e09589d4d1e718d2a"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
  "proc-macro2",
  "prost-build 0.9.0",
@@ -2306,20 +2155,19 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00e500fff5fa1131c866b246041a6bf96da9c965f8fe4128cb1421f23e93c00"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.4",
+ "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.0",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2339,9 +2187,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if",
  "log",
@@ -2352,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2363,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
 dependencies = [
  "lazy_static",
 ]
@@ -2411,15 +2259,15 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -2439,8 +2287,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -2463,9 +2311,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"
@@ -2480,6 +2328,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "vsss-rs"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f509df857e50af93bea4921d55f66a719d2b5f1f6d066abe7f21800448d09ca"
+dependencies = [
+ "ff 0.10.1",
+ "group 0.10.0",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "serde",
+ "serde-big-array",
+ "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -2505,10 +2369,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.78"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2516,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2531,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2541,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2554,15 +2424,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2580,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",
@@ -2622,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
@@ -2639,18 +2509,18 @@ checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "50344758e2f40e3a1fcfc8f6f91aa57b5f8ebd8d27919fe6451f15aaaf9ee608"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.2"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2239,6 +2239,7 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
+ "indexmap",
  "okapi",
  "prost 0.9.0",
  "prost-types 0.9.0",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,7 @@ yaml-rust = "0.3"
 colored = "2"
 blake3 = "1.2"
 bytes = "1.1"
+indexmap = "1.8"
 
 [build-dependencies]
 tonic-build = { version = "0.6", features = ["prost", "rustfmt"] }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -12,6 +12,10 @@ fn main() {
             "ServiceOptions",
             "#[derive(::serde::Serialize, ::serde::Deserialize)]",
         )
+        .type_attribute(
+            ".services",
+            "#[derive(::serde::Serialize, ::serde::Deserialize)]",
+        )
         // .field_attribute(
         //     "ServiceOptions.auth_token",
         //     "#[serde(skip_serializing_if = \"String::is_empty\")]",

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -12,14 +12,14 @@ fn main() {
             "ServiceOptions",
             "#[derive(::serde::Serialize, ::serde::Deserialize)]",
         )
-        .field_attribute(
-            "ServiceOptions.auth_token",
-            "#[serde(skip_serializing_if = \"String::is_empty\")]",
-        )
-        .type_attribute(
-            "JsonPayload.json",
-            "#[derive(::serde::Serialize, ::serde::Deserialize)]",
-        )
+        // .field_attribute(
+        //     "ServiceOptions.auth_token",
+        //     "#[serde(skip_serializing_if = \"String::is_empty\")]",
+        // )
+        // .type_attribute(
+        //     "JsonPayload.json",
+        //     "#[derive(::serde::Serialize, ::serde::Deserialize)]",
+        // )
         .compile(
             &[
                 "../proto/pbmse/v1/pbmse.proto",

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -9,10 +9,13 @@ fn main() {
     config
         .compile_well_known_types(true)
         .type_attribute(
-            "JsonPayload",
+            "ServiceOptions",
             "#[derive(::serde::Serialize, ::serde::Deserialize)]",
         )
-        .field_attribute("JsonPayload.json", "#[serde(flatten)]")
+        .field_attribute(
+            "ServiceOptions.auth_token",
+            "#[serde(skip_serializing_if = \"String::is_empty\")]",
+        )
         .type_attribute(
             "JsonPayload.json",
             "#[derive(::serde::Serialize, ::serde::Deserialize)]",

--- a/cli/src/cli.yaml
+++ b/cli/src/cli.yaml
@@ -165,6 +165,13 @@ subcommands:
                   value_name: FILE
                   help: The file with JSON values of the credential subject
                   takes_value: true
+              - out:
+                  long: out
+                  short: o
+                  value_name: OUTPUT_FILE
+                  help: (Optional) Output file to store the issued credential
+                  takes_value: true
+                  required: false
         - update-status:
             about: Update the credential status (revocation) of an issued credential
             args:
@@ -190,26 +197,33 @@ subcommands:
                   takes_value: true
                   required: true
         - create-proof:
-            about: Create a proof
+            about: Create a proof of signature from a document in the user's wallet or a file
             args:
-              - reveal-document:
-                  long: reveal-document
-                  value_name: JSONLD_FRAME_FILE
-                  help: Document
+              - reveal-document-file:
+                  long: reveal-document-file
+                  value_name: REVEAL FRAME FILE
+                  help: (Optional) Input document that contains valid JSON-LD frame to be used for creating the proof
                   takes_value: true
-                  required: true
-              - document-id:
-                  long: document-id
+                  required: false
+              - item-id:
+                  long: item-id
                   value_name: STRING
-                  help: Document id
+                  help: Item ID of a document in the user's wallet
                   takes_value: true
-                  required: true
+                  required: false
+              - document-file:
+                  long: document-file
+                  value_name: FILE
+                  help: File that contains a signed document
+                  takes_value: true
+                  required: false
               - out:
                   long: out
+                  short: o
                   value_name: OUTPUT_FILE
-                  help: output location for created_proof
+                  help: Output file to store the generated proof
                   takes_value: true
-                  required: true
+                  required: false
         - verify-proof:
             about: Verify a proof
             args:

--- a/cli/src/cli.yaml
+++ b/cli/src/cli.yaml
@@ -70,11 +70,12 @@ subcommands:
                   help: (Optional) Invitation code provided by authorized entity
                   takes_value: true
                   required: false
-              - default:
-                  long: default
-                  takes_value: false
+              - ecosystem:
+                  long: ecosystem
+                  short: e
+                  takes_value: true
                   required: false
-                  help: (Optional) Set this profile as default
+                  help: (Optional) The ecosystem name or id to sign in
         - info:
             about: Show account information
   - wallet:

--- a/cli/src/cli.yaml
+++ b/cli/src/cli.yaml
@@ -284,7 +284,7 @@ subcommands:
                   value_name: SQL query
                   help: |
                     The SQL query to search the registry.
-                    Default value is "SELECT * FROM c".
+                    Default value is "SELECT c.data, c.id, c.type FROM c".
                   takes_value: true
                   required: true
         - check-issuer:

--- a/cli/src/cli.yaml
+++ b/cli/src/cli.yaml
@@ -17,29 +17,27 @@ subcommands:
             takes_value: true
             required: false
             long: server-endpoint
+            short: e
         - server-port:
             value_name: NUMBER
             help: "(Optional) Port of the server endpoint. (default: 443)"
             takes_value: true
             required: false
             long: server-port
+            short: p
         - server-use-tls:
             value_name: BOOL
             help: "(Optional) Indicates if TLS should be used. (default: true)"
             takes_value: true
             required: false
             long: server-use-tls
-        - profile-default:
-            long: profile-default
+        - auth-token:
+            long: auth-token
+            short: a
             value_name: NAME
-            help: (Optional) Name of the profile to set as default
+            help: (Optional) Sets the auth token for outgoing requests
             takes_value: true
             required: false
-        - show:
-            long: show
-            takes_value: false
-            required: false
-            help: Show the current configuration file
   - account:
       about: Account Service
       subcommands:
@@ -72,14 +70,6 @@ subcommands:
                   help: (Optional) Invitation code provided by authorized entity
                   takes_value: true
                   required: false
-              - alias:
-                  long: alias
-                  value_name: PROFILE_NAME
-                  help: >-
-                    (Required) Alias of the local profile to use to store
-                    authentication data
-                  takes_value: true
-                  required: true
               - default:
                   long: default
                   takes_value: false
@@ -469,15 +459,6 @@ subcommands:
                   takes_value: true
                   required: true
 args:
-  - profile:
-      long: alias
-      short: a
-      value_name: NAME
-      help: >-
-        (Optional) Account alias to use for authentication. If not set, it will
-        use the default configured.
-      takes_value: true
-      required: false
   - debug:
       long: debug
       short: d

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -9,6 +9,7 @@ pub(crate) enum Error {
     SerializationError,
     APIError { code: String, message: String },
     MissingArguments,
+    ConnectionError,
     InvalidArgument(String),
     UnknownCommand,
 }
@@ -22,6 +23,18 @@ impl From<toml::ser::Error> for Error {
 impl From<toml::de::Error> for Error {
     fn from(_: toml::de::Error) -> Self {
         Error::SerializationError
+    }
+}
+
+impl From<tonic::codegen::http::uri::InvalidUri> for Error {
+    fn from(_: tonic::codegen::http::uri::InvalidUri) -> Self {
+        Error::InvalidArgument("invalid server uri".to_string())
+    }
+}
+
+impl From<tonic::transport::Error> for Error {
+    fn from(_: tonic::transport::Error) -> Self {
+        Error::ConnectionError
     }
 }
 

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -9,6 +9,7 @@ pub(crate) enum Error {
     SerializationError,
     APIError { code: String, message: String },
     MissingArguments,
+    InvalidArgument(String),
     UnknownCommand,
 }
 

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,0 +1,58 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+use tonic::Status;
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub(crate) enum Error {
+    IOError,
+    SerializationError,
+    APIError { code: String, message: String },
+    MissingArguments,
+    UnknownCommand,
+}
+
+impl From<toml::ser::Error> for Error {
+    fn from(_: toml::ser::Error) -> Self {
+        Error::SerializationError
+    }
+}
+
+impl From<toml::de::Error> for Error {
+    fn from(_: toml::de::Error) -> Self {
+        Error::SerializationError
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(_: std::io::Error) -> Self {
+        Error::IOError
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(_: serde_json::Error) -> Self {
+        Error::SerializationError
+    }
+}
+
+impl From<prost::DecodeError> for Error {
+    fn from(_: prost::DecodeError) -> Self {
+        Error::SerializationError
+    }
+}
+
+impl From<Status> for Error {
+    fn from(status: Status) -> Self {
+        Error::APIError {
+            code: status.code().to_string(),
+            message: status.message().to_string(),
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:#?}", self))
+    }
+}

--- a/cli/src/macros.rs
+++ b/cli/src/macros.rs
@@ -1,11 +1,7 @@
 #[macro_export]
 macro_rules! grpc_channel {
     ($x:expr) => {
-        Channel::from_shared(&$x.options)
-            .unwrap()
-            .connect()
-            .await
-            .expect("Unable to connect to server")
+        Channel::from_shared(&$x.options)?.connect().await?
     };
 }
 

--- a/cli/src/macros.rs
+++ b/cli/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! grpc_channel {
     ($x:expr) => {
-        Channel::from_shared(&$x.server)
+        Channel::from_shared(&$x.options)
             .unwrap()
             .connect()
             .await

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,7 +14,6 @@ use colored::Colorize;
 use parser::template;
 use prost::{DecodeError, Message};
 use serde::Serialize;
-use serde_json::Value;
 use services::config::CliConfig;
 
 pub static mut DEBUG: bool = false;
@@ -65,8 +64,8 @@ fn main() {
             Ok(output) => {
                 println!("{}", "ok".bold().green());
                 for (key, value) in output.iter() {
-                    println!("{}", format!("[{}]", key).bold());
-                    println!("{}", value.italic());
+                    print!("{} {} ", key.bold().yellow(), "→".bold().bright_black());
+                    println!("{}", value);
                     println!();
                 }
             }
@@ -84,7 +83,17 @@ fn main() {
                         format!("{}", message.to_lowercase())
                     );
                 }
-                Error::MissingArguments => todo!(),
+                Error::MissingArguments => println!(
+                    "{}: {}",
+                    "error".red().bold(),
+                    "missing command arguments".bold()
+                ),
+                Error::InvalidArgument(x) => println!(
+                    "{}: {}: {}",
+                    "error".red().bold(),
+                    "invalid argument".bold(),
+                    x
+                ),
             },
         },
         Err(err) => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -66,7 +66,6 @@ fn main() {
                 for (key, value) in output.iter() {
                     print!("{} {} ", key.bold().yellow(), "→".bold().bright_black());
                     println!("{}", value);
-                    println!();
                 }
             }
             Err(err) => match err {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,9 +59,8 @@ fn main() {
     let matches = app.get_matches();
 
     let config = CliConfig::from(&matches);
-    let service = parser::parse(&matches);
 
-    match service {
+    match parser::parse(&matches) {
         Ok(service) => match services::execute(&service, config) {
             Ok(output) => {
                 println!("{}", "ok".bold().green());
@@ -98,12 +97,7 @@ fn main() {
             println!();
             println!(
                 "{}",
-                format!(
-                    "For more information try {} or {}",
-                    format!("-h").green(),
-                    format!("--help").green()
-                )
-                .italic()
+                format!("For more information try {}", format!("--help").green()).italic()
             )
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,16 +4,17 @@ pub mod services;
 pub mod utils;
 #[macro_use]
 pub(crate) mod macros;
+pub(crate) mod error;
 
 #[macro_use]
 extern crate clap;
-use crate::services::config::Error;
+use crate::error::Error;
 use clap::{App, AppSettings};
 use colored::Colorize;
 use parser::template;
 use prost::{DecodeError, Message};
 use serde_json::Value;
-use services::config::DefaultConfig;
+use services::config::CliConfig;
 
 pub static mut DEBUG: bool = false;
 
@@ -51,7 +52,7 @@ fn main() {
         .subcommand(template::subcommand());
     let matches = app.get_matches();
 
-    let config = DefaultConfig::from(&matches);
+    let config = CliConfig::from(&matches);
     let service = parser::parse(&matches);
 
     match service {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -68,32 +68,35 @@ fn main() {
                     println!("{}", value);
                 }
             }
-            Err(err) => match err {
-                Error::IOError => println!("{}", format!("io error").red()),
-                Error::SerializationError => {
-                    println!("{}", format!("serialization error").red())
-                }
-                Error::UnknownCommand => unimplemented!("should not be hit"),
-                Error::APIError { code, message } => {
-                    println!(
+            Err(err) => {
+                match err {
+                    Error::IOError => println!("{}", format!("io error").red()),
+                    Error::SerializationError => {
+                        println!("{}", format!("serialization error").red())
+                    }
+                    Error::UnknownCommand => unimplemented!("should not be hit"),
+                    Error::APIError { code, message } => {
+                        println!(
+                            "{}: {}: {}",
+                            format!("error").red().bold(),
+                            format!("{}", code.to_lowercase()).bold(),
+                            format!("{}", message.to_lowercase())
+                        );
+                    }
+                    Error::MissingArguments => println!(
+                        "{}: {}",
+                        "error".red().bold(),
+                        "missing command arguments".bold()
+                    ),
+                    Error::InvalidArgument(x) => println!(
                         "{}: {}: {}",
-                        format!("error").red().bold(),
-                        format!("{}", code.to_lowercase()).bold(),
-                        format!("{}", message.to_lowercase())
-                    );
-                }
-                Error::MissingArguments => println!(
-                    "{}: {}",
-                    "error".red().bold(),
-                    "missing command arguments".bold()
-                ),
-                Error::InvalidArgument(x) => println!(
-                    "{}: {}: {}",
-                    "error".red().bold(),
-                    "invalid argument".bold(),
-                    x
-                ),
-            },
+                        "error".red().bold(),
+                        "invalid argument".bold(),
+                        x
+                    ),
+                    Error::ConnectionError => println!("{}", format!("connection error").red()),
+                };
+            }
         },
         Err(err) => {
             println!(
@@ -106,7 +109,7 @@ fn main() {
             println!(
                 "{}",
                 format!("For more information try {}", format!("--help").green()).italic()
-            )
+            );
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -118,7 +118,7 @@ mod test {
     #[test]
     fn run_custom_command() {
         let yaml = load_yaml!("cli.yaml");
-        let matches = App::from_yaml(yaml)
+        let _matches = App::from_yaml(yaml)
             .get_matches_from_safe(vec![
                 "trinsic",
                 "config",

--- a/cli/src/parser/account.rs
+++ b/cli/src/parser/account.rs
@@ -26,8 +26,7 @@ fn sign_in<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
         email: args.value_of("email"),
         sms: args.value_of("sms"),
         invitation_code: args.value_of("invitation-code"),
-        alias: args.value_of("alias"),
-        set_default: args.is_present("default"),
+        ecosystem: args.value_of("ecosystem").map(|x| x.into()),
     }))
 }
 
@@ -45,10 +44,9 @@ pub enum Command<'a> {
 pub struct SignInArgs<'a> {
     pub invitation_code: Option<&'a str>,
     pub name: Option<&'a str>,
-    pub alias: Option<&'a str>,
-    pub set_default: bool,
     pub email: Option<&'a str>,
     pub sms: Option<&'a str>,
+    pub ecosystem: Option<String>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/cli/src/parser/account.rs
+++ b/cli/src/parser/account.rs
@@ -1,6 +1,6 @@
 use clap::ArgMatches;
 
-use crate::services::config::Error;
+use crate::error::Error;
 
 pub(crate) fn parse<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
     if args.is_present("login") {

--- a/cli/src/parser/config.rs
+++ b/cli/src/parser/config.rs
@@ -1,6 +1,6 @@
 use clap::ArgMatches;
 
-use crate::services::config::DefaultConfig;
+use crate::services::config::CliConfig;
 
 #[derive(Debug, PartialEq, Default)]
 pub struct Command<'a> {
@@ -27,7 +27,7 @@ pub fn parse<'a>(args: &'a ArgMatches<'_>) -> Command<'a> {
 
     let mut empty = true;
     if args.is_present("show") {
-        DefaultConfig::init().unwrap().print().unwrap();
+        CliConfig::init().unwrap().print().unwrap();
         empty = false;
     } else {
         if args.is_present("server-endpoint") {
@@ -49,7 +49,7 @@ pub fn parse<'a>(args: &'a ArgMatches<'_>) -> Command<'a> {
     }
 
     if empty {
-        DefaultConfig::init().unwrap().print().unwrap();
+        CliConfig::init().unwrap().print().unwrap();
     }
 
     command

--- a/cli/src/parser/config.rs
+++ b/cli/src/parser/config.rs
@@ -3,25 +3,25 @@ use clap::ArgMatches;
 use crate::services::config::CliConfig;
 
 #[derive(Debug, PartialEq, Default)]
-pub struct Command<'a> {
-    pub server: ServerArgs<'a>,
-    pub profile: ProfileArgs<'a>,
+pub struct ConfigCommand {
+    pub options: SdkOptionsArgs,
+    pub custom: Option<CustomArgs>,
 }
 
 #[derive(Debug, PartialEq, Default)]
-pub struct ServerArgs<'a> {
-    pub endpoint: Option<&'a str>,
+pub struct SdkOptionsArgs {
+    pub endpoint: Option<String>,
     pub port: Option<u16>,
     pub use_tls: Option<bool>,
+    pub auth_token: Option<String>,
+    pub default_ecosystem: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Default)]
-pub struct ProfileArgs<'a> {
-    pub default: Option<&'a str>,
-}
+pub struct CustomArgs {}
 
-pub fn parse<'a>(args: &'a ArgMatches<'_>) -> Command<'a> {
-    let mut command = Command {
+pub fn parse<'a>(args: &'a ArgMatches<'_>) -> ConfigCommand {
+    let mut command = ConfigCommand {
         ..Default::default()
     };
 
@@ -31,19 +31,24 @@ pub fn parse<'a>(args: &'a ArgMatches<'_>) -> Command<'a> {
         empty = false;
     } else {
         if args.is_present("server-endpoint") {
-            command.server.endpoint = args.value_of("server-endpoint");
+            command.options.endpoint = args.value_of("server-endpoint").map(|x| x.into());
             empty = false;
         }
         if args.is_present("server-port") {
-            command.server.port = args.value_of("server-port").map(|x| x.parse().unwrap());
+            command.options.port = args.value_of("server-port").map(|x| x.parse().unwrap());
             empty = false;
         }
         if args.is_present("server-use-tls") {
-            command.server.use_tls = args.value_of("server-use-tls").map(|x| x.parse().unwrap());
+            command.options.use_tls = args.value_of("server-use-tls").map(|x| x.parse().unwrap());
             empty = false;
         }
-        if args.is_present("profile-default") {
-            command.profile.default = args.value_of("profile-default");
+        if args.is_present("auth-token") {
+            command.options.auth_token = args.value_of("auth-token").map(|x| x.into());
+            empty = false;
+        }
+        if args.is_present("default-ecosystem") {
+            command.options.default_ecosystem =
+                args.value_of("default-ecosystem").map(|x| x.into());
             empty = false;
         }
     }

--- a/cli/src/parser/issuer.rs
+++ b/cli/src/parser/issuer.rs
@@ -1,4 +1,4 @@
-use crate::services::config::Error;
+use crate::error::Error;
 use clap::ArgMatches;
 
 pub(crate) fn parse<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {

--- a/cli/src/parser/mod.rs
+++ b/cli/src/parser/mod.rs
@@ -1,4 +1,4 @@
-use crate::services::{config::Error, Service};
+use crate::{error::Error, services::Service};
 use clap::ArgMatches;
 
 pub mod account;

--- a/cli/src/parser/mod.rs
+++ b/cli/src/parser/mod.rs
@@ -3,10 +3,10 @@ use clap::ArgMatches;
 
 pub mod account;
 pub mod config;
-pub mod issuer;
 pub mod provider;
 pub mod template;
 pub mod trustregistry;
+pub mod vc;
 pub mod wallet;
 
 pub(crate) fn parse<'a>(args: &'a ArgMatches<'_>) -> Result<Service<'a>, Error> {
@@ -23,7 +23,7 @@ pub(crate) fn parse<'a>(args: &'a ArgMatches<'_>) -> Result<Service<'a>, Error> 
                 .expect("Error parsing request"),
         ))
     } else if args.is_present("vc") {
-        Service::VerifiableCredential(issuer::parse(
+        Service::VerifiableCredential(vc::parse(
             &args
                 .subcommand_matches("vc")
                 .expect("Error parsing request"),

--- a/cli/src/parser/provider.rs
+++ b/cli/src/parser/provider.rs
@@ -1,4 +1,4 @@
-use crate::services::config::Error;
+use crate::error::Error;
 use clap::ArgMatches;
 use std::fmt::{self, Display, Formatter};
 

--- a/cli/src/parser/template.rs
+++ b/cli/src/parser/template.rs
@@ -61,9 +61,12 @@ pub enum FieldType {
     Bool,
 }
 
-use crate::proto::services::verifiablecredentials::templates::v1::FieldType as ProtoFieldType;
-use crate::proto::services::verifiablecredentials::templates::v1::TemplateField as ProtoField;
-use crate::services::config::Error;
+use crate::{
+    error::Error,
+    proto::services::verifiablecredentials::templates::v1::{
+        FieldType as ProtoFieldType, TemplateField as ProtoField,
+    },
+};
 
 impl Default for FieldType {
     fn default() -> Self {

--- a/cli/src/parser/trustregistry.rs
+++ b/cli/src/parser/trustregistry.rs
@@ -1,6 +1,6 @@
 use clap::ArgMatches;
 
-use crate::services::config::Error;
+use crate::error::Error;
 
 #[derive(Debug, PartialEq)]
 pub enum Command {

--- a/cli/src/parser/vc.rs
+++ b/cli/src/parser/vc.rs
@@ -45,8 +45,8 @@ pub(crate) fn parse<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> 
 
 fn issue<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
     Ok(Command::Issue(IssueArgs {
-        document: args.value_of("document"),
-        out: args.value_of("out"),
+        document: args.value_of("document").map(|x| x.into()),
+        out: args.value_of("out").map(|x| x.into()),
     }))
 }
 
@@ -57,6 +57,7 @@ fn issue_from_template<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Erro
             .map_or(String::default(), |x| x.to_string()),
         values_json: args.value_of("values-data").map(|x| x.to_string()),
         values_file: args.value_of("values-file").map(|x| x.to_string()),
+        output_file: args.value_of("out").map(|x| x.to_string()),
     }))
 }
 
@@ -79,9 +80,10 @@ fn update_status<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
 
 fn create_proof<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
     Ok(Command::CreateProof(CreateProofArgs {
-        reveal_document: args.value_of("reveal-document"),
-        document_id: args.value_of("document-id"),
-        out: args.value_of("out"),
+        reveal_document: args.value_of("reveal-document-file").map(|x| x.into()),
+        document_file: args.value_of("document-file").map(|x| x.into()),
+        item_id: args.value_of("item-id").map(|x| x.into()),
+        out: args.value_of("out").map(|x| x.into()),
     }))
 }
 
@@ -93,18 +95,18 @@ fn verify_proof<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum Command<'a> {
-    Issue(IssueArgs<'a>),
+    Issue(IssueArgs),
     IssueFromTemplate(IssueFromTemplateArgs),
     GetStatus(GetStatusArgs),
     UpdateStatus(UpdateStatusArgs),
-    CreateProof(CreateProofArgs<'a>),
+    CreateProof(CreateProofArgs),
     VerifyProof(VerifyProofArgs<'a>),
 }
 
 #[derive(Debug, PartialEq)]
-pub struct IssueArgs<'a> {
-    pub document: Option<&'a str>,
-    pub out: Option<&'a str>,
+pub struct IssueArgs {
+    pub document: Option<String>,
+    pub out: Option<String>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -112,6 +114,7 @@ pub struct IssueFromTemplateArgs {
     pub template_id: String,
     pub values_json: Option<String>,
     pub values_file: Option<String>,
+    pub output_file: Option<String>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -126,10 +129,11 @@ pub struct UpdateStatusArgs {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct CreateProofArgs<'a> {
-    pub reveal_document: Option<&'a str>,
-    pub document_id: Option<&'a str>,
-    pub out: Option<&'a str>,
+pub struct CreateProofArgs {
+    pub reveal_document: Option<String>,
+    pub document_file: Option<String>,
+    pub item_id: Option<String>,
+    pub out: Option<String>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/cli/src/parser/wallet.rs
+++ b/cli/src/parser/wallet.rs
@@ -1,6 +1,5 @@
+use crate::error::Error;
 use clap::ArgMatches;
-
-use crate::services::config::Error;
 
 pub(crate) fn parse<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
     if args.is_present("search") {

--- a/cli/src/proto/sdk/options/v1/mod.rs
+++ b/cli/src/proto/sdk/options/v1/mod.rs
@@ -12,7 +12,6 @@ pub struct ServiceOptions {
     pub server_use_tls: bool,
     /// default auth token for oberon security scheme
     #[prost(string, tag = "4")]
-    #[serde(skip_serializing_if = "String::is_empty")]
     pub auth_token: ::prost::alloc::string::String,
     /// ecosystem to use with endpoints that require it
     #[prost(string, tag = "5")]

--- a/cli/src/proto/sdk/options/v1/mod.rs
+++ b/cli/src/proto/sdk/options/v1/mod.rs
@@ -1,5 +1,5 @@
 /// service options
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct ServiceOptions {
     /// service endpoint
     #[prost(string, tag = "1")]
@@ -12,6 +12,7 @@ pub struct ServiceOptions {
     pub server_use_tls: bool,
     /// default auth token for oberon security scheme
     #[prost(string, tag = "4")]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub auth_token: ::prost::alloc::string::String,
     /// ecosystem to use with endpoints that require it
     #[prost(string, tag = "5")]

--- a/cli/src/proto/services/account/v1/mod.rs
+++ b/cli/src/proto/services/account/v1/mod.rs
@@ -1,5 +1,5 @@
 /// Request for creating new account
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct SignInRequest {
     /// Account registration details
     #[prost(message, optional, tag = "1")]
@@ -14,7 +14,7 @@ pub struct SignInRequest {
     pub ecosystem_id: ::prost::alloc::string::String,
 }
 /// Account Registration Details
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct AccountDetails {
     /// Account name (optional)
     #[prost(string, tag = "1")]
@@ -30,7 +30,7 @@ pub struct AccountDetails {
 /// This object will indicate if a confirmation code
 /// was sent to one of the users two-factor methods
 /// like email, SMS, etc.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct SignInResponse {
     /// The status of the response
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
@@ -49,7 +49,7 @@ pub struct SignInResponse {
 }
 /// Device profile containing sensitive authentication data.
 /// This information should be stored securely
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct AccountProfile {
     /// The type of profile, used to differentiate between
     /// protocol schemes or versions
@@ -68,7 +68,7 @@ pub struct AccountProfile {
     pub protection: ::core::option::Option<TokenProtection>,
 }
 /// Token protection info
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct TokenProtection {
     /// Indicates if token is protected using a PIN,
     /// security code, HSM secret, etc.
@@ -78,9 +78,9 @@ pub struct TokenProtection {
     #[prost(enumeration = "ConfirmationMethod", tag = "2")]
     pub method: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct InfoRequest {}
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct InfoResponse {
     /// The account details associated with
     /// the calling request context
@@ -90,15 +90,15 @@ pub struct InfoResponse {
     #[prost(message, repeated, tag = "2")]
     pub ecosystems: ::prost::alloc::vec::Vec<AccountEcosystem>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct ListDevicesRequest {}
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct ListDevicesResponse {}
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct RevokeDeviceRequest {}
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct RevokeDeviceResponse {}
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct AccountEcosystem {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
@@ -110,7 +110,19 @@ pub struct AccountEcosystem {
     pub uri: ::prost::alloc::string::String,
 }
 /// Confirmation method type for two-factor workflows
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
 #[repr(i32)]
 pub enum ConfirmationMethod {
     /// No confirmation required

--- a/cli/src/proto/services/common/v1/mod.rs
+++ b/cli/src/proto/services/common/v1/mod.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct ServerConfig {
     /// service endpoint
     #[prost(string, tag = "1")]
@@ -11,7 +11,7 @@ pub struct ServerConfig {
     pub use_tls: bool,
 }
 /// Nonce used to generate an oberon proof
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct Nonce {
     /// UTC unix millisecond timestamp the request was made
     #[prost(int64, tag = "1")]
@@ -20,7 +20,19 @@ pub struct Nonce {
     #[prost(bytes = "vec", tag = "2")]
     pub request_hash: ::prost::alloc::vec::Vec<u8>,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
 #[repr(i32)]
 pub enum ResponseStatus {
     Success = 0,

--- a/cli/src/proto/services/provider/v1/mod.rs
+++ b/cli/src/proto/services/provider/v1/mod.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct Invite {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
@@ -11,7 +11,7 @@ pub struct Invite {
     #[prost(string, tag = "5")]
     pub expires: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct InviteRequest {
     #[prost(enumeration = "ParticipantType", tag = "1")]
     pub participant: i32,
@@ -22,10 +22,10 @@ pub struct InviteRequest {
 }
 /// Nested message and enum types in `InviteRequest`.
 pub mod invite_request {
-    #[derive(Clone, PartialEq, ::prost::Message)]
+    #[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
     pub struct DidCommInvitation {}
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct InviteResponse {
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
     pub status: i32,
@@ -40,12 +40,12 @@ pub struct InviteResponse {
 /// an individual or organization.
 /// The reference_id passed is the response from the
 /// `Onboard` method call
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct InvitationStatusRequest {
     #[prost(string, tag = "1")]
     pub invitation_id: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct InvitationStatusResponse {
     #[prost(enumeration = "invitation_status_response::Status", tag = "1")]
     pub status: i32,
@@ -54,7 +54,19 @@ pub struct InvitationStatusResponse {
 }
 /// Nested message and enum types in `InvitationStatusResponse`.
 pub mod invitation_status_response {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        ::serde::Serialize,
+        ::serde::Deserialize,
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration,
+    )]
     #[repr(i32)]
     pub enum Status {
         /// Onboarding resulted in error
@@ -67,7 +79,7 @@ pub mod invitation_status_response {
         Expired = 3,
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct Ecosystem {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
@@ -78,7 +90,7 @@ pub struct Ecosystem {
     #[prost(string, tag = "4")]
     pub uri: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CreateEcosystemRequest {
     /// Globally unique name for the Ecosystem. This name will be
     /// part of the ecosystem specific URLs and namespaces.
@@ -97,7 +109,7 @@ pub struct CreateEcosystemRequest {
     #[prost(message, optional, tag = "4")]
     pub details: ::core::option::Option<super::super::account::v1::AccountDetails>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CreateEcosystemResponse {
     /// Details of the created ecosystem
     #[prost(message, optional, tag = "1")]
@@ -113,19 +125,31 @@ pub struct CreateEcosystemResponse {
     )]
     pub confirmation_method: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GenerateTokenRequest {
     /// Optional description to identify this token
     #[prost(string, tag = "1")]
     pub description: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GenerateTokenResponse {
     /// Account authentication profile that contains unprotected token
     #[prost(message, optional, tag = "1")]
     pub profile: ::core::option::Option<super::super::account::v1::AccountProfile>,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
 #[repr(i32)]
 pub enum ParticipantType {
     Individual = 0,

--- a/cli/src/proto/services/trustregistry/v1/mod.rs
+++ b/cli/src/proto/services/trustregistry/v1/mod.rs
@@ -1,24 +1,24 @@
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct AddFrameworkRequest {
     #[prost(message, optional, tag = "1")]
     pub governance_framework: ::core::option::Option<GovernanceFramework>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct AddFrameworkResponse {
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
     pub status: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct RemoveFrameworkRequest {
     #[prost(message, optional, tag = "1")]
     pub governance_framework: ::core::option::Option<GovernanceFramework>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct RemoveFrameworkResponse {
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
     pub status: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct SearchRegistryRequest {
     /// SELECT c from c where c.type == 'GovernanceFramework'
     #[prost(string, tag = "1")]
@@ -26,7 +26,7 @@ pub struct SearchRegistryRequest {
     #[prost(string, tag = "2")]
     pub continuation_token: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct SearchRegistryResponse {
     #[prost(string, tag = "1")]
     pub items_json: ::prost::alloc::string::String,
@@ -37,7 +37,7 @@ pub struct SearchRegistryResponse {
     #[prost(string, tag = "4")]
     pub continuation_token: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GovernanceFramework {
     #[prost(string, tag = "1")]
     pub governance_framework_uri: ::prost::alloc::string::String,
@@ -46,7 +46,7 @@ pub struct GovernanceFramework {
     #[prost(string, tag = "3")]
     pub description: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct RegisterIssuerRequest {
     #[prost(string, tag = "10")]
     pub credential_type_uri: ::prost::alloc::string::String,
@@ -61,7 +61,7 @@ pub struct RegisterIssuerRequest {
 }
 /// Nested message and enum types in `RegisterIssuerRequest`.
 pub mod register_issuer_request {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Oneof)]
     pub enum Authority {
         #[prost(string, tag = "1")]
         DidUri(::prost::alloc::string::String),
@@ -69,12 +69,12 @@ pub mod register_issuer_request {
         X509Cert(::prost::alloc::string::String),
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct RegisterIssuerResponse {
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
     pub status: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct RegisterVerifierRequest {
     #[prost(string, tag = "10")]
     pub presentation_type_uri: ::prost::alloc::string::String,
@@ -89,7 +89,7 @@ pub struct RegisterVerifierRequest {
 }
 /// Nested message and enum types in `RegisterVerifierRequest`.
 pub mod register_verifier_request {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Oneof)]
     pub enum Authority {
         #[prost(string, tag = "1")]
         DidUri(::prost::alloc::string::String),
@@ -97,12 +97,12 @@ pub mod register_verifier_request {
         X509Cert(::prost::alloc::string::String),
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct RegisterVerifierResponse {
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
     pub status: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct UnregisterIssuerRequest {
     #[prost(string, tag = "10")]
     pub credential_type_uri: ::prost::alloc::string::String,
@@ -113,7 +113,7 @@ pub struct UnregisterIssuerRequest {
 }
 /// Nested message and enum types in `UnregisterIssuerRequest`.
 pub mod unregister_issuer_request {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Oneof)]
     pub enum Authority {
         #[prost(string, tag = "1")]
         DidUri(::prost::alloc::string::String),
@@ -121,12 +121,12 @@ pub mod unregister_issuer_request {
         X509Cert(::prost::alloc::string::String),
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct UnregisterIssuerResponse {
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
     pub status: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct UnregisterVerifierRequest {
     #[prost(string, tag = "10")]
     pub presentation_type_uri: ::prost::alloc::string::String,
@@ -137,7 +137,7 @@ pub struct UnregisterVerifierRequest {
 }
 /// Nested message and enum types in `UnregisterVerifierRequest`.
 pub mod unregister_verifier_request {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Oneof)]
     pub enum Authority {
         #[prost(string, tag = "1")]
         DidUri(::prost::alloc::string::String),
@@ -145,12 +145,12 @@ pub mod unregister_verifier_request {
         X509Cert(::prost::alloc::string::String),
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct UnregisterVerifierResponse {
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
     pub status: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CheckIssuerStatusRequest {
     #[prost(string, tag = "1")]
     pub governance_framework_uri: ::prost::alloc::string::String,
@@ -161,7 +161,7 @@ pub struct CheckIssuerStatusRequest {
 }
 /// Nested message and enum types in `CheckIssuerStatusRequest`.
 pub mod check_issuer_status_request {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Oneof)]
     pub enum Member {
         #[prost(string, tag = "2")]
         DidUri(::prost::alloc::string::String),
@@ -169,12 +169,12 @@ pub mod check_issuer_status_request {
         X509Cert(::prost::alloc::string::String),
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CheckIssuerStatusResponse {
     #[prost(enumeration = "RegistrationStatus", tag = "1")]
     pub status: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CheckVerifierStatusRequest {
     #[prost(string, tag = "1")]
     pub governance_framework_uri: ::prost::alloc::string::String,
@@ -185,7 +185,7 @@ pub struct CheckVerifierStatusRequest {
 }
 /// Nested message and enum types in `CheckVerifierStatusRequest`.
 pub mod check_verifier_status_request {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Oneof)]
     pub enum Member {
         #[prost(string, tag = "2")]
         DidUri(::prost::alloc::string::String),
@@ -193,19 +193,19 @@ pub mod check_verifier_status_request {
         X509Cert(::prost::alloc::string::String),
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CheckVerifierStatusResponse {
     #[prost(enumeration = "RegistrationStatus", tag = "1")]
     pub status: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct FetchDataRequest {
     #[prost(string, tag = "1")]
     pub governance_framework_uri: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub query: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct FetchDataResponse {
     #[prost(string, tag = "1")]
     pub response_json: ::prost::alloc::string::String,
@@ -214,7 +214,19 @@ pub struct FetchDataResponse {
     #[prost(string, tag = "3")]
     pub continuation_token: ::prost::alloc::string::String,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
 #[repr(i32)]
 pub enum RegistrationStatus {
     /// - the entity is currently authorized, as of time of the query.

--- a/cli/src/proto/services/universalwallet/v1/mod.rs
+++ b/cli/src/proto/services/universalwallet/v1/mod.rs
@@ -1,7 +1,7 @@
 // Search
 
 /// Search request object
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct SearchRequest {
     #[prost(string, tag = "1")]
     pub query: ::prost::alloc::string::String,
@@ -9,7 +9,7 @@ pub struct SearchRequest {
     pub continuation_token: ::prost::alloc::string::String,
 }
 /// Search response object
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct SearchResponse {
     #[prost(string, repeated, tag = "1")]
     pub items: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
@@ -23,14 +23,14 @@ pub struct SearchResponse {
 // Get Item
 
 /// Get item request object
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GetItemRequest {
     /// The item identifier
     #[prost(string, tag = "1")]
     pub item_id: ::prost::alloc::string::String,
 }
 /// Get item response object
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GetItemResponse {
     /// The item data represented as stringified JSON
     #[prost(string, tag = "1")]
@@ -42,7 +42,7 @@ pub struct GetItemResponse {
 // Update Item
 
 /// Update item request object
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct UpdateItemRequest {
     /// The item identifier
     #[prost(string, tag = "1")]
@@ -52,7 +52,7 @@ pub struct UpdateItemRequest {
     pub item_type: ::prost::alloc::string::String,
 }
 /// Update item response object
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct UpdateItemResponse {
     /// Response status
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
@@ -61,7 +61,7 @@ pub struct UpdateItemResponse {
 // InsertItem
 
 /// Insert item request
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct InsertItemRequest {
     /// the document to insert as stringified json
     #[prost(string, tag = "1")]
@@ -71,7 +71,7 @@ pub struct InsertItemRequest {
     pub item_type: ::prost::alloc::string::String,
 }
 /// Insert item response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct InsertItemResponse {
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
     pub status: i32,
@@ -80,14 +80,14 @@ pub struct InsertItemResponse {
     pub item_id: ::prost::alloc::string::String,
 }
 /// Delete item request
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct DeleteItemRequest {
     /// item identifier of the record to delete
     #[prost(string, tag = "1")]
     pub item_id: ::prost::alloc::string::String,
 }
 /// Delete item response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct DeleteItemResponse {
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
     pub status: i32,

--- a/cli/src/proto/services/verifiablecredentials/templates/v1/mod.rs
+++ b/cli/src/proto/services/verifiablecredentials/templates/v1/mod.rs
@@ -1,14 +1,14 @@
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GetCredentialTemplateRequest {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GetCredentialTemplateResponse {
     #[prost(message, optional, tag = "1")]
     pub template: ::core::option::Option<TemplateData>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct SearchCredentialTemplatesRequest {
     /// SELECT * FROM c WHERE c.name = 'Diploma'
     #[prost(string, tag = "1")]
@@ -16,7 +16,7 @@ pub struct SearchCredentialTemplatesRequest {
     #[prost(string, tag = "2")]
     pub continuation_token: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct SearchCredentialTemplatesResponse {
     #[prost(string, tag = "1")]
     pub items_json: ::prost::alloc::string::String,
@@ -27,7 +27,7 @@ pub struct SearchCredentialTemplatesResponse {
     #[prost(string, tag = "4")]
     pub continuation_token: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct ListCredentialTemplatesRequest {
     /// SELECT * FROM c WHERE c.name = 'Diploma'
     #[prost(string, tag = "1")]
@@ -35,7 +35,7 @@ pub struct ListCredentialTemplatesRequest {
     #[prost(string, tag = "2")]
     pub continuation_token: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct ListCredentialTemplatesResponse {
     #[prost(message, repeated, tag = "1")]
     pub templates: ::prost::alloc::vec::Vec<TemplateData>,
@@ -44,15 +44,15 @@ pub struct ListCredentialTemplatesResponse {
     #[prost(string, tag = "3")]
     pub continuation_token: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct DeleteCredentialTemplateRequest {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct DeleteCredentialTemplateResponse {}
 /// Request to create new template
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CreateCredentialTemplateRequest {
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
@@ -61,12 +61,12 @@ pub struct CreateCredentialTemplateRequest {
     #[prost(bool, tag = "3")]
     pub allow_additional_fields: bool,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CreateCredentialTemplateResponse {
     #[prost(message, optional, tag = "1")]
     pub data: ::core::option::Option<TemplateData>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct TemplateField {
     #[prost(string, tag = "2")]
     pub description: ::prost::alloc::string::String,
@@ -75,24 +75,24 @@ pub struct TemplateField {
     #[prost(enumeration = "FieldType", tag = "4")]
     pub r#type: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GetTemplateRequest {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GetTemplateResponse {
     #[prost(message, optional, tag = "1")]
     pub data: ::core::option::Option<TemplateData>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct ListTemplatesRequest {}
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct ListTemplatesResponse {
     #[prost(message, repeated, tag = "1")]
     pub templates: ::prost::alloc::vec::Vec<TemplateData>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct TemplateData {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
@@ -113,7 +113,19 @@ pub struct TemplateData {
     #[prost(string, tag = "9")]
     pub r#type: ::prost::alloc::string::String,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
 #[repr(i32)]
 pub enum FieldType {
     String = 0,

--- a/cli/src/proto/services/verifiablecredentials/v1/mod.rs
+++ b/cli/src/proto/services/verifiablecredentials/v1/mod.rs
@@ -1,27 +1,27 @@
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct IssueRequest {
     #[prost(string, tag = "1")]
     pub document_json: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct IssueResponse {
     #[prost(string, tag = "1")]
     pub signed_document_json: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct IssueFromTemplateRequest {
     #[prost(string, tag = "1")]
     pub template_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub values_json: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct IssueFromTemplateResponse {
     #[prost(string, tag = "1")]
     pub document_json: ::prost::alloc::string::String,
 }
 /// Create Proof
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CreateProofRequest {
     /// Optional document that describes which fields should be
     /// revealed in the generated proof. If specified, this document must be
@@ -39,7 +39,7 @@ pub struct CreateProofRequest {
 pub mod create_proof_request {
     /// Specify the input to be used to derive this proof.
     /// Input can be an existing item in the wallet or an input document
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Oneof)]
     pub enum Proof {
         /// The item identifier that contains a record with a verifiable
         /// credential to be used for generating the proof.
@@ -52,18 +52,18 @@ pub mod create_proof_request {
         DocumentJson(::prost::alloc::string::String),
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CreateProofResponse {
     #[prost(string, tag = "1")]
     pub proof_document_json: ::prost::alloc::string::String,
 }
 /// Verify Proof
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct VerifyProofRequest {
     #[prost(string, tag = "1")]
     pub proof_document_json: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct VerifyProofResponse {
     /// Indicates if the proof is valid
     #[prost(bool, tag = "1")]
@@ -76,7 +76,7 @@ pub struct VerifyProofResponse {
     #[prost(string, repeated, tag = "2")]
     pub validation_messages: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct SendRequest {
     #[prost(string, tag = "100")]
     pub document_json: ::prost::alloc::string::String,
@@ -85,7 +85,7 @@ pub struct SendRequest {
 }
 /// Nested message and enum types in `SendRequest`.
 pub mod send_request {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Oneof)]
     pub enum DeliveryMethod {
         #[prost(string, tag = "1")]
         Email(::prost::alloc::string::String),
@@ -95,13 +95,13 @@ pub mod send_request {
         DidcommInvitationJson(::prost::alloc::string::String),
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct SendResponse {
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
     pub status: i32,
 }
 /// request object to update the status of the revocation entry
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct UpdateStatusRequest {
     /// the credential status id
     #[prost(string, tag = "1")]
@@ -111,20 +111,20 @@ pub struct UpdateStatusRequest {
     pub revoked: bool,
 }
 /// response object for update of status of revocation entry
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct UpdateStatusResponse {
     #[prost(enumeration = "super::super::common::v1::ResponseStatus", tag = "1")]
     pub status: i32,
 }
 /// request object to update the status of the revocation entry
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CheckStatusRequest {
     /// the credential status id
     #[prost(string, tag = "1")]
     pub credential_status_id: ::prost::alloc::string::String,
 }
 /// response object for update of status of revocation entry
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct CheckStatusResponse {
     /// indicates if the status is revoked
     #[prost(bool, tag = "1")]

--- a/cli/src/services/account.rs
+++ b/cli/src/services/account.rs
@@ -84,7 +84,7 @@ async fn sign_in(args: &SignInArgs, config: CliConfig) -> Result<(), Error> {
 
     println!(
         "{}: {}",
-        format!("result").blue().bold(),
+        format!("result").cyan().bold(),
         format!("success").bold()
     );
     println!("auth_token = {}", new_config.options.auth_token);

--- a/cli/src/services/account.rs
+++ b/cli/src/services/account.rs
@@ -40,7 +40,7 @@ async fn sign_in(args: &SignInArgs, config: CliConfig) -> Result<Output, Error> 
             email: args.email.map_or(String::default(), |x| x.to_string()),
             sms: args.sms.map_or(String::default(), |x| x.to_string()),
         }),
-        ecosystem_id: "default".into(),
+        ecosystem_id: config.options.default_ecosystem.clone(),
         invitation_code: args
             .invitation_code
             .map_or(String::default(), |x| x.to_string()),

--- a/cli/src/services/account.rs
+++ b/cli/src/services/account.rs
@@ -31,6 +31,10 @@ async fn sign_in(args: &SignInArgs, config: CliConfig) -> Result<Output, Error> 
         Some(desc) => desc.to_string(),
         None => "New Wallet (from CLI)".to_string(),
     };
+    let ecosystem = args
+        .ecosystem
+        .as_ref()
+        .map_or(config.options.default_ecosystem.clone(), |x| x.to_owned());
 
     let mut client = grpc_client!(AccountClient<Channel>, config.to_owned());
 
@@ -40,11 +44,10 @@ async fn sign_in(args: &SignInArgs, config: CliConfig) -> Result<Output, Error> 
             email: args.email.map_or(String::default(), |x| x.to_string()),
             sms: args.sms.map_or(String::default(), |x| x.to_string()),
         }),
-        ecosystem_id: config.options.default_ecosystem.clone(),
+        ecosystem_id: ecosystem,
         invitation_code: args
             .invitation_code
             .map_or(String::default(), |x| x.to_string()),
-        ..Default::default()
     });
 
     let response = client.sign_in(request).await?.into_inner();

--- a/cli/src/services/account.rs
+++ b/cli/src/services/account.rs
@@ -1,6 +1,7 @@
-use std::io;
-
+use super::config::CliConfig;
+use crate::parser::account::{Command, InfoArgs, SignInArgs};
 use crate::{
+    error::Error,
     grpc_channel, grpc_client, grpc_client_with_auth,
     proto::services::account::v1::{
         account_client::AccountClient, AccountDetails, AccountProfile, ConfirmationMethod,
@@ -9,14 +10,11 @@ use crate::{
 };
 use colored::Colorize;
 use okapi::{proto::security::UnBlindOberonTokenRequest, Oberon};
+use std::io;
 use tonic::transport::Channel;
 
-use crate::parser::account::{Command, InfoArgs, SignInArgs};
-
-use super::config::{DefaultConfig, Error};
-
 #[allow(clippy::unit_arg)]
-pub(crate) fn execute(args: &Command, config: DefaultConfig) -> Result<(), Error> {
+pub(crate) fn execute(args: &Command, config: CliConfig) -> Result<(), Error> {
     match args {
         Command::SignIn(args) => sign_in(args, config),
         Command::Info(args) => info(args, config),
@@ -24,7 +22,7 @@ pub(crate) fn execute(args: &Command, config: DefaultConfig) -> Result<(), Error
 }
 
 #[tokio::main]
-async fn sign_in(args: &SignInArgs, config: DefaultConfig) -> Result<(), Error> {
+async fn sign_in(args: &SignInArgs, config: CliConfig) -> Result<(), Error> {
     let mut new_config = config.clone();
 
     let name = match &args.name {
@@ -88,7 +86,7 @@ async fn sign_in(args: &SignInArgs, config: DefaultConfig) -> Result<(), Error> 
 }
 
 #[tokio::main]
-async fn info(_args: &InfoArgs, config: DefaultConfig) -> Result<(), Error> {
+async fn info(_args: &InfoArgs, config: CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(AccountClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(InfoRequest {});

--- a/cli/src/services/account.rs
+++ b/cli/src/services/account.rs
@@ -85,7 +85,7 @@ async fn sign_in(args: &SignInArgs, config: CliConfig) -> Result<Output, Error> 
     new_config.save()?;
 
     let mut output = Output::new();
-    output.insert("auth_token".into(), new_config.options.auth_token);
+    output.insert("auth token".into(), new_config.options.auth_token);
 
     Ok(output)
 }
@@ -99,7 +99,7 @@ async fn info(_args: &InfoArgs, config: CliConfig) -> Result<Output, Error> {
     let response = client.info(request).await?.into_inner();
 
     let mut output = Output::new();
-    output.insert("account_data".into(), response.to_string_pretty()?);
+    output.insert("account data".into(), response.to_string_pretty()?);
 
     Ok(output)
 }

--- a/cli/src/services/config.rs
+++ b/cli/src/services/config.rs
@@ -184,7 +184,7 @@ impl Interceptor for CliConfig {
         let proof = Oberon::proof(&CreateOberonProofRequest {
             data: profile.auth_data.clone(),
             token: profile.auth_token,
-            nonce: nonce.to_vec(),
+            nonce: nonce.encode_to_vec(),
             blinding: vec![],
         })
         .unwrap();
@@ -193,7 +193,7 @@ impl Interceptor for CliConfig {
             "Oberon data={data},proof={proof},nonce={nonce},ver=1",
             data = base64::encode_config(profile.auth_data, base64::URL_SAFE_NO_PAD),
             proof = base64::encode_config(proof.proof, base64::URL_SAFE_NO_PAD),
-            nonce = base64::encode_config(nonce.to_vec(), base64::URL_SAFE_NO_PAD)
+            nonce = base64::encode_config(nonce.encode_to_vec(), base64::URL_SAFE_NO_PAD)
         );
 
         unsafe {

--- a/cli/src/services/config.rs
+++ b/cli/src/services/config.rs
@@ -194,7 +194,7 @@ fn print() -> Result<Output, Error> {
     let config = CliConfig::init()?.options;
 
     Ok(indexmap! {
-        "path".into() => data_path()?.to_string_lossy().into(),
+        "path".into() => data_path()?.join(CONFIG_FILENAME).to_string_lossy().into(),
         "server endpoint".into() => config.server_endpoint,
         "server port".into() => config.server_port.to_string(),
         "server use tls".into() => config.server_use_tls.to_string(),

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -18,9 +18,7 @@ pub(crate) fn execute(args: &Service, config: CliConfig) -> Result<Output, Error
         Service::VerifiableCredential(args) => vc::execute(&args, config),
         Service::Provider(args) => provider::execute(&args, config),
         Service::Config(args) => Ok(config::execute(&args)).map(|_| Output::new()),
-        Service::TrustRegistry(args) => {
-            trustregistry::execute(&args, &config).map(|_| Output::new())
-        }
+        Service::TrustRegistry(args) => trustregistry::execute(&args, &config),
         Service::Template(args) => template::execute(&args, &config),
         _ => Err(Error::UnknownCommand),
     }

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -8,9 +8,6 @@ mod wallet;
 
 use std::collections::BTreeMap;
 
-use prost::Message;
-use serde::Serialize;
-
 use self::config::CliConfig;
 use crate::error::Error;
 

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -17,7 +17,7 @@ pub(crate) fn execute(args: &Service, config: CliConfig) -> Result<Output, Error
         Service::Account(args) => account::execute(&args, config),
         Service::VerifiableCredential(args) => vc::execute(&args, config),
         Service::Provider(args) => provider::execute(&args, config),
-        Service::Config(args) => Ok(config::execute(&args)).map(|_| Output::new()),
+        Service::Config(args) => config::execute(&args),
         Service::TrustRegistry(args) => trustregistry::execute(&args, &config),
         Service::Template(args) => template::execute(&args, &config),
         _ => Err(Error::UnknownCommand),

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -6,7 +6,7 @@ mod trustregistry;
 mod vc;
 mod wallet;
 
-use std::collections::BTreeMap;
+use indexmap::IndexMap;
 
 use self::config::CliConfig;
 use crate::error::Error;
@@ -38,4 +38,5 @@ pub(crate) enum Service<'a> {
     Unknown,
 }
 
-type Output = BTreeMap<String, String>;
+// type Output = BTreeMap<String, String>;
+type Output = IndexMap<String, String>;

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -27,7 +27,7 @@ pub(crate) enum Service<'a> {
     Wallet(crate::parser::wallet::Command<'a>),
     VerifiableCredential(crate::parser::issuer::Command<'a>),
     Provider(crate::parser::provider::Command<'a>),
-    Config(crate::parser::config::Command<'a>),
+    Config(crate::parser::config::ConfigCommand),
     Account(crate::parser::account::Command<'a>),
     TrustRegistry(crate::parser::trustregistry::Command),
     Template(crate::parser::template::TemplateCommand),

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -6,18 +6,25 @@ mod trustregistry;
 mod vc;
 mod wallet;
 
+use std::collections::BTreeMap;
+
+use prost::Message;
+use serde::Serialize;
+
 use self::config::CliConfig;
 use crate::error::Error;
 
-pub(crate) fn execute(args: &Service, config: CliConfig) -> Result<(), Error> {
+pub(crate) fn execute(args: &Service, config: CliConfig) -> Result<Output, Error> {
     match args {
         Service::Wallet(args) => wallet::execute(&args, config),
         Service::Account(args) => account::execute(&args, config),
-        Service::VerifiableCredential(args) => vc::execute(&args, config),
-        Service::Provider(args) => provider::execute(&args, config),
-        Service::Config(args) => Ok(config::execute(&args)),
-        Service::TrustRegistry(args) => trustregistry::execute(&args, &config),
-        Service::Template(args) => template::execute(&args, &config),
+        Service::VerifiableCredential(args) => vc::execute(&args, config).map(|_| Output::new()),
+        Service::Provider(args) => provider::execute(&args, config).map(|_| Output::new()),
+        Service::Config(args) => Ok(config::execute(&args)).map(|_| Output::new()),
+        Service::TrustRegistry(args) => {
+            trustregistry::execute(&args, &config).map(|_| Output::new())
+        }
+        Service::Template(args) => template::execute(&args, &config).map(|_| Output::new()),
         _ => Err(Error::UnknownCommand),
     }
 }
@@ -33,3 +40,5 @@ pub(crate) enum Service<'a> {
     Template(crate::parser::template::TemplateCommand),
     Unknown,
 }
+
+type Output = BTreeMap<String, String>;

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -21,7 +21,7 @@ pub(crate) fn execute(args: &Service, config: CliConfig) -> Result<Output, Error
         Service::TrustRegistry(args) => {
             trustregistry::execute(&args, &config).map(|_| Output::new())
         }
-        Service::Template(args) => template::execute(&args, &config).map(|_| Output::new()),
+        Service::Template(args) => template::execute(&args, &config),
         _ => Err(Error::UnknownCommand),
     }
 }

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -15,7 +15,7 @@ pub(crate) fn execute(args: &Service, config: CliConfig) -> Result<Output, Error
     match args {
         Service::Wallet(args) => wallet::execute(&args, config),
         Service::Account(args) => account::execute(&args, config),
-        Service::VerifiableCredential(args) => vc::execute(&args, config).map(|_| Output::new()),
+        Service::VerifiableCredential(args) => vc::execute(&args, config),
         Service::Provider(args) => provider::execute(&args, config).map(|_| Output::new()),
         Service::Config(args) => Ok(config::execute(&args)).map(|_| Output::new()),
         Service::TrustRegistry(args) => {
@@ -29,7 +29,7 @@ pub(crate) fn execute(args: &Service, config: CliConfig) -> Result<Output, Error
 #[derive(Debug, PartialEq)]
 pub(crate) enum Service<'a> {
     Wallet(crate::parser::wallet::Command<'a>),
-    VerifiableCredential(crate::parser::issuer::Command<'a>),
+    VerifiableCredential(crate::parser::vc::Command<'a>),
     Provider(crate::parser::provider::Command<'a>),
     Config(crate::parser::config::ConfigCommand),
     Account(crate::parser::account::Command<'a>),

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -16,7 +16,7 @@ pub(crate) fn execute(args: &Service, config: CliConfig) -> Result<Output, Error
         Service::Wallet(args) => wallet::execute(&args, config),
         Service::Account(args) => account::execute(&args, config),
         Service::VerifiableCredential(args) => vc::execute(&args, config),
-        Service::Provider(args) => provider::execute(&args, config).map(|_| Output::new()),
+        Service::Provider(args) => provider::execute(&args, config),
         Service::Config(args) => Ok(config::execute(&args)).map(|_| Output::new()),
         Service::TrustRegistry(args) => {
             trustregistry::execute(&args, &config).map(|_| Output::new())

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -6,9 +6,10 @@ mod trustregistry;
 mod vc;
 mod wallet;
 
-use self::config::{DefaultConfig, Error};
+use self::config::CliConfig;
+use crate::error::Error;
 
-pub(crate) fn execute(args: &Service, config: DefaultConfig) -> Result<(), Error> {
+pub(crate) fn execute(args: &Service, config: CliConfig) -> Result<(), Error> {
     match args {
         Service::Wallet(args) => wallet::execute(&args, config),
         Service::Account(args) => account::execute(&args, config),

--- a/cli/src/services/provider.rs
+++ b/cli/src/services/provider.rs
@@ -11,7 +11,7 @@ use crate::*;
 use tonic::transport::Channel;
 
 #[allow(clippy::unit_arg)]
-pub(crate) fn execute(args: &Command, config: DefaultConfig) -> Result<(), Error> {
+pub(crate) fn execute(args: &Command, config: CliConfig) -> Result<(), Error> {
     match args {
         Command::Invite(args) => Ok(invite(args, config)),
         Command::CreateEcosystem(args) => create_ecosystem(args, &config),
@@ -20,7 +20,7 @@ pub(crate) fn execute(args: &Command, config: DefaultConfig) -> Result<(), Error
 }
 
 #[tokio::main]
-async fn invite(args: &InviteArgs, config: DefaultConfig) {
+async fn invite(args: &InviteArgs, config: CliConfig) {
     let client = grpc_client_with_auth!(ProviderClient<Channel>, config);
 
     let request = tonic::Request::new(InviteRequest {
@@ -57,7 +57,7 @@ async fn invite(args: &InviteArgs, config: DefaultConfig) {
 }
 
 #[tokio::main]
-async fn create_ecosystem(args: &CreateEcosystemArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn create_ecosystem(args: &CreateEcosystemArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client!(ProviderClient<Channel>, config.to_owned());
 
     let req = CreateEcosystemRequest {

--- a/cli/src/services/template.rs
+++ b/cli/src/services/template.rs
@@ -1,20 +1,22 @@
 use std::collections::HashMap;
 
-use crate::parser::template::*;
-
-use crate::proto::services::verifiablecredentials::templates::v1::{
-    credential_templates_client::CredentialTemplatesClient, CreateCredentialTemplateRequest,
-    DeleteCredentialTemplateRequest, GetCredentialTemplateRequest, ListCredentialTemplatesRequest,
-    SearchCredentialTemplatesRequest,
+use crate::{
+    error::Error,
+    grpc_channel, grpc_client_with_auth,
+    parser::template::*,
+    proto::services::verifiablecredentials::templates::v1::{
+        credential_templates_client::CredentialTemplatesClient, CreateCredentialTemplateRequest,
+        DeleteCredentialTemplateRequest, GetCredentialTemplateRequest,
+        ListCredentialTemplatesRequest, SearchCredentialTemplatesRequest,
+    },
+    services::CliConfig,
+    utils::read_file_as_string,
 };
-use crate::services::config::Error;
-use crate::services::DefaultConfig;
-use crate::utils::read_file_as_string;
-use crate::{grpc_channel, grpc_client_with_auth};
+
 use colored::Colorize;
 use tonic::transport::Channel;
 
-pub(crate) fn execute(args: &TemplateCommand, config: &DefaultConfig) -> Result<(), Error> {
+pub(crate) fn execute(args: &TemplateCommand, config: &CliConfig) -> Result<(), Error> {
     match args {
         TemplateCommand::Create(args) => create(args, config),
         TemplateCommand::Get(args) => get(args, config),
@@ -25,7 +27,7 @@ pub(crate) fn execute(args: &TemplateCommand, config: &DefaultConfig) -> Result<
 }
 
 #[tokio::main]
-async fn create(args: &CreateTemplateArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn create(args: &CreateTemplateArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(CredentialTemplatesClient<Channel>, config.to_owned());
 
     let fields: Result<HashMap<String, Field>, _> = match &args.fields_data {
@@ -51,7 +53,7 @@ async fn create(args: &CreateTemplateArgs, config: &DefaultConfig) -> Result<(),
 }
 
 #[tokio::main]
-async fn get(args: &GetTemplateArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn get(args: &GetTemplateArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(CredentialTemplatesClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(GetCredentialTemplateRequest {
@@ -66,7 +68,7 @@ async fn get(args: &GetTemplateArgs, config: &DefaultConfig) -> Result<(), Error
 }
 
 #[tokio::main]
-async fn list(args: &ListTemplatesArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn list(args: &ListTemplatesArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(CredentialTemplatesClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(ListCredentialTemplatesRequest {
@@ -89,7 +91,7 @@ async fn list(args: &ListTemplatesArgs, config: &DefaultConfig) -> Result<(), Er
 }
 
 #[tokio::main]
-async fn search(args: &SearchTemplatesArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn search(args: &SearchTemplatesArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(CredentialTemplatesClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(SearchCredentialTemplatesRequest {
@@ -112,7 +114,7 @@ async fn search(args: &SearchTemplatesArgs, config: &DefaultConfig) -> Result<()
 }
 
 #[tokio::main]
-async fn delete(args: &DeleteTemplateArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn delete(args: &DeleteTemplateArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(CredentialTemplatesClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(DeleteCredentialTemplateRequest {

--- a/cli/src/services/template.rs
+++ b/cli/src/services/template.rs
@@ -10,7 +10,7 @@ use crate::{
         ListCredentialTemplatesRequest, SearchCredentialTemplatesRequest,
     },
     services::CliConfig,
-    utils::read_file_as_string,
+    utils::read_file,
 };
 
 use colored::Colorize;
@@ -33,7 +33,7 @@ async fn create(args: &CreateTemplateArgs, config: &CliConfig) -> Result<(), Err
     let fields: Result<HashMap<String, Field>, _> = match &args.fields_data {
         Some(data) => serde_json::from_str(&data),
         None => match &args.fields_file {
-            Some(file) => serde_json::from_str(&read_file_as_string(Some(&file))),
+            Some(file) => serde_json::from_str(&read_file(file)?),
             None => panic!("you must specify fields data or file"),
         },
     };

--- a/cli/src/services/trustregistry.rs
+++ b/cli/src/services/trustregistry.rs
@@ -1,16 +1,17 @@
-use crate::parser::trustregistry::*;
-use crate::proto::services::common::v1::ResponseStatus;
+use super::config::CliConfig;
 use crate::{
+    error::Error,
     grpc_channel, grpc_client_with_auth,
-    proto::services::trustregistry::v1::{trust_registry_client::TrustRegistryClient, *},
+    parser::trustregistry::*,
+    proto::services::{
+        common::v1::ResponseStatus,
+        trustregistry::v1::{trust_registry_client::TrustRegistryClient, *},
+    },
 };
-
 use colored::Colorize;
 use tonic::transport::Channel;
 
-use super::config::{DefaultConfig, Error};
-
-pub(crate) fn execute(args: &Command, config: &DefaultConfig) -> Result<(), Error> {
+pub(crate) fn execute(args: &Command, config: &CliConfig) -> Result<(), Error> {
     match args {
         Command::Search(args) => search(args, config),
         Command::RegisterIssuer(args) => register_issuer(args, config),
@@ -25,7 +26,7 @@ pub(crate) fn execute(args: &Command, config: &DefaultConfig) -> Result<(), Erro
 }
 
 #[tokio::main]
-async fn search(args: &SearchArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn search(args: &SearchArgs, config: &CliConfig) -> Result<(), Error> {
     let query = args
         .query
         .as_ref()
@@ -46,7 +47,7 @@ async fn search(args: &SearchArgs, config: &DefaultConfig) -> Result<(), Error> 
 }
 
 #[tokio::main]
-async fn register_issuer(args: &RegistrationArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn register_issuer(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(RegisterIssuerRequest {
@@ -72,7 +73,7 @@ async fn register_issuer(args: &RegistrationArgs, config: &DefaultConfig) -> Res
 }
 
 #[tokio::main]
-async fn check_issuer(args: &RegistrationArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn check_issuer(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(CheckIssuerStatusRequest {
@@ -102,7 +103,7 @@ async fn check_issuer(args: &RegistrationArgs, config: &DefaultConfig) -> Result
 }
 
 #[tokio::main]
-async fn check_verifier(args: &RegistrationArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn check_verifier(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(CheckVerifierStatusRequest {
@@ -135,7 +136,7 @@ async fn check_verifier(args: &RegistrationArgs, config: &DefaultConfig) -> Resu
 }
 
 #[tokio::main]
-async fn unregister_issuer(args: &RegistrationArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn unregister_issuer(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(UnregisterIssuerRequest {
@@ -161,7 +162,7 @@ async fn unregister_issuer(args: &RegistrationArgs, config: &DefaultConfig) -> R
 }
 
 #[tokio::main]
-async fn unregister_verifier(args: &RegistrationArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn unregister_verifier(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(UnregisterVerifierRequest {
@@ -190,7 +191,7 @@ async fn unregister_verifier(args: &RegistrationArgs, config: &DefaultConfig) ->
 }
 
 #[tokio::main]
-async fn register_verifier(args: &RegistrationArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn register_verifier(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(RegisterVerifierRequest {
@@ -219,7 +220,7 @@ async fn register_verifier(args: &RegistrationArgs, config: &DefaultConfig) -> R
 }
 
 #[tokio::main]
-async fn add_framework(args: &AddFrameworkArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn add_framework(args: &AddFrameworkArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(AddFrameworkRequest {
@@ -244,7 +245,7 @@ async fn add_framework(args: &AddFrameworkArgs, config: &DefaultConfig) -> Resul
 }
 
 #[tokio::main]
-async fn remove_framework(args: &RemoveFrameworkArgs, config: &DefaultConfig) -> Result<(), Error> {
+async fn remove_framework(args: &RemoveFrameworkArgs, config: &CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(RemoveFrameworkRequest {

--- a/cli/src/services/trustregistry.rs
+++ b/cli/src/services/trustregistry.rs
@@ -1,17 +1,14 @@
-use super::config::CliConfig;
+use super::{config::CliConfig, Output};
 use crate::{
     error::Error,
     grpc_channel, grpc_client_with_auth,
     parser::trustregistry::*,
-    proto::services::{
-        common::v1::ResponseStatus,
-        trustregistry::v1::{trust_registry_client::TrustRegistryClient, *},
-    },
+    proto::services::trustregistry::v1::{trust_registry_client::TrustRegistryClient, *},
 };
-use colored::Colorize;
+use indexmap::indexmap;
 use tonic::transport::Channel;
 
-pub(crate) fn execute(args: &Command, config: &CliConfig) -> Result<(), Error> {
+pub(crate) fn execute(args: &Command, config: &CliConfig) -> Result<Output, Error> {
     match args {
         Command::Search(args) => search(args, config),
         Command::RegisterIssuer(args) => register_issuer(args, config),
@@ -26,7 +23,7 @@ pub(crate) fn execute(args: &Command, config: &CliConfig) -> Result<(), Error> {
 }
 
 #[tokio::main]
-async fn search(args: &SearchArgs, config: &CliConfig) -> Result<(), Error> {
+async fn search(args: &SearchArgs, config: &CliConfig) -> Result<Output, Error> {
     let query = args
         .query
         .as_ref()
@@ -39,15 +36,13 @@ async fn search(args: &SearchArgs, config: &CliConfig) -> Result<(), Error> {
         ..Default::default()
     });
 
-    let response = client.search_registry(request).await?.into_inner();
+    let _response = client.search_registry(request).await?.into_inner();
 
-    println!("{}", response.items_json);
-
-    Ok(())
+    Ok(Output::new())
 }
 
 #[tokio::main]
-async fn register_issuer(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
+async fn register_issuer(args: &RegistrationArgs, config: &CliConfig) -> Result<Output, Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(RegisterIssuerRequest {
@@ -62,18 +57,13 @@ async fn register_issuer(args: &RegistrationArgs, config: &CliConfig) -> Result<
         ..Default::default()
     });
 
-    let response = client.register_issuer(request).await?.into_inner();
+    let _response = client.register_issuer(request).await?.into_inner();
 
-    println!(
-        "{}",
-        format!(": {:?}", ResponseStatus::from_i32(response.status).unwrap()).bright_yellow()
-    );
-
-    Ok(())
+    Ok(Output::new())
 }
 
 #[tokio::main]
-async fn check_issuer(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
+async fn check_issuer(args: &RegistrationArgs, config: &CliConfig) -> Result<Output, Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(CheckIssuerStatusRequest {
@@ -90,20 +80,13 @@ async fn check_issuer(args: &RegistrationArgs, config: &CliConfig) -> Result<(),
 
     let response = client.check_issuer_status(request).await?.into_inner();
 
-    println!(
-        "{}",
-        format!(
-            ": {:?}",
-            RegistrationStatus::from_i32(response.status).unwrap()
-        )
-        .bright_yellow()
-    );
-
-    Ok(())
+    Ok(indexmap! {
+        "status".into() => format!("{:?}", RegistrationStatus::from_i32(response.status).ok_or(Error::SerializationError)?),
+    })
 }
 
 #[tokio::main]
-async fn check_verifier(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
+async fn check_verifier(args: &RegistrationArgs, config: &CliConfig) -> Result<Output, Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(CheckVerifierStatusRequest {
@@ -123,20 +106,13 @@ async fn check_verifier(args: &RegistrationArgs, config: &CliConfig) -> Result<(
 
     let response = client.check_verifier_status(request).await?.into_inner();
 
-    println!(
-        "{}",
-        format!(
-            ": {:?}",
-            RegistrationStatus::from_i32(response.status).unwrap()
-        )
-        .bright_yellow()
-    );
-
-    Ok(())
+    Ok(indexmap! {
+        "status".into() => format!("{:?}", RegistrationStatus::from_i32(response.status).ok_or(Error::SerializationError)?),
+    })
 }
 
 #[tokio::main]
-async fn unregister_issuer(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
+async fn unregister_issuer(args: &RegistrationArgs, config: &CliConfig) -> Result<Output, Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(UnregisterIssuerRequest {
@@ -151,18 +127,13 @@ async fn unregister_issuer(args: &RegistrationArgs, config: &CliConfig) -> Resul
         ..Default::default()
     });
 
-    let response = client.unregister_issuer(request).await?.into_inner();
+    let _response = client.unregister_issuer(request).await?.into_inner();
 
-    println!(
-        "{}",
-        format!(": {:?}", ResponseStatus::from_i32(response.status).unwrap()).bright_yellow()
-    );
-
-    Ok(())
+    Ok(Output::new())
 }
 
 #[tokio::main]
-async fn unregister_verifier(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
+async fn unregister_verifier(args: &RegistrationArgs, config: &CliConfig) -> Result<Output, Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(UnregisterVerifierRequest {
@@ -180,18 +151,13 @@ async fn unregister_verifier(args: &RegistrationArgs, config: &CliConfig) -> Res
         ..Default::default()
     });
 
-    let response = client.unregister_verifier(request).await?.into_inner();
+    let _response = client.unregister_verifier(request).await?.into_inner();
 
-    println!(
-        "{}",
-        format!(": {:?}", ResponseStatus::from_i32(response.status).unwrap()).bright_yellow()
-    );
-
-    Ok(())
+    Ok(Output::new())
 }
 
 #[tokio::main]
-async fn register_verifier(args: &RegistrationArgs, config: &CliConfig) -> Result<(), Error> {
+async fn register_verifier(args: &RegistrationArgs, config: &CliConfig) -> Result<Output, Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(RegisterVerifierRequest {
@@ -209,18 +175,13 @@ async fn register_verifier(args: &RegistrationArgs, config: &CliConfig) -> Resul
         ..Default::default()
     });
 
-    let response = client.register_verifier(request).await?.into_inner();
+    let _response = client.register_verifier(request).await?.into_inner();
 
-    println!(
-        "{}",
-        format!(": {:?}", ResponseStatus::from_i32(response.status).unwrap()).bright_yellow()
-    );
-
-    Ok(())
+    Ok(Output::new())
 }
 
 #[tokio::main]
-async fn add_framework(args: &AddFrameworkArgs, config: &CliConfig) -> Result<(), Error> {
+async fn add_framework(args: &AddFrameworkArgs, config: &CliConfig) -> Result<Output, Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(AddFrameworkRequest {
@@ -234,18 +195,13 @@ async fn add_framework(args: &AddFrameworkArgs, config: &CliConfig) -> Result<()
         }),
     });
 
-    let response = client.add_framework(request).await?.into_inner();
+    let _response = client.add_framework(request).await?.into_inner();
 
-    println!(
-        "{}",
-        format!(": {:?}", ResponseStatus::from_i32(response.status).unwrap()).bright_yellow()
-    );
-
-    Ok(())
+    Ok(Output::new())
 }
 
 #[tokio::main]
-async fn remove_framework(args: &RemoveFrameworkArgs, config: &CliConfig) -> Result<(), Error> {
+async fn remove_framework(args: &RemoveFrameworkArgs, config: &CliConfig) -> Result<Output, Error> {
     let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
 
     let request = tonic::Request::new(RemoveFrameworkRequest {
@@ -255,12 +211,7 @@ async fn remove_framework(args: &RemoveFrameworkArgs, config: &CliConfig) -> Res
         }),
     });
 
-    let response = client.remove_framework(request).await?.into_inner();
+    let _response = client.remove_framework(request).await?.into_inner();
 
-    println!(
-        "{}",
-        format!(": {:?}", ResponseStatus::from_i32(response.status).unwrap()).bright_yellow()
-    );
-
-    Ok(())
+    Ok(Output::new())
 }

--- a/cli/src/services/vc.rs
+++ b/cli/src/services/vc.rs
@@ -13,11 +13,11 @@ use crate::{
     *,
 };
 
-use super::{super::parser::issuer::*, config::DefaultConfig};
+use super::{super::parser::issuer::*, config::CliConfig};
 
 use tonic::transport::Channel;
 
-pub(crate) fn execute(args: &Command, config: DefaultConfig) -> Result<(), Error> {
+pub(crate) fn execute(args: &Command, config: CliConfig) -> Result<(), Error> {
     match args {
         Command::Issue(args) => issue(args, config),
         Command::CreateProof(args) => create_proof(args, config),
@@ -29,7 +29,7 @@ pub(crate) fn execute(args: &Command, config: DefaultConfig) -> Result<(), Error
 }
 
 #[tokio::main]
-async fn issue(args: &IssueArgs, config: DefaultConfig) -> Result<(), Error> {
+async fn issue(args: &IssueArgs, config: CliConfig) -> Result<(), Error> {
     let document_json = read_file_as_string(args.document);
 
     let mut client = grpc_client_with_auth!(VerifiableCredentialClient<Channel>, config);
@@ -44,10 +44,7 @@ async fn issue(args: &IssueArgs, config: DefaultConfig) -> Result<(), Error> {
 }
 
 #[tokio::main]
-async fn issue_from_template(
-    args: &IssueFromTemplateArgs,
-    config: DefaultConfig,
-) -> Result<(), Error> {
+async fn issue_from_template(args: &IssueFromTemplateArgs, config: CliConfig) -> Result<(), Error> {
     let values = args.values_json.as_ref().map_or_else(
         || {
             args.values_file.as_ref().map_or_else(
@@ -75,7 +72,7 @@ async fn issue_from_template(
 }
 
 #[tokio::main]
-async fn get_status(args: &GetStatusArgs, config: DefaultConfig) -> Result<(), Error> {
+async fn get_status(args: &GetStatusArgs, config: CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(VerifiableCredentialClient<Channel>, config);
 
     let request = tonic::Request::new(CheckStatusRequest {
@@ -90,7 +87,7 @@ async fn get_status(args: &GetStatusArgs, config: DefaultConfig) -> Result<(), E
 }
 
 #[tokio::main]
-async fn update_status(args: &UpdateStatusArgs, config: DefaultConfig) -> Result<(), Error> {
+async fn update_status(args: &UpdateStatusArgs, config: CliConfig) -> Result<(), Error> {
     let mut client = grpc_client_with_auth!(VerifiableCredentialClient<Channel>, config);
 
     let request = tonic::Request::new(UpdateStatusRequest {
@@ -106,7 +103,7 @@ async fn update_status(args: &UpdateStatusArgs, config: DefaultConfig) -> Result
 }
 
 #[tokio::main]
-async fn create_proof(args: &CreateProofArgs, config: DefaultConfig) -> Result<(), Error> {
+async fn create_proof(args: &CreateProofArgs, config: CliConfig) -> Result<(), Error> {
     let document_id = match args.document_id {
         Some(id) => id.to_string(),
         None => panic!("Please include document id"),
@@ -128,7 +125,7 @@ async fn create_proof(args: &CreateProofArgs, config: DefaultConfig) -> Result<(
 }
 
 #[tokio::main]
-async fn verify_proof(args: &VerifyProofArgs, config: DefaultConfig) -> Result<(), Error> {
+async fn verify_proof(args: &VerifyProofArgs, config: CliConfig) -> Result<(), Error> {
     let proof_document_json = read_file_as_string(args.proof_document);
 
     let mut client = grpc_client_with_auth!(VerifiableCredentialClient<Channel>, config);

--- a/cli/src/services/vc.rs
+++ b/cli/src/services/vc.rs
@@ -1,23 +1,18 @@
-use crate::parser::issuer::{IssueFromTemplateArgs, UpdateStatusArgs};
+use super::{super::parser::vc::*, config::CliConfig, Output};
 use crate::{
     grpc_client_with_auth,
-    proto::services::{
-        common::v1::ResponseStatus,
-        verifiablecredentials::v1::{
-            create_proof_request::Proof, verifiable_credential_client::VerifiableCredentialClient,
-            CheckStatusRequest, CreateProofRequest, IssueFromTemplateRequest, IssueRequest,
-            UpdateStatusRequest, VerifyProofRequest,
-        },
+    parser::vc::{IssueFromTemplateArgs, UpdateStatusArgs},
+    proto::services::verifiablecredentials::v1::{
+        create_proof_request::Proof, verifiable_credential_client::VerifiableCredentialClient,
+        CheckStatusRequest, CreateProofRequest, IssueFromTemplateRequest, IssueRequest,
+        UpdateStatusRequest, VerifyProofRequest,
     },
-    utils::{read_file_as_string, write_file},
+    utils::{prettify_json, read_file, write_file},
     *,
 };
-
-use super::{super::parser::issuer::*, config::CliConfig};
-
 use tonic::transport::Channel;
 
-pub(crate) fn execute(args: &Command, config: CliConfig) -> Result<(), Error> {
+pub(crate) fn execute(args: &Command, config: CliConfig) -> Result<Output, Error> {
     match args {
         Command::Issue(args) => issue(args, config),
         Command::CreateProof(args) => create_proof(args, config),
@@ -29,8 +24,12 @@ pub(crate) fn execute(args: &Command, config: CliConfig) -> Result<(), Error> {
 }
 
 #[tokio::main]
-async fn issue(args: &IssueArgs, config: CliConfig) -> Result<(), Error> {
-    let document_json = read_file_as_string(args.document);
+async fn issue(args: &IssueArgs, config: CliConfig) -> Result<Output, Error> {
+    let document_json = read_file(
+        args.document
+            .as_ref()
+            .ok_or(Error::InvalidArgument("missing document file".to_string()))?,
+    )?;
 
     let mut client = grpc_client_with_auth!(VerifiableCredentialClient<Channel>, config);
 
@@ -38,22 +37,39 @@ async fn issue(args: &IssueArgs, config: CliConfig) -> Result<(), Error> {
 
     let response = client.issue(request).await?.into_inner();
 
-    write_file(args.out, &response.signed_document_json.as_bytes());
+    match &args.out {
+        Some(file) => write_file(
+            file,
+            &prettify_json(&response.signed_document_json)?.as_bytes(),
+        )?,
+        None => (),
+    }
 
-    Ok(())
+    let mut output = Output::default();
+    output.insert(
+        "signed document".into(),
+        prettify_json(&response.signed_document_json)?,
+    );
+    Ok(output)
 }
 
 #[tokio::main]
-async fn issue_from_template(args: &IssueFromTemplateArgs, config: CliConfig) -> Result<(), Error> {
-    let values = args.values_json.as_ref().map_or_else(
-        || {
-            args.values_file.as_ref().map_or_else(
-                || panic!("you must specify values json or input file"),
-                |x| read_file_as_string(Some(&x)),
-            )
+async fn issue_from_template(
+    args: &IssueFromTemplateArgs,
+    config: CliConfig,
+) -> Result<Output, Error> {
+    let values = match &args.values_json {
+        Some(x) => x.to_owned(),
+        None => match &args.values_file {
+            Some(x) => read_file(x)?,
+            None => {
+                return Err(Error::InvalidArgument(
+                    "you must specify input values as argument or specify an input file"
+                        .to_string(),
+                ))
+            }
         },
-        |x| x.to_owned(),
-    );
+    };
 
     let mut client = grpc_client_with_auth!(VerifiableCredentialClient<Channel>, config);
 
@@ -64,15 +80,21 @@ async fn issue_from_template(args: &IssueFromTemplateArgs, config: CliConfig) ->
 
     let response = client.issue_from_template(request).await?.into_inner();
 
-    // parse and format, to get pretty print *shrug*
-    let json: Value = serde_json::from_str(&response.document_json).unwrap();
-    println!("{}", serde_json::to_string_pretty(&json).unwrap());
+    match &args.output_file {
+        Some(file) => write_file(file, &prettify_json(&response.document_json)?.as_bytes())?,
+        None => (),
+    }
 
-    Ok(())
+    let mut output = Output::default();
+    output.insert(
+        "signed document".into(),
+        prettify_json(&response.document_json)?,
+    );
+    Ok(output)
 }
 
 #[tokio::main]
-async fn get_status(args: &GetStatusArgs, config: CliConfig) -> Result<(), Error> {
+async fn get_status(args: &GetStatusArgs, config: CliConfig) -> Result<Output, Error> {
     let mut client = grpc_client_with_auth!(VerifiableCredentialClient<Channel>, config);
 
     let request = tonic::Request::new(CheckStatusRequest {
@@ -81,13 +103,13 @@ async fn get_status(args: &GetStatusArgs, config: CliConfig) -> Result<(), Error
 
     let response = client.check_status(request).await?.into_inner();
 
-    println!("Revoked = {}", response.revoked);
-
-    Ok(())
+    let mut output = Output::default();
+    output.insert("revoked".into(), response.revoked.to_string());
+    Ok(output)
 }
 
 #[tokio::main]
-async fn update_status(args: &UpdateStatusArgs, config: CliConfig) -> Result<(), Error> {
+async fn update_status(args: &UpdateStatusArgs, config: CliConfig) -> Result<Output, Error> {
     let mut client = grpc_client_with_auth!(VerifiableCredentialClient<Channel>, config);
 
     let request = tonic::Request::new(UpdateStatusRequest {
@@ -95,38 +117,59 @@ async fn update_status(args: &UpdateStatusArgs, config: CliConfig) -> Result<(),
         revoked: args.revoked,
     });
 
-    let response = client.update_status(request).await?.into_inner();
+    let _response = client.update_status(request).await?.into_inner();
 
-    println!("{:#?}", ResponseStatus::from_i32(response.status).unwrap());
-
-    Ok(())
+    Ok(Output::new())
 }
 
 #[tokio::main]
-async fn create_proof(args: &CreateProofArgs, config: CliConfig) -> Result<(), Error> {
-    let document_id = match args.document_id {
-        Some(id) => id.to_string(),
-        None => panic!("Please include document id"),
+async fn create_proof(args: &CreateProofArgs, config: CliConfig) -> Result<Output, Error> {
+    let document_json = match &args.document_file {
+        Some(x) => read_file(x)?,
+        None => String::default(),
     };
-    let reveal_document_json = read_file_as_string(args.reveal_document);
+    let reveal_document_json = match &args.reveal_document {
+        Some(x) => read_file(x)?,
+        None => String::default(),
+    };
 
     let mut client = grpc_client_with_auth!(VerifiableCredentialClient<Channel>, config);
 
     let request = tonic::Request::new(CreateProofRequest {
         reveal_document_json,
-        proof: Some(Proof::ItemId(document_id)),
+        proof: Some(if document_json.is_empty() {
+            Proof::ItemId(
+                args.item_id
+                    .as_ref()
+                    .ok_or(Error::MissingArguments)?
+                    .clone(),
+            )
+        } else {
+            Proof::DocumentJson(document_json)
+        }),
     });
 
     let response = client.create_proof(request).await?.into_inner();
 
-    write_file(args.out, response.proof_document_json.as_bytes());
+    match &args.out {
+        Some(file) => write_file(
+            file,
+            prettify_json(&response.proof_document_json)?.as_bytes(),
+        )?,
+        None => (),
+    }
 
-    Ok(())
+    let mut output = Output::default();
+    output.insert(
+        "proof document".into(),
+        prettify_json(&response.proof_document_json)?,
+    );
+    Ok(output)
 }
 
 #[tokio::main]
-async fn verify_proof(args: &VerifyProofArgs, config: CliConfig) -> Result<(), Error> {
-    let proof_document_json = read_file_as_string(args.proof_document);
+async fn verify_proof(args: &VerifyProofArgs, config: CliConfig) -> Result<Output, Error> {
+    let proof_document_json = read_file(args.proof_document.unwrap())?;
 
     let mut client = grpc_client_with_auth!(VerifiableCredentialClient<Channel>, config);
 
@@ -136,7 +179,7 @@ async fn verify_proof(args: &VerifyProofArgs, config: CliConfig) -> Result<(), E
 
     let response = client.verify_proof(request).await?.into_inner();
 
-    println!("{:}", response.is_valid);
-
-    Ok(())
+    let mut output = Output::default();
+    output.insert("is valid".into(), response.is_valid.to_string());
+    Ok(output)
 }

--- a/cli/src/services/wallet.rs
+++ b/cli/src/services/wallet.rs
@@ -1,6 +1,7 @@
 use std::default::*;
 
 use super::super::parser::wallet::*;
+use crate::error::Error;
 use crate::proto::services::universalwallet::v1::DeleteItemRequest;
 use crate::utils::read_file_as_string;
 use crate::{grpc_channel, grpc_client_with_auth};
@@ -19,7 +20,7 @@ use crate::{
 use tonic::transport::Channel;
 
 #[allow(clippy::unit_arg)]
-pub(crate) fn execute(args: &Command, config: DefaultConfig) -> Result<(), Error> {
+pub(crate) fn execute(args: &Command, config: CliConfig) -> Result<(), Error> {
     match args {
         Command::Search(args) => Ok(search(args, config)),
         Command::InsertItem(args) => Ok(insert_item(args, config)),
@@ -29,7 +30,7 @@ pub(crate) fn execute(args: &Command, config: DefaultConfig) -> Result<(), Error
 }
 
 #[tokio::main]
-async fn search(args: &SearchArgs, config: DefaultConfig) {
+async fn search(args: &SearchArgs, config: CliConfig) {
     let query = args
         .query
         .map_or("SELECT * FROM c".to_string(), |q| q.to_string());
@@ -56,7 +57,7 @@ async fn search(args: &SearchArgs, config: DefaultConfig) {
 }
 
 #[tokio::main]
-async fn insert_item(args: &InsertItemArgs, config: DefaultConfig) {
+async fn insert_item(args: &InsertItemArgs, config: CliConfig) {
     let item_json = read_file_as_string(args.item);
 
     let mut client = grpc_client_with_auth!(UniversalWalletClient<Channel>, config.to_owned());
@@ -73,7 +74,7 @@ async fn insert_item(args: &InsertItemArgs, config: DefaultConfig) {
 }
 
 #[tokio::main]
-async fn delete_item(args: &DeleteItemArgs, config: DefaultConfig) {
+async fn delete_item(args: &DeleteItemArgs, config: CliConfig) {
     let mut client = grpc_client_with_auth!(UniversalWalletClient<Channel>, config.to_owned());
     let response = client
         .delete_item(DeleteItemRequest {
@@ -87,7 +88,7 @@ async fn delete_item(args: &DeleteItemArgs, config: DefaultConfig) {
 }
 
 #[tokio::main]
-async fn send(args: &SendArgs, config: DefaultConfig) {
+async fn send(args: &SendArgs, config: CliConfig) {
     let item = read_file_as_string(args.item);
 
     let mut client = grpc_client_with_auth!(VerifiableCredentialClient<Channel>, config.to_owned());

--- a/cli/src/services/wallet.rs
+++ b/cli/src/services/wallet.rs
@@ -1,5 +1,3 @@
-use std::default::*;
-
 use super::{super::parser::wallet::*, Output};
 use crate::{
     error::Error,
@@ -15,9 +13,10 @@ use crate::{
         },
     },
     services::config::*,
-    utils::read_file,
+    utils::{prettify_json, read_file},
 };
-use serde_json::Value;
+use indexmap::indexmap;
+use std::default::*;
 use tonic::transport::Channel;
 
 #[allow(clippy::unit_arg)]
@@ -55,17 +54,10 @@ async fn search(args: &SearchArgs, config: CliConfig) -> Result<Output, Error> {
     out = out.trim_end_matches(",").to_string();
     out.push_str("]");
 
-    let mut output = Output::new();
-    output.insert(
-        "items".into(),
-        // serde back and forth to get pretty print
-        serde_json::to_string_pretty(
-            &serde_json::from_str::<Value>(&out).map_err(|_| Error::SerializationError)?,
-        )?,
-    );
-    output.insert("query".into(), query);
-
-    Ok(output)
+    Ok(indexmap! {
+        "query".into() => query,
+        "items".into() => prettify_json(&out)?
+    })
 }
 
 #[tokio::main]

--- a/cli/src/utils/mod.rs
+++ b/cli/src/utils/mod.rs
@@ -1,9 +1,11 @@
 use chrono::{DateTime, Local, Utc};
-use serde_json::json;
+use serde_json::{json, Value};
 use std::fs::{create_dir_all, OpenOptions};
 use std::io::{stdin, stdout, BufRead, Read, Write};
 use std::path::Path;
 use std::str;
+
+use crate::error::Error;
 
 pub static SERVER_URL: &str = "http://localhost:5000";
 pub static SECURITY_CONTEXT_V1_URL: &str = "https://w3id.org/security/v1";
@@ -12,23 +14,11 @@ pub static SECURITY_CONTEXT_V3_URL: &str = "https://w3id.org/security/v3-unstabl
 pub static SECURITY_PROOF_URL: &str = "https://w3id.org/security#proof";
 pub static DID_V1_URL: &str = "https://www.w3.org/ns/did/v1";
 
-pub fn read_file(filename: Option<&str>) -> Vec<u8> {
-    match filename {
-        Some(path) => {
-            let mut file = OpenOptions::new()
-                .read(true)
-                .open(path)
-                .expect("Unable to open file");
-            let mut data: Vec<u8> = Vec::new();
-            file.read_to_end(&mut data).expect("Unable to read file");
-            data
-        }
-        None => {
-            let mut data: Vec<u8> = Vec::new();
-            stdin().read_to_end(&mut data).expect("Unable to read file");
-            data
-        }
-    }
+pub(crate) fn read_file<P: AsRef<Path>>(path: P) -> Result<String, Error> {
+    let mut file = OpenOptions::new().read(true).open(path)?;
+    let mut data = String::new();
+    file.read_to_string(&mut data)?;
+    Ok(data)
 }
 
 pub fn read_line(out: Option<&str>) -> String {
@@ -54,34 +44,24 @@ pub fn read_line(out: Option<&str>) -> String {
     }
 }
 
-pub fn read_file_as_string(filename: Option<&str>) -> String {
-    str::from_utf8(&read_file(filename))
-        .expect("Unable to read file as utf 8")
-        .to_string()
+pub(crate) fn prettify_json(json: &String) -> Result<String, Error> {
+    Ok(serde_json::to_string_pretty(
+        &serde_json::from_str::<Value>(json)?,
+    )?)
 }
 
-pub fn write_file(filename: Option<&str>, data: &[u8]) {
-    match filename {
-        Some(out) => {
-            let parent = Path::new(out)
-                .parent()
-                .expect("Unable to resolve parent directory of output");
-            create_dir_all(parent).expect("Unable to create parent directory of output file");
-            let mut file = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(out)
-                .expect("Unable to open file");
-            file.write_all(&data)
-                .expect("Unable to write to output file");
-        }
-        None => {
-            stdout()
-                .write_all(&data)
-                .expect("Unable to write to stdout");
-        }
-    };
+pub(crate) fn write_file<P: AsRef<Path>>(path: P, data: &[u8]) -> Result<(), Error> {
+    let parent = path.as_ref().parent().ok_or(Error::IOError)?;
+    create_dir_all(parent)?;
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)?;
+    file.write_all(&data)?;
+
+    Ok(())
 }
 
 pub fn get_capability_document(wallet_id: &str) -> String {


### PR DESCRIPTION
- Eliminates the use of panics and crashes; it now fails gracefully and reports more meaningful errors
- Missing API options; relaxed requirements where needed
- Use new `ServiceOptions` in config (breaking, requires removing old configuration file)
- Use single auth profile; can be updated using CLI
- Most commands now have the option to save the responses in file