### PR TITLE
Expose the `*Request` object for .NET

### DIFF
--- a/dotnet/Tests/Tests.cs
+++ b/dotnet/Tests/Tests.cs
@@ -16,6 +16,7 @@ using FluentAssertions;
 using Google.Protobuf;
 using Trinsic.Sdk.Options.V1;
 using Trinsic.Services.Account.V1;
+using Trinsic.Services.UniversalWallet.V1;
 using Trinsic.Services.VerifiableCredentials.Templates.V1;
 using Trinsic.Services.VerifiableCredentials.V1;
 using FieldType = Trinsic.Services.VerifiableCredentials.Templates.V1.FieldType;
@@ -110,7 +111,7 @@ public class Tests
         walletService.Options.AuthToken = credentialsService.Options.AuthToken = allison;
 
         var itemId = await walletService.InsertItemAsync(new() {ItemJson = credential.SignedDocumentJson});
-        var walletItems = await walletService.SearchAsync();
+        var walletItems = await walletService.SearchAsync(new());
         _testOutputHelper.WriteLine($"Last wallet item:\n{walletItems.Items.Last()}");
         // }
 
@@ -197,7 +198,7 @@ public class Tests
         verifierStatus.Should().Be(RegistrationStatus.Current);
 
         // search registry
-        var searchResult = await service.SearchRegistryAsync();
+        var searchResult = await service.SearchRegistryAsync(new());
 
         searchResult.Should().NotBeNull();
         searchResult.ItemsJson.Should().NotBeNull().And.NotBeEmpty();
@@ -273,7 +274,12 @@ public class Tests
         var myAccountService = new AccountService(_options);
         var myProfile = await myAccountService.SignInAsync(new());
         var myTrustRegistryService = new TrustRegistryService(_options.CloneWithAuthToken(myProfile));
-        await Assert.ThrowsAsync<Exception>(async () => await myTrustRegistryService.RegisterGovernanceFrameworkAsync("", "invalid uri"));
+        await Assert.ThrowsAsync<Exception>(async () => await myTrustRegistryService.RegisterGovernanceFrameworkAsync(new () {
+            GovernanceFramework = new() {
+                Description = "invalid uri",
+                GovernanceFrameworkUri = ""
+            }
+        }));
     }
 
     [Fact(DisplayName = "Demo: template management and credential issuance from template")]

--- a/dotnet/Tests/Tests.cs
+++ b/dotnet/Tests/Tests.cs
@@ -145,8 +145,8 @@ public class Tests
         var valid = await credentialsService.VerifyProofAsync(new() {
             ProofDocumentJson = credentialProof.ProofDocumentJson
         });
-        _testOutputHelper.WriteLine($"Verification result: {valid}");
-        Assert.True(valid);
+        _testOutputHelper.WriteLine($"Verification result: {valid.IsValid}");
+        Assert.True(valid.IsValid);
         // }
     }
 
@@ -322,12 +322,12 @@ public class Tests
 
         credentialJson.Should().NotBeNull();
 
-        var jsonDocument = JsonDocument.Parse(credentialJson).RootElement.EnumerateObject();
+        var jsonDocument = JsonDocument.Parse(credentialJson.DocumentJson).RootElement.EnumerateObject();
 
         jsonDocument.Should().Contain(x => x.Name == "id");
         jsonDocument.Should().Contain(x => x.Name == "credentialSubject");
 
-        var itemId = await walletService.InsertItemAsync(new() {ItemJson = credentialJson});
+        var itemId = await walletService.InsertItemAsync(new() {ItemJson = credentialJson.DocumentJson});
 
         var frame = new JObject {
             {"@context", "https://www.w3.org/2018/credentials/v1"},
@@ -337,13 +337,13 @@ public class Tests
         // Create proof from input document
         {
             var proof = await credentialService.CreateProofAsync(new() {
-                DocumentJson = credentialJson,
+                DocumentJson = credentialJson.DocumentJson,
                 RevealDocumentJson = frame.ToString(Formatting.None)
             });
 
             var valid = await credentialService.VerifyProofAsync(new() {ProofDocumentJson = proof.ProofDocumentJson});
 
-            valid.Should().BeTrue();
+            valid.IsValid.Should().BeTrue();
         }
 
         // Create proof from item id
@@ -355,7 +355,7 @@ public class Tests
 
             var valid = await credentialService.VerifyProofAsync(new() {ProofDocumentJson = proof.ProofDocumentJson});
 
-            valid.Should().BeTrue();
+            valid.IsValid.Should().BeTrue();
         }
     }
 }

--- a/dotnet/Trinsic/CredentialsService.cs
+++ b/dotnet/Trinsic/CredentialsService.cs
@@ -109,33 +109,26 @@ public class CredentialsService : ServiceBase
     /// <summary>
     /// Check credential template status
     /// </summary>
-    /// <param name="credentialStatusId"></param>
     /// <returns></returns>
-    public async Task<CheckStatusResponse> CheckStatusAsync(string credentialStatusId) {
-        CheckStatusRequest request = new() {CredentialStatusId = credentialStatusId};
+    public async Task<CheckStatusResponse> CheckStatusAsync(CheckStatusRequest request) {
         return await Client.CheckStatusAsync(request, await BuildMetadataAsync(request));
     }
 
-    public CheckStatusResponse CheckStatus(string credentialStatusId) {
-        CheckStatusRequest request = new() {CredentialStatusId = credentialStatusId};
+    public CheckStatusResponse CheckStatus(CheckStatusRequest request) {
         return Client.CheckStatus(request, BuildMetadata(request));
     }
 
     /// <summary>
     /// Update credential template revocation status
     /// </summary>
-    /// <param name="credentialStatusId"></param>
-    /// <param name="revoked"></param>
     /// <returns></returns>
-    public async Task UpdateStatusAsync(string credentialStatusId, bool revoked) {
-        UpdateStatusRequest request = new() {CredentialStatusId = credentialStatusId, Revoked = revoked};
+    public async Task UpdateStatusAsync(UpdateStatusRequest request) {
         var response = await Client.UpdateStatusAsync(request, await BuildMetadataAsync(request));
         if (response.Status == ResponseStatus.Success) return;
         throw new($"Status not completely updated {response.Status}");
     }
 
-    public void UpdateStatus(string credentialStatusId, bool revoked) {
-        UpdateStatusRequest request = new() {CredentialStatusId = credentialStatusId, Revoked = revoked};
+    public void UpdateStatus(UpdateStatusRequest request) {
         var response = Client.UpdateStatus(request, BuildMetadata(request));
         if (response.Status == ResponseStatus.Success) return;
         throw new($"Status not completely updated {response.Status}");

--- a/dotnet/Trinsic/CredentialsService.cs
+++ b/dotnet/Trinsic/CredentialsService.cs
@@ -50,9 +50,9 @@ public class CredentialsService : ServiceBase
     /// </summary>
     /// <param name="request">The request object with the template identifier and the values</param>
     /// <returns>Verifiable credential as JSON</returns>
-    public async Task<string> IssueFromTemplateAsync(IssueFromTemplateRequest request) {
+    public async Task<IssueFromTemplateResponse> IssueFromTemplateAsync(IssueFromTemplateRequest request) {
         var response = await Client.IssueFromTemplateAsync(request, await BuildMetadataAsync(request));
-        return response.DocumentJson;
+        return response;
     }
 
     /// <summary>
@@ -60,9 +60,9 @@ public class CredentialsService : ServiceBase
     /// </summary>
     /// <param name="request">The request object with the template identifier and the values</param>
     /// <returns>Verifiable credential as JSON</returns>
-    public string IssueFromTemplate(IssueFromTemplateRequest request) {
+    public IssueFromTemplateResponse IssueFromTemplate(IssueFromTemplateRequest request) {
         var response = Client.IssueFromTemplate(request, BuildMetadata(request));
-        return response.DocumentJson;
+        return response;
     }
 
     /// <summary>
@@ -90,20 +90,20 @@ public class CredentialsService : ServiceBase
     /// </summary>
     /// <param name="request"></param>
     /// <returns></returns>
-    public async Task<bool> VerifyProofAsync(VerifyProofRequest request) {
+    public async Task<VerifyProofResponse> VerifyProofAsync(VerifyProofRequest request) {
         var response = await Client.VerifyProofAsync(
             request,
             await BuildMetadataAsync(request));
 
-        return response.IsValid;
+        return response;
     }
 
-    public bool VerifyProof(VerifyProofRequest request) {
+    public VerifyProofResponse VerifyProof(VerifyProofRequest request) {
         var response = Client.VerifyProof(
             request,
             BuildMetadata(request));
 
-        return response.IsValid;
+        return response;
     }
 
     /// <summary>

--- a/dotnet/Trinsic/Trinsic.xml
+++ b/dotnet/Trinsic/Trinsic.xml
@@ -103,19 +103,16 @@
             <param name="request"></param>
             <returns></returns>
         </member>
-        <member name="M:Trinsic.CredentialsService.CheckStatusAsync(System.String)">
+        <member name="M:Trinsic.CredentialsService.CheckStatusAsync(Trinsic.Services.VerifiableCredentials.V1.CheckStatusRequest)">
             <summary>
             Check credential template status
             </summary>
-            <param name="credentialStatusId"></param>
             <returns></returns>
         </member>
-        <member name="M:Trinsic.CredentialsService.UpdateStatusAsync(System.String,System.Boolean)">
+        <member name="M:Trinsic.CredentialsService.UpdateStatusAsync(Trinsic.Services.VerifiableCredentials.V1.UpdateStatusRequest)">
             <summary>
             Update credential template revocation status
             </summary>
-            <param name="credentialStatusId"></param>
-            <param name="revoked"></param>
             <returns></returns>
         </member>
         <member name="M:Trinsic.CredentialsService.SendAsync(Trinsic.Services.VerifiableCredentials.V1.SendRequest)">
@@ -2702,15 +2699,13 @@
             The search response and continuation token, if available
             </returns>
         </member>
-        <member name="M:Trinsic.TrustRegistryService.RegisterGovernanceFrameworkAsync(System.String,System.String)">
+        <member name="M:Trinsic.TrustRegistryService.RegisterGovernanceFrameworkAsync(Trinsic.Services.TrustRegistry.V1.AddFrameworkRequest)">
             <summary>
             Register a Governance Framework with the Trust Registry.
             </summary>
             <remarks>
             Calling this multiple times with the same URI will update the previously registered framework.
             </remarks>
-            <param name="governanceFramework">The governance framework URI</param>
-            <param name="description">The framework description</param>
             <returns></returns>
         </member>
         <member name="M:Trinsic.TrustRegistryService.RegisterIssuerAsync(Trinsic.Services.TrustRegistry.V1.RegisterIssuerRequest)">
@@ -2740,29 +2735,25 @@
             <param name="request">The request object</param>
             <returns>The status of the registration</returns>
         </member>
-        <member name="M:Trinsic.TrustRegistryService.SearchRegistryAsync(System.String,System.String)">
+        <member name="M:Trinsic.TrustRegistryService.SearchRegistryAsync(Trinsic.Services.TrustRegistry.V1.SearchRegistryRequest)">
             <summary>
             Search the trust registry
             </summary>
-            <param name="query"></param>
-            <param name="continuationToken">continuation token from a previous search</param>
             <returns></returns>
         </member>
-        <member name="M:Trinsic.WalletService.SearchAsync(System.String)">
+        <member name="M:Trinsic.WalletService.SearchAsync(Trinsic.Services.UniversalWallet.V1.SearchRequest)">
             <summary>
             Search the wallet for records matching the specified criteria
             </summary>
-            <param name="query">The SQL query</param>
             <remarks>
             See https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-select
             </remarks>
             <returns></returns>
         </member>
-        <member name="M:Trinsic.WalletService.Search(System.String)">
+        <member name="M:Trinsic.WalletService.Search(Trinsic.Services.UniversalWallet.V1.SearchRequest)">
             <summary>
             Search the wallet for records matching the specified criteria
             </summary>
-            <param name="query">The SQL query</param>
             <remarks>
             See https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-select
             </remarks>

--- a/dotnet/Trinsic/TrustRegistryService.cs
+++ b/dotnet/Trinsic/TrustRegistryService.cs
@@ -35,29 +35,16 @@ public class TrustRegistryService : ServiceBase
     /// <remarks>
     /// Calling this multiple times with the same URI will update the previously registered framework.
     /// </remarks>
-    /// <param name="governanceFramework">The governance framework URI</param>
-    /// <param name="description">The framework description</param>
     /// <returns></returns>
-    public async Task RegisterGovernanceFrameworkAsync(string governanceFramework, string description) {
-        if (!Uri.TryCreate(governanceFramework, UriKind.Absolute, out _)) throw new("Invalid URI string");
+    public async Task<AddFrameworkResponse> RegisterGovernanceFrameworkAsync(AddFrameworkRequest request) {
+        if (!Uri.TryCreate(request.GovernanceFramework.GovernanceFrameworkUri, UriKind.Absolute, out _)) throw new("Invalid URI string");
 
-        AddFrameworkRequest request = new() {
-            GovernanceFramework = new() {
-                GovernanceFrameworkUri = governanceFramework,
-                Description = description
-            }
-        };
-        var response = await Client.AddFrameworkAsync(request, await BuildMetadataAsync(request));
+        return await Client.AddFrameworkAsync(request, await BuildMetadataAsync(request));
     }
 
-    public void RegisterGovernanceFramework(string governanceFramework, string description) {
-        if (!Uri.TryCreate(governanceFramework, UriKind.Absolute, out _)) throw new("Invalid URI string");
-        AddFrameworkRequest request = new() {
-            GovernanceFramework = new() {
-                GovernanceFrameworkUri = governanceFramework,
-                Description = description
-            }
-        };
+    public void RegisterGovernanceFramework(AddFrameworkRequest request) {
+        if (!Uri.TryCreate(request.GovernanceFramework.GovernanceFrameworkUri, UriKind.Absolute, out _)) throw new("Invalid URI string");
+        
         Client.AddFramework(request, BuildMetadata(request));
     }
 
@@ -147,23 +134,19 @@ public class TrustRegistryService : ServiceBase
     /// <summary>
     /// Search the trust registry
     /// </summary>
-    /// <param name="query"></param>
-    /// <param name="continuationToken">continuation token from a previous search</param>
     /// <returns></returns>
-    public async Task<SearchRegistryResponse> SearchRegistryAsync(string query = "SELECT * FROM c", string? continuationToken = null) {
-        SearchRegistryRequest request = new() {
-            Query = query,
-            ContinuationToken = continuationToken ?? string.Empty
-        };
+    public async Task<SearchRegistryResponse> SearchRegistryAsync(SearchRegistryRequest request) {
+        if (String.IsNullOrWhiteSpace(request.Query))
+            request.Query = "SELECT * FROM c";
+        
         var response = await Client.SearchRegistryAsync(request, await BuildMetadataAsync(request));
         return response;
     }
 
-    public SearchRegistryResponse SearchRegistry(string query = "SELECT * FROM c", string? continuationToken = null) {
-        SearchRegistryRequest request = new() {
-            Query = query,
-            ContinuationToken = continuationToken ?? string.Empty
-        };
+    public SearchRegistryResponse SearchRegistry(SearchRegistryRequest request) {
+        if (String.IsNullOrWhiteSpace(request.Query))
+            request.Query = "SELECT * FROM c";
+        
         return Client.SearchRegistry(request, BuildMetadata(request));
     }
 

--- a/dotnet/Trinsic/WalletService.cs
+++ b/dotnet/Trinsic/WalletService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Trinsic.Services.UniversalWallet.V1;
@@ -29,13 +30,14 @@ public class WalletService : ServiceBase
     /// <summary>
     /// Search the wallet for records matching the specified criteria
     /// </summary>
-    /// <param name="query">The SQL query</param>
     /// <remarks>
     /// See https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-select
     /// </remarks>
     /// <returns></returns>
-    public async Task<SearchResponse> SearchAsync(string query = "SELECT * FROM c") {
-        SearchRequest request = new() {Query = query};
+    public async Task<SearchResponse> SearchAsync(SearchRequest request) {
+        if (String.IsNullOrWhiteSpace(request.Query))
+            request.Query = "SELECT * FROM c";
+        
         var response = await Client.SearchAsync(request, await BuildMetadataAsync(request));
         return response;
     }
@@ -43,13 +45,14 @@ public class WalletService : ServiceBase
     /// <summary>
     /// Search the wallet for records matching the specified criteria
     /// </summary>
-    /// <param name="query">The SQL query</param>
     /// <remarks>
     /// See https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-select
     /// </remarks>
     /// <returns></returns>
-    public SearchResponse Search(string query = "SELECT * FROM c") {
-        SearchRequest request = new() {Query = query};
+    public SearchResponse Search(SearchRequest request) {
+        if (String.IsNullOrWhiteSpace(request.Query))
+            request.Query = "SELECT * FROM c";
+        
         var response = Client.Search(request, BuildMetadata(request));
         return response;
     }


### PR DESCRIPTION
This relates to #479 . We should only expose `*Request` and `*Response` objects for everything to be consistent.