### PR TITLE
Macro for Protobuf Message injection in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,34 @@ The docs are easy to edit. Find the `nav` tag in [./mkdocs.yml](.mkdocs.yml) fil
 
 Write markdown in the `docs` folder. You can use normal markdown, html, or any of our theme's features - [Reference](https://squidfunk.github.io/mkdocs-material-insiders/reference/abbreviations/)
 
+### Trinsic-specific Macros
+
+To make editing docs easier to work on (and more powerful), we make use of a few macros that we've developed -- the source for these lives in the `mkdocs_macros_main.py` file in the root of this repository.
+
+#### `include_section`
+
+This macro includes a section from another markdown file.
+
+Usage: `{{ include_section(file_name: str, section_name: str, include_heading: bool=False) }}`
+
+- `file_name` is the path, _relative to the docs root_, of the markdown file you wish to include a section from
+- `section_name` is the name of the section you wish to include
+- `include_heading` controls whether or not to include the heading itself
+
+#### `proto_obj`
+
+This macro allows you to inject the documentation for any protobuf message or service that is documented in `reference/proto/index.md`.
+
+Usage: `{{ proto_obj(obj: str, header_text: str=None) }}`
+
+- `obj` is the name of the protobuf message or service
+    - For example, `ServiceOptions`
+- `header_text`, if specified, overrides the text of the header with whatever you specify
+    - If unspecified, the name of the message is used (same as the value of `obj`)
+
+
+Example: `{{ proto_obj('SignInRequest') }}`
+
 ### Build and deploy
 
 When finished editing, just make a PR.

--- a/docs/_static/extra.css
+++ b/docs/_static/extra.css
@@ -26,3 +26,34 @@ h1, h2, h3 {
     width: auto;
     height: 1.8rem;
 }
+
+
+/***********************************************************
+ * Protobuf Object Inclusion Macro Styles  ( proto_obj() )
+ ***********************************************************/
+
+.proto-obj-container {
+    padding-left: 0.5rem;
+    border-left: 4px solid #3498db;
+}
+
+/* Name of protobuf object */
+.proto-obj-header {
+    font-feature-settings: "kern";
+    font-family: var(--md-code-font-family);
+}
+
+/* Remove dangling <p> block in proto-obj-header */
+.proto-obj-header p {
+    display: none;
+}
+
+/* Remove "Top" link that is erroneously included with some protobuf object injections */
+.proto-obj-contents a[href="#top"] {
+    display: none;
+}
+
+/* Prefix text before protobuf message table */
+.proto-obj-contents p {
+    font-size: 0.6rem;
+}

--- a/docs/reference/services/account-service.md
+++ b/docs/reference/services/account-service.md
@@ -49,7 +49,7 @@ will find how to instantiate the Account Service with default settings, by simpl
 The constructor also accepts an `options` object as an argument. It follows the same structure of [ServiceOptions](../proto/index.md#serviceoptions), with the following
 properties:
 
-{{ include_section('reference/proto/', 'ServiceOptions') }}
+{{ proto_obj('ServiceOptions') }}
 
 The exact structure of such object will depend on the language you are working with. You can always rely on your editor's intellisense when in doubt. 
 
@@ -61,11 +61,11 @@ and an SMS phone number. You may also provide an invitation code and ecosystem I
 
 The sign in request should look like this:
 
-{{ include_section('reference/proto/', 'SignInRequest') }}
+{{ proto_obj('SignInRequest') }}
 
 And the [Account Details](../proto/#signinrequest) object should look like this:
 
-{{ include_section('reference/proto/', 'AccountDetails') }}
+{{ proto_obj('AccountDetails') }}
 
 
 
@@ -115,14 +115,14 @@ And the [Account Details](../proto/#signinrequest) object should look like this:
 This operation produces a response that has the structure of a [Sign In Response](../proto/#signinresponse), indicating whether or not a confirmation code
 was sent to one of the users two-factor methods like email, SMS, etc. (as defined by the Sign In Request).
 
-{{ include_section('reference/proto/', 'SignInResponse') }}
+{{ proto_obj('SignInResponse') }}
 
 ### Get Account Info
 This will returns the account info of the current active profile in the SDK or CLI. This can only be called on a profile that has been 
 [unprotected](./account-service.md/#unprotect-account-profile) by providing a code that was sent through email or SMS when the account was 
 signed in. Its response is a [Info Response](../proto/index.md#inforesponse) object and has the following properties:
 
-{{ include_section('reference/proto/', 'InfoResponse') }}
+{{ proto_obj('InfoResponse') }}
 
 Calling this procedure, is as trivial as evidenced below. Keep it mind, however, that it assumes you have the correct profile active.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ markdown_extensions:
   - def_list
   - admonition
   - pymdownx.details
+  - markdown.extensions.md_in_html
   - toc:
       permalink: true
       toc_depth: 3

--- a/mkdocs_macros_main.py
+++ b/mkdocs_macros_main.py
@@ -1,5 +1,5 @@
 """
-Import a subsection of another markdown file
+Macros created by Trinsic for documentation site
 """
 
 from requests import head
@@ -10,6 +10,9 @@ def define_env(env):
     
     @env.macro
     def include_section(file_name: str, section_name: str, include_heading: bool=False):
+        """
+        Import a subsection of another markdown file
+        """
         pages = env.variables['navigation'].pages
         reference_page = [page for page in pages if page.url == file_name][0]
         markdown_lines = reference_page.markdown.split('\n')
@@ -26,3 +29,21 @@ def define_env(env):
                 return "\n".join(markdown_lines[index:next_index])
                 
         return f"TODO: Include {file_name}#{section_name} {'with' if include_heading else 'without'} heading"
+    
+    @env.macro
+    def proto_obj(obj: str, header_text: str=None):
+        """
+        Inject documentation for specified protobuf message
+        """
+
+        if header_text is None:
+            header_text = obj
+
+        section_contents = include_section('reference/proto/', obj)
+
+        return (
+            "<div class='proto-obj-container' markdown>"
+                f"<div class='proto-obj-header' markdown>[{header_text}](/reference/proto#{obj.lower()})</div>"
+                f"<div class='proto-obj-contents' markdown>{section_contents}</div>"
+            "</div>"
+        )


### PR DESCRIPTION
Currently, to include documentation for a protobuf message in a page, the following syntax must be used:

`{{ include_section('reference/proto/', 'ServiceOptions') }}`

Which produces the following result:

<img src="https://user-images.githubusercontent.com/1294419/164090009-f3fe79fc-3c08-46de-b974-945970300766.png" width=500/>



This PR introduces a new macro, `proto_obj()`, which can be used to quickly inject documentation for any Protobuf message. Its usage is as such:

`{{ proto_obj('ServiceOptions') }}`

Which produces the following result:

<img src="https://user-images.githubusercontent.com/1294419/164090426-f4c599a6-5d81-4060-8c45-78af2d603ed8.png" width=500/>



This has the following benefits:

- Simpler to include a protobuf object; they are treated as a first-class citizen
- Automatically includes a link to the object definition on the protobuf documentation page
- Packages the object's name, its description, and its fields into a visually parseable block, clearly separated from the rest of the page's contents
- Produces HTML that can easily be styled by us later on
- Removes annoying "Top" link that is injected from the protobuf documentation page (which doesn't really belong in pages it's injected into)