### PR TITLE
Improve protobuf markdown tables

### DIFF
--- a/devops/README.md
+++ b/devops/README.md
@@ -1,0 +1,40 @@
+# Trinsic SDK DevOps
+
+This folder contains automation scripts for the Trinsic SDK. These are mainly useful for maintainers of the SDK -- if you're not a maintainer, you likely won't find much value here.
+
+
+
+## `build_sdks.py`
+
+Builds the SDK packages for release in each language.
+
+### Setup
+
+`pip install -r requirements.txt`
+
+### Usage
+
+TODO: document usage
+
+
+
+
+## `generate_proto_files.py`
+
+Compiles the Trinsic API protobuf files for each SDK language.
+
+Additionally, this script generates the markdown documentation file which outlines each service and message. This uses the `resources/markdown.tmpl` template.
+
+
+### Setup
+
+- Install pip packages
+  - `pip install -r requirements.txt`
+- Install [protoc](https://developers.google.com/protocol-buffers/docs/downloads). It must be accessible as `protoc` on your PATH.
+- Install [protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc). It must also be accessible on your PATH.
+  - Simplest method, if you don't have `go` installed, is to simply download the precompiled binary from the Releases in the GitHub repository.
+
+
+### Usage
+
+`python generate_proto_files.py`

--- a/devops/generate_proto_files.py
+++ b/devops/generate_proto_files.py
@@ -8,7 +8,7 @@ import os
 import sys
 from platform import system
 import urllib.request
-from os.path import abspath, join, dirname
+from os.path import abspath, relpath, join, dirname
 from typing import List, Dict, Union
 
 
@@ -26,6 +26,16 @@ def protoc_plugin_versions(key: str = None) -> Union[str, Dict[str, str]]:
 def plugin_path() -> str:
     return abspath(join(dirname(__file__), 'protoc-plugins'))
 
+
+def md_template_path() -> str:
+    """
+    Returns the relative path (from the current working directory) to the markdown template file
+
+    We're forced to return the relative -- instead of absolute -- path, because 
+    passing in an absolute path on Windows causes `protoc-gen-markdown` to explode.
+    """
+
+    return relpath(abspath(join(dirname(__file__), 'resources/markdown.tmpl')))
 
 def java_plugin() -> str:
     return abspath(join(plugin_path(), 'protoc-gen-grpc-java.exe'))
@@ -152,7 +162,9 @@ def update_java():
 def update_markdown():
     lang_path = get_language_dir('docs')
     lang_proto_path = join(lang_path, 'reference', 'proto')
-    run_protoc({'doc_out': lang_proto_path}, {'doc_opt': 'markdown,index.md'}, get_proto_files())
+    template_path = md_template_path()
+    
+    run_protoc({'doc_out': lang_proto_path}, {'doc_opt': f"{template_path},index.md"}, get_proto_files())
 
 
 def update_python():

--- a/devops/resources/markdown.tmpl
+++ b/devops/resources/markdown.tmpl
@@ -1,0 +1,106 @@
+# Protocol Documentation
+<a name="top"></a>
+
+This page documents the Protobuf Services and Messages which compose the Trinsic API.
+
+## Table of Contents
+{{range .Files}}
+{{$file_name := .Name}}- [{{.Name}}](#{{.Name | anchor}})
+  {{- if .Messages }}
+  {{range .Messages}}  - [{{.LongName}}](#{{.FullName | anchor}})
+  {{end}}
+  {{- end -}}
+  {{- if .Enums }}
+  {{range .Enums}}  - [{{.LongName}}](#{{.FullName | anchor}})
+  {{end}}
+  {{- end -}}
+  {{- if .Extensions }}
+  {{range .Extensions}}  - [File-level Extensions](#{{$file_name | anchor}}-extensions)
+  {{end}}
+  {{- end -}}
+  {{- if .Services }}
+  {{range .Services}}  - [{{.Name}}](#{{.FullName | anchor}})
+  {{end}}
+  {{- end -}}
+{{end}}
+- [Scalar Value Types](#scalar-value-types)
+
+{{range .Files}}
+{{$file_name := .Name}}
+<a name="{{.Name | anchor}}"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## {{.Name}}
+{{.Description}}
+
+{{range .Messages}}
+<a name="{{.FullName | anchor}}"></a>
+
+### {{.LongName}}
+{{.Description}}
+
+{{if .HasFields}}
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+{{range .Fields -}}
+  | {{.Name}} | [{{.LongType}}](#{{.FullType | anchor}}){{if eq .Label "repeated"}}[]{{end}} | {{if (index .Options "deprecated"|default false)}}**Deprecated.** {{end}}{{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+{{end}}
+{{end}}
+
+{{if .HasExtensions}}
+| Extension | Type | Base | Number | Description |
+| --------- | ---- | ---- | ------ | ----------- |
+{{range .Extensions -}}
+  | {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+{{end}}
+{{end}}
+
+{{end}} <!-- end messages -->
+
+{{range .Enums}}
+<a name="{{.FullName | anchor}}"></a>
+
+### {{.LongName}}
+{{.Description}}
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+{{range .Values -}}
+  | {{.Name}} | {{.Number}} | {{nobr .Description}} |
+{{end}}
+
+{{end}} <!-- end enums -->
+
+{{if .HasExtensions}}
+<a name="{{$file_name | anchor}}-extensions"></a>
+
+### File-level Extensions
+| Extension | Type | Base | Number | Description |
+| --------- | ---- | ---- | ------ | ----------- |
+{{range .Extensions -}}
+  | {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{nobr .Description}}{{if .DefaultValue}} Default: `{{.DefaultValue}}`{{end}} |
+{{end}}
+{{end}} <!-- end HasExtensions -->
+
+{{range .Services}}
+<a name="{{.FullName | anchor}}"></a>
+
+### {{.Name}}
+{{.Description}}
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+{{range .Methods -}}
+  | {{.Name}} | [{{.RequestLongType}}](#{{.RequestFullType | anchor}}){{if .RequestStreaming}} stream{{end}} | [{{.ResponseLongType}}](#{{.ResponseFullType | anchor}}){{if .ResponseStreaming}} stream{{end}} | {{nobr .Description}} |
+{{end}}
+{{end}} <!-- end services -->
+
+{{end}}
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby |
+| ----------- | ----- | --- | ---- | ------ | -- | -- | --- | ---- |
+{{range .Scalars -}}
+  | <a name="{{.ProtoType | anchor}}" /> {{.ProtoType}} | {{.Notes}} | {{.CppType}} | {{.JavaType}} | {{.PythonType}} | {{.GoType}} | {{.CSharp}} | {{.PhpType}} | {{.RubyType}} |
+{{end}}


### PR DESCRIPTION
Presently, the documentation for our Protobuf messages and services is auto-generated using the default `protoc-gen-doc` markdown template, which includes a `Label` column for every Message.

This `Label` column can have a value of `optional`, `required`, or `repeated`. In our codebase, we only use the `repeated` label. Because of this, we are wasting a _lot_ of horizontal space for this column. 

Because these tables are being included in other areas of our documentation (for example, the `Account Service` page), it creates a very ugly look.

[Image of problem](https://user-images.githubusercontent.com/1294419/164039982-661e4af0-6274-4890-b9c4-ef061066cd69.png)



This PR introduces a custom template which removes this column, and instead appends `[]` to the type of any message field which is `repeated`.

Additionally, I have added a `README.md` to the `devops/` folder in the process of making this change.



[Before 1](https://user-images.githubusercontent.com/1294419/164040854-2deee6c7-f60d-49ff-8de1-e6c9503e905e.png) | [After 1](https://user-images.githubusercontent.com/1294419/164040942-8f78024e-8fee-4547-9bde-a241a9fba029.png)

[Before 2](https://user-images.githubusercontent.com/1294419/164041039-ed7468e5-2312-4338-bf43-d9dc3df5d908.png) | [After 2](https://user-images.githubusercontent.com/1294419/164041131-4a822d34-aec7-45a0-b664-0aa4c7c1ae24.png)





