### PR TITLE
CLI config init panic fix on older config format

### DIFF
--- a/cli/src/services/config.rs
+++ b/cli/src/services/config.rs
@@ -95,7 +95,15 @@ impl CliConfig {
                 let mut buffer = String::new();
                 file.read_to_string(&mut buffer)?;
 
-                toml::from_str(&buffer)?
+                match toml::from_str(&buffer) {
+                    Ok(buffer) => buffer,
+                    Err(_) => {
+                        let config = CliConfig::default();
+                        config.save()?;
+
+                        config
+                    }
+                }
             }
             Err(_) => {
                 let config = CliConfig::default();


### PR DESCRIPTION
Adds a fix that allows the CLI to initiate correctly if a config file with older or invalid format is found