### PR TITLE
[dotnet] Correctly process auth token during ecosystem create

### DIFF
--- a/dotnet/Trinsic/ProviderService.cs
+++ b/dotnet/Trinsic/ProviderService.cs
@@ -81,7 +81,10 @@ public class ProviderService : ServiceBase
 
         var authToken = Convert.ToBase64String(response.Profile.ToByteArray());
 
-        if (!response.Profile.Protection?.Enabled ?? false) Options.AuthToken = authToken;
+        if (!response.Profile.Protection?.Enabled ?? true) {
+            Options.AuthToken = authToken;
+            await TokenProvider.SaveAsync(authToken);
+        }
         return (response.Ecosystem, authToken);
     }
 
@@ -90,14 +93,16 @@ public class ProviderService : ServiceBase
     /// </summary>
     /// <param name="request"></param>
     /// <returns></returns>
-    /// <exception cref="Exception"></exception>
     public (Ecosystem ecosystem, string authToken) CreateEcosystem(CreateEcosystemRequest request) {
         request.Details ??= new();
 
         var response = Client.CreateEcosystem(request);
         var authToken = Convert.ToBase64String(response.Profile.ToByteArray());
 
-        if (!response.Profile.Protection?.Enabled ?? true) Options.AuthToken = authToken;
+        if (!response.Profile.Protection?.Enabled ?? true) {
+            Options.AuthToken = authToken;
+            TokenProvider.Save(authToken);
+        }
         return (response.Ecosystem, authToken);
     }
 

--- a/dotnet/Trinsic/ServiceBase.cs
+++ b/dotnet/Trinsic/ServiceBase.cs
@@ -73,7 +73,9 @@ public abstract class ServiceBase
     /// </summary>
     /// <returns></returns>
     protected async Task<Metadata> BuildMetadataAsync(IMessage request) {
-        var authToken = string.IsNullOrWhiteSpace(Options.AuthToken) ? TokenProvider.Get() : Options.AuthToken;
+        var authToken = string.IsNullOrWhiteSpace(Options.AuthToken)
+            ? await TokenProvider.GetAsync()
+            : Options.AuthToken;
         if (authToken is null) throw new("Cannot call authenticated endpoint before signing in");
 
         var profile = AccountProfile.Parser.ParseFrom(Convert.FromBase64String(authToken));
@@ -88,7 +90,9 @@ public abstract class ServiceBase
     /// </summary>
     /// <returns></returns>
     protected Metadata BuildMetadata(IMessage request) {
-        var authToken = string.IsNullOrWhiteSpace(Options.AuthToken) ? TokenProvider.Get() : Options.AuthToken;
+        var authToken = string.IsNullOrWhiteSpace(Options.AuthToken) 
+            ? TokenProvider.Get() 
+            : Options.AuthToken;
         if (authToken is null) throw new("Cannot call authenticated endpoint before signing in");
 
         var profile = AccountProfile.Parser.ParseFrom(Convert.FromBase64String(authToken));

--- a/dotnet/Trinsic/Trinsic.xml
+++ b/dotnet/Trinsic/Trinsic.xml
@@ -2613,7 +2613,6 @@
             </summary>
             <param name="request"></param>
             <returns></returns>
-            <exception cref="T:System.Exception"></exception>
         </member>
         <member name="M:Trinsic.ProviderService.GenerateTokenAsync(Trinsic.Services.Provider.V1.GenerateTokenRequest)">
             <summary>


### PR DESCRIPTION
- token wasn't saved after ecosystem create
- auto assign token logic for provider service had incorrect check 