### PR TITLE
[sc-9197] sdk/go: added ability to configure client-side middleware

### DIFF
--- a/go/services/service_base.go
+++ b/go/services/service_base.go
@@ -17,7 +17,7 @@ import (
 // NewServiceBase returns a base service which is the foundation
 // for all the other services
 func NewServiceBase(options *Options) (Service, error) {
-	conn, err := NewServiceConnection(options.ServiceOptions)
+	conn, err := NewServiceConnection(options.ServiceOptions, options.GrpcDialOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (s *serviceBase) BuildMetadata(message proto.Message) (metadata.MD, error) 
 
 // NewServiceConnection returns a grpc client connection to the target
 // provided in the options (ServerEndpoint, ServerPort, and ServerUseTLS)
-func NewServiceConnection(options *sdk.ServiceOptions) (*grpc.ClientConn, error) {
+func NewServiceConnection(options *sdk.ServiceOptions, grpcDialOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
 	var dialOptions []grpc.DialOption
 
 	if !options.ServerUseTls {
@@ -139,6 +139,10 @@ func NewServiceConnection(options *sdk.ServiceOptions) (*grpc.ClientConn, error)
 		}
 		creds := credentials.NewClientTLSFromCert(rootCAs, "")
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(creds))
+	}
+
+	for _, dialOption := range grpcDialOptions {
+		dialOptions = append(dialOptions, dialOption)
 	}
 
 	return grpc.Dial(fmt.Sprintf("%s:%d", options.ServerEndpoint, options.ServerPort), dialOptions...)

--- a/go/services/services.go
+++ b/go/services/services.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 
 	sdk "github.com/trinsic-id/sdk/go/proto"
+	"google.golang.org/grpc"
 )
 
 //Options for configuring the sdk
 type Options struct {
-	ServiceOptions *sdk.ServiceOptions
+	ServiceOptions  *sdk.ServiceOptions
+	GrpcDialOptions []grpc.DialOption
 }
 
 // NewServiceOptions returns a service options configuration with the provided options set
@@ -42,6 +44,18 @@ type Option func(*Options) error
 func WithAuthToken(token string) Option {
 	return func(s *Options) error {
 		s.ServiceOptions.AuthToken = token
+
+		return nil
+	}
+}
+
+// WithGrpcDialOptions sets grpc dial options
+//
+// This function can be user for setting up client-side middlewares (i.e. monitoring, logging, tracing, retry)
+func WithGrpcDialOptions(grpcDialOptions []grpc.DialOption) Option {
+	return func(s *Options) error {
+		s.GrpcDialOptions = make([]grpc.DialOption, len(grpcDialOptions))
+		copy(s.GrpcDialOptions, grpcDialOptions)
 
 		return nil
 	}

--- a/go/services/services.go
+++ b/go/services/services.go
@@ -52,7 +52,7 @@ func WithAuthToken(token string) Option {
 // WithGrpcDialOptions sets grpc dial options
 //
 // This function can be user for setting up client-side middlewares (i.e. monitoring, logging, tracing, retry)
-func WithGrpcDialOptions(grpcDialOptions []grpc.DialOption) Option {
+func WithGrpcDialOptions(grpcDialOptions ...grpc.DialOption) Option {
 	return func(s *Options) error {
 		s.GrpcDialOptions = make([]grpc.DialOption, len(grpcDialOptions))
 		copy(s.GrpcDialOptions, grpcDialOptions)


### PR DESCRIPTION
Added ability to configure middlewares for go grpc client. 
This will enable sdk consumers to configure monitoring, logging, tracing or other [grpc middlewares](https://github.com/grpc-ecosystem/go-grpc-middleware).