### PR TITLE
Update template.rs

### DIFF
--- a/cli/src/parser/template.rs
+++ b/cli/src/parser/template.rs
@@ -182,7 +182,7 @@ pub(crate) fn subcommand<'a, 'b>() -> App<'a, 'b> {
             SubCommand::with_name("create")
             .setting(AppSettings::ArgRequiredElseHelp)
             .about("Create new template")
-            .after_help("EXAMPLES:\r\n\ttrinsic template create --name 'My Credential' --fields-data '{\\"firstName\\":{}}'")
+            .after_help("EXAMPLES:\r\n\ttrinsic template create --name 'My Credential' --fields-data '{\"firstName\":{}}'")
             .arg(Arg::from_usage("-n --name <TEMPLATE_NAME> 'Sets the name of the template'").required(true))
             .arg(Arg::from_usage("--fields-data <JSON> 'Sets the fields of the template formatted as JSON'").required(false))
             .arg(Arg::from_usage("--fields-file <FILE> 'Sets the file containing fields JSON data'").required(false))

--- a/cli/src/parser/template.rs
+++ b/cli/src/parser/template.rs
@@ -182,7 +182,7 @@ pub(crate) fn subcommand<'a, 'b>() -> App<'a, 'b> {
             SubCommand::with_name("create")
             .setting(AppSettings::ArgRequiredElseHelp)
             .about("Create new template")
-            .after_help("EXAMPLES:\r\n\ttrinsic template create --name 'My Credential' --fields-data '{\\\"firstName\\\":{}}'")
+            .after_help("EXAMPLES:\r\n\ttrinsic template create --name 'My Credential' --fields-data '{\\"firstName\\":{}}'")
             .arg(Arg::from_usage("-n --name <TEMPLATE_NAME> 'Sets the name of the template'").required(true))
             .arg(Arg::from_usage("--fields-data <JSON> 'Sets the fields of the template formatted as JSON'").required(false))
             .arg(Arg::from_usage("--fields-file <FILE> 'Sets the file containing fields JSON data'").required(false))


### PR DESCRIPTION
When using the CLI, it tells me the example is:
EXAMPLES:
    trinsic template create --name 'My Credential' --fields-data '{\"firstName\":{}}'

Using that command directly gives me a "serialization error"

This fix removes the extra backslashes around firstName. The intent is to enable people to simply copy/paste the example command and have a successful call without getting a serialization error.

Loom: https://www.loom.com/share/105d602bcbca46208971dc4f98dc38a2