### PR TITLE
Docs cleanup

### DIFF
--- a/docs/ios/index.md
+++ b/docs/ios/index.md
@@ -2,10 +2,10 @@
 
 The Trinsic Swift SDK makes it easy to interact with the Trinsic API from any application built for iOS, MacCatalyst, or MacOS. The SDK is available for Swift Package Manager and can be added in your dependency section in `Package.swift` as follows:
 
- ```swift
- dependencies: [
-     .package(name: "Trinsic", url: "https://github.com/trinsic-id/sdk-swift", branch: "main")
- ],
+```swift
+dependencies: [
+    .package(name: "Trinsic", url: "https://github.com/trinsic-id/sdk-swift", branch: "main")
+],
 ```
 
  You can find more details, source code, and tests for the Swift SDK at [trinsic-id/sdk-swift](https://github.com/trinsic-id/sdk-swift).

--- a/docs/learn/templates.md
+++ b/docs/learn/templates.md
@@ -28,38 +28,38 @@ This an example of a list of attributes that would comprise a credential templat
 
 This will create a Template that has the following structure:
 ```
-    TemplateData {
-        id: "urn:template:alices-local-guides:review",
-        name: "Review",
-        version: 1,
-        fields: {
-            "name": TemplateField {
-                description: "Name of the business",
-                optional: false,
-                r#type: String,
-            },
-            "rating": TemplateField {
-                description: "rating on scale of 1-10",
-                optional: false,
-                r#type: Number,
-            },
-            "details": TemplateField {
-                description: "An individual's last name",
-                optional: false,
-                r#type: String,
-            },
-            "website": TemplateField {
-                description: "More information about the business",
-                optional: false,
-                r#type: String,
-            },
+TemplateData {
+    id: "urn:template:alices-local-guides:review",
+    name: "Review",
+    version: 1,
+    fields: {
+        "name": TemplateField {
+            description: "Name of the business",
+            optional: false,
+            r#type: String,
         },
-        allow_additional_fields: true,
-        schema_uri: "https://staging-schema.trinsic.cloud/__default/review",
-        context_uri: "https://staging-schema.trinsic.cloud/__default/review/context",
-        ecosystem_id: "__default",
-        r#type: "VerifiableCredential",
-    }
-    ```
+        "rating": TemplateField {
+            description: "rating on scale of 1-10",
+            optional: false,
+            r#type: Number,
+        },
+        "details": TemplateField {
+            description: "An individual's last name",
+            optional: false,
+            r#type: String,
+        },
+        "website": TemplateField {
+            description: "More information about the business",
+            optional: false,
+            r#type: String,
+        },
+    },
+    allow_additional_fields: true,
+    schema_uri: "https://staging-schema.trinsic.cloud/__default/review",
+    context_uri: "https://staging-schema.trinsic.cloud/__default/review/context",
+    ecosystem_id: "__default",
+    r#type: "VerifiableCredential",
+}
+```
 You can view the `schema_uri` and the `context_uri` in the browser as raw json
 

--- a/docs/reference/services/account-service.md
+++ b/docs/reference/services/account-service.md
@@ -12,30 +12,35 @@ will find how to instantiate the Account Service with default settings, by simpl
     ```typescript
     const accountService = new AccountService();
     ```
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:accountServiceConstructor
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/tests/test_trinsic_services.py) inside_block:accountServiceConstructor
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [CreateEcosystem](../../../go/services/account_service_test.go) inside_block:accountServiceConstructor
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [CreateEcosystem](../../../java/src/test/java/trinsic/AccountServiceTest.java) inside_block:accountServiceConstructor
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     ```ruby
     account_service = Trinsic::AccountService.new(nil, Trinsic::trinsic_prod_server)
@@ -68,34 +73,40 @@ And the [Account Details](../proto/#signinrequest) object should look like this:
     ```bash
     trinsic account login --email <PROFILE_EMAIL> --name <PROFILE_NAME>
     ```
+
 === "TypeScript"
     ```typescript
     const allison = (await accountService.signIn()).getProfile();
     ```
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:accountServiceSignIn
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/tests/test_trinsic_services.py) inside_block:accountServiceConstructor
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [CreateEcosystem](../../../go/services/account_service_test.go) inside_block:accountServiceSignIn
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [CreateEcosystem](../../../java/src/test/java/trinsic/AccountServiceTest.java) inside_block:accountServiceSignIn
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     ```ruby
     allison = account_service.sign_in(nil).profile
@@ -119,34 +130,40 @@ Calling this procedure, is as trivial as evidenced below. Keep it mind, however,
     ```bash
     trinsic account info
     ```
+
 === "TypeScript"
     ```typescript
     const info = await accountService.info();
     ```
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:accountServiceGetInfo
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/tests/test_trinsic_services.py) inside_block:accountServiceGetInfo
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [CreateEcosystem](../../../go/services/account_service_test.go) inside_block:getInfo
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [CreateEcosystem](../../../java/src/test/java/trinsic/AccountServiceTest.java) inside_block:getInfo
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     ```ruby
     info = account_service.get_info()
@@ -160,30 +177,35 @@ provide are evidenced in the code snippets below:
     ```typescript
     const protectedProfile = await accountService.protect(accountProfile, "1234");
     ```
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:protectUnprotectProfile
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/tests/test_trinsic_services.py) inside_block:protectUnprotectProfile
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [CreateEcosystem](../../../go/services/account_service_test.go) inside_block:protectUnprotectProfile
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [CreateEcosystem](../../../java/src/test/java/trinsic/AccountServiceTest.java) inside_block:protectUnprotectProfile
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     ```ruby
     protected_profile = account_service.protect(account_profile, '1234')
@@ -198,30 +220,35 @@ email or SMS as the `securityCode` argument.
     ```typescript
     const accountProfile = await accountService.unprotect(protectedProfile, "1234");
     ```
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:protectUnprotectProfile
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/tests/test_trinsic_services.py) inside_block:protectUnprotectProfile
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [CreateEcosystem](../../../go/services/account_service_test.go) inside_block:protectUnprotectProfile
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [CreateEcosystem](../../../java/src/test/java/trinsic/AccountServiceTest.java) inside_block:protectUnprotectProfile
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     ```ruby
     account_profile = account_service.unprotect(protected_profile, '1234')

--- a/docs/reference/services/credential-service.md
+++ b/docs/reference/services/credential-service.md
@@ -12,6 +12,7 @@ The Credential service supports signing data using [BBS+ Signatures <small>:mate
     ```bash
     trinsic issuer issue --document <INPUT_JSONLD_FILE> --out <OUTPUT_FILE>
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
@@ -39,12 +40,14 @@ The Credential service supports signing data using [BBS+ Signatures <small>:mate
     [VerifyProof](../../../go/services/services_test.go) inside_block:issueCredentialSample
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [CreateProof](../../../java/src/test/java/trinsic/VaccineDemo.java) inside_block:issueCredentialSample
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
@@ -60,6 +63,7 @@ The output of this method will be a signed JSON document using BBS+ Signature Su
     ```bash
     
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
@@ -87,12 +91,14 @@ The output of this method will be a signed JSON document using BBS+ Signature Su
     [Issue From Template](../../../go/services/credentialtemplate_service_test.go) inside_block:issueFromTemplate
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [IssueFromTemplate](../../../java/src/test/java/trinsic/TemplatesDemo.java) inside_block:issueFromTemplate
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
@@ -106,10 +112,12 @@ The output of this method will be a signed JSON document using BBS+ Signature Su
     ```bash
     
     ```
+
 === "TypeScript"
     ```typescript
     
     ```
+
 === "C#"
     <!--codeinclude-->
     ```csharp
@@ -130,12 +138,14 @@ The output of this method will be a signed JSON document using BBS+ Signature Su
     [Issue From Template](../../../go/services/credentialtemplate_service_test.go) inside_block:checkCredentialStatus
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [IssueFromTemplate](../../../java/src/test/java/trinsic/TemplatesDemo.java) inside_block:checkCredentialStatus
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     ```ruby
     
@@ -147,10 +157,12 @@ The output of this method will be a signed JSON document using BBS+ Signature Su
     ```bash
     
     ```
+
 === "TypeScript"
     ```typescript
     
     ```
+
 === "C#"
     <!--codeinclude-->
     ```csharp
@@ -171,12 +183,14 @@ The output of this method will be a signed JSON document using BBS+ Signature Su
     [Issue From Template](../../../go/services/credentialtemplate_service_test.go) inside_block:updateCredentialStatus
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [IssueFromTemplate](../../../java/src/test/java/trinsic/TemplatesDemo.java) inside_block:updateCredentialStatus
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     ```ruby
     
@@ -223,12 +237,14 @@ The endpoint to create a proof requires two inputs:
     [CreateProof](../../../go/services/services_test.go) inside_block:createProof
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [CreateProof](../../../java/src/test/java/trinsic/VaccineDemo.java) inside_block:createProof
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
@@ -244,6 +260,7 @@ This endpoint verifies if the submitted data contains a valid proof. The data to
     ```bash
     trinsic vc issuer verify-proof --proof-document <JSONLD_FILE>
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
@@ -271,12 +288,14 @@ This endpoint verifies if the submitted data contains a valid proof. The data to
     [VerifyProof](../../../go/services/services_test.go) inside_block:verifyProof
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [VerifyProof](../../../java/src/test/java/trinsic/VaccineDemo.java) inside_block:verifyProof
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
@@ -302,6 +321,7 @@ To send a document to another user, they must have created a wallet and [associa
     ```bash
     trinsic vc send --email <EMAIL_ADDRESS> --item <FILE>
     ```
+
 === "TypeScript"
 
     ```typescript
@@ -328,16 +348,19 @@ To send a document to another user, they must have created a wallet and [associa
     [Issue From Template](../../../go/services/services_test.go) inside_block:sendCredential
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [VerifyProof](../../../java/src/test/java/trinsic/VaccineDemo.java) inside_block:sendCredential
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     ```ruby
     
     ```
+
 === "Swift"
     ```swift
     

--- a/docs/reference/services/trust-registry-service.md
+++ b/docs/reference/services/trust-registry-service.md
@@ -23,42 +23,49 @@ An ecosystem governance framework is useful because it provides a good basis for
     ```bash
     trinsic trust-registry register-efg
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
     
     ```
     <!--/codeinclude-->
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:registerGovernanceFramework
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:registerGovernanceFramework
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [RegisterIssuer](../../../go/services/services_test.go) inside_block:registerGovernanceFramework
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [RegisterGovernanceFramework](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:registerGovernanceFramework
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
     
     ```
     <!--/codeinclude-->
+
 ### Register Issuers
 Each entity on the governance framework, whether an issuer or a verifier, is represented by a decentralized identifier. These entities are registered to either issue or verify specific credential types. A credential type is represented as a fully qualified `type` URI, of the kind found in a JSON-LD Verifiable Credential.
 Finally, each entity must be registered on a specific governance framework. 
@@ -70,42 +77,49 @@ Finally, each entity must be registered on a specific governance framework.
         --credential-type https://w3id.org/vaccination#VaccinationCertificate \
         --did did:example:fabre
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
     
     ```
     <!--/codeinclude-->
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:registerIssuer
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:registerIssuer
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [RegisterIssuer](../../../go/services/services_test.go) inside_block:registerIssuer
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [RegisterIssuer](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:registerIssuer
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
     
     ```
     <!--/codeinclude-->
+
 
 ### Register Verifiers
 
@@ -116,42 +130,49 @@ Finally, each entity must be registered on a specific governance framework.
         --credential-type https://w3id.org/vaccination#VaccinationCertificate \
         --did did:example:fabre
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
     
     ```
     <!--/codeinclude-->
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:registerVerifier
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:registerVerifier
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [RegisterIssuer](../../../go/services/services_test.go) inside_block:registerVerifier
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [RegisterIssuer](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:registerVerifier
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
     
     ```
     <!--/codeinclude-->
+
 
 ### Unregister Issuers
 To unregister an entity, include the credential type, the did, and the ecosystem governance framework. The credential type will be unregistered from that issuer.
@@ -163,42 +184,49 @@ To unregister an entity, include the credential type, the did, and the ecosystem
         --credential-type https://w3id.org/vaccination#VaccinationCertificate \
         --did did:example:fabre
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
     
     ```
     <!--/codeinclude-->
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:unregisterIssuer
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:unregisterIssuer
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [RegisterIssuer](../../../go/services/services_test.go) inside_block:unregisterIssuer
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [RegisterIssuer](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:unregisterIssuer
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
     
     ```
     <!--/codeinclude-->
+
 
 ### Unregister Verifiers
 To unregister an entity, include the credential type, the did, and the ecosystem governance framework. The credential type will be unregistered from that issuer.
@@ -210,42 +238,49 @@ To unregister an entity, include the credential type, the did, and the ecosystem
         --credential-type https://w3id.org/vaccination#VaccinationCertificate \
         --did did:example:fabre
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
     
     ```
     <!--/codeinclude-->
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:unregisterVerifier
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:unregisterVerifier
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [RegisterIssuer](../../../go/services/services_test.go) inside_block:unregisterVerifier
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [RegisterIssuer](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:unregisterVerifier
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
     
     ```
     <!--/codeinclude-->
+
 
 ### Check Issuer Status
 Check the status of an issuer for a credential type within a given governance framework. Returns all historical data for the given input parameter.
@@ -257,42 +292,49 @@ Check the status of an issuer for a credential type within a given governance fr
         --credential-type https://w3id.org/vaccination#VaccinationCertificate \
         --did did:example:fabre
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
     
     ```
     <!--/codeinclude-->
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:checkIssuerStatus
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:checkIssuerStatus
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [RegisterIssuer](../../../go/services/services_test.go) inside_block:checkIssuerStatus
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [RegisterIssuer](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:checkIssuerStatus
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
     
     ```
     <!--/codeinclude-->
+
 
 ### Check Verifier Status
 Check the status of an issuer for a credential type within a given governance framework. Returns all historical data for the given input parameter.
@@ -304,42 +346,49 @@ Check the status of an issuer for a credential type within a given governance fr
         --credential-type https://w3id.org/vaccination#VaccinationCertificate \
         --did did:example:fabre
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
     
     ```
     <!--/codeinclude-->
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:checkVerifierStatus
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:checkVerifierStatus
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [RegisterIssuer](../../../go/services/services_test.go) inside_block:checkVerifierStatus
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [RegisterIssuer](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:checkVerifierStatus
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
     
     ```
     <!--/codeinclude-->
+
 
 ### Search
 Search the registry for authoritative issuer and verifiers using a custom query in a SQL format.
@@ -348,42 +397,49 @@ Search the registry for authoritative issuer and verifiers using a custom query 
     ```bash
     trinsic trust-registry search --query <SQL query>
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
     
     ```
     <!--/codeinclude-->
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:searchTrustRegistry
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:searchTrustRegistry
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [RegisterIssuer](../../../go/services/services_test.go) inside_block:searchTrustRegistry
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [RegisterIssuer](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:searchTrustRegistry
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
     
     ```
     <!--/codeinclude-->
+
 
     
 ### Cache Offline Registry File

--- a/docs/reference/services/wallet-service.md
+++ b/docs/reference/services/wallet-service.md
@@ -16,36 +16,42 @@ This method allows inserting any JSON data in the wallet.
     ```bash
     trinsic wallet insert-item --item <INPUT_JSON_FILE>
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
     [VerifyProof](../../../node/test/WalletService.ts) inside_block:insertItemWallet
     ```
     <!--/codeinclude-->
+
 === "C#"
     <!--codeinclude-->
     ```csharp
     [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:insertItemWallet
     ```
     <!--/codeinclude-->
+
 === "Python"
     <!--codeinclude-->
     ```python
     [Insert Item Wallet](../../../python/samples/vaccine_demo.py) inside_block:insertItemWallet
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [RegisterIssuer](../../../go/services/services_test.go) inside_block:insertItemWallet
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [RegisterIssuer](../../../java/src/test/java/trinsic/VaccineDemo.java) inside_block:insertItemWallet
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
@@ -70,6 +76,7 @@ The default query used in the commands below returns a full wallet result set. T
     ```bash
     trinsic wallet search
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
@@ -90,18 +97,21 @@ The default query used in the commands below returns a full wallet result set. T
     [Insert Item Wallet](../../../python/samples/vaccine_demo.py) inside_block:searchWallet
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [RegisterIssuer](../../../go/services/services_test.go) inside_block:searchWallet
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [RegisterIssuer](../../../java/src/test/java/trinsic/VaccineDemo.java) inside_block:searchWallet
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby
@@ -118,6 +128,7 @@ To pass custom query to the search function, use the query parameter or the avai
     trinsic wallet search \
         --query "SELECT * FROM c WHERE c.type = 'VerifiableCredential'"
     ```
+
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
@@ -138,18 +149,21 @@ To pass custom query to the search function, use the query parameter or the avai
     [Insert Item Wallet](../../../python/samples/vaccine_demo.py) inside_block:searchWalletSQL
     ```
     <!--/codeinclude-->
+
 === "Go"
     <!--codeinclude-->
     ```golang
     [RegisterIssuer](../../../go/services/services_test.go) inside_block:searchWalletSQL
     ```
     <!--/codeinclude-->
+
 === "Java"
     <!--codeinclude-->
     ```java
     [RegisterIssuer](../../../java/src/test/java/trinsic/VaccineDemo.java) inside_block:searchWalletSQL
     ```
     <!--/codeinclude-->
+
 === "Ruby"
     <!--codeinclude-->
     ```ruby

--- a/docs/walkthroughs/vaccination.md
+++ b/docs/walkthroughs/vaccination.md
@@ -243,7 +243,7 @@ If you would like to save the profile for future use, you can simply export the 
 
 === "Python"
 
-=== "Java" -->
+=== "Java"
 
 ## Issue a Credential
 Upon receiving her vaccine, Allison also receives a digital certificate from the clinic. This certificate is digitally signed by the clinic, acting as an issuer.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
     - Account Service: reference/services/account-service.md
     - Wallet Service: reference/services/wallet-service.md
     - Credential Service: reference/services/credential-service.md
+    - Template Service: reference/services/template-service.md
     - Provider Service: reference/services/provider-service.md
     - Trust Registry Service: reference/services/trust-registry-service.md
     - Protocol Buffers: reference/proto/index.md


### PR DESCRIPTION
- Add template service to navigation
- Fix template structure display in `learn/templates.md`
- Fix Swift SDK dependency code markdown
- Fix all code tabs in SDK reference
  - Due to the `codeinclude` tags, an extra newline must be added before all tab-initializing markdown to prevent glitchy behavior.
- Fix Java tab display in vaccination walkthrough