### PR TITLE
Update CLI winget instructions with FQNs

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -16,8 +16,8 @@ The Trinsic CLI makes it easy to interact with the Trinsic API from your termina
 === "Windows"
     The CLI can be installed using [Winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/)
     ```
-    winget install okapi
-    winget install trinsic
+    winget install trinsic.okapi
+    winget install trinsic.cli
     ```
 
 === "From source"


### PR DESCRIPTION
Executing `winget install trinsic` does not install Trinsic CLI due to naming conflicts with another package on `winget`.

This PR simply changes the `winget` install instructions to fully qualify the package names. While `okapi` doesn't conflict with any other names (and thus installs the `trinsic.okapi` package without complaint), it's best to be uniform and forward-thinking.