### PR TITLE
Update protoc markdown template

### DIFF
--- a/devops/resources/markdown.tmpl
+++ b/devops/resources/markdown.tmpl
@@ -1,29 +1,10 @@
+{{/* Set URL base for embedded links to types, so that they can be resolved correctly when this generated markdown is injected into other pages */}}
+{{$url_base := "/reference/proto"}}
+
 # Protocol Documentation
 <a name="top"></a>
 
 This page documents the Protobuf Services and Messages which compose the Trinsic API.
-
-## Table of Contents
-{{range .Files}}
-{{$file_name := .Name}}- [{{.Name}}](#{{.Name | anchor}})
-  {{- if .Messages }}
-  {{range .Messages}}  - [{{.LongName}}](#{{.FullName | anchor}})
-  {{end}}
-  {{- end -}}
-  {{- if .Enums }}
-  {{range .Enums}}  - [{{.LongName}}](#{{.FullName | anchor}})
-  {{end}}
-  {{- end -}}
-  {{- if .Extensions }}
-  {{range .Extensions}}  - [File-level Extensions](#{{$file_name | anchor}}-extensions)
-  {{end}}
-  {{- end -}}
-  {{- if .Services }}
-  {{range .Services}}  - [{{.Name}}](#{{.FullName | anchor}})
-  {{end}}
-  {{- end -}}
-{{end}}
-- [Scalar Value Types](#scalar-value-types)
 
 {{range .Files}}
 {{$file_name := .Name}}
@@ -32,6 +13,19 @@ This page documents the Protobuf Services and Messages which compose the Trinsic
 
 ## {{.Name}}
 {{.Description}}
+
+{{range .Services}}
+<a name="{{.FullName | anchor}}"></a>
+
+### Service - {{.Name}}
+{{.Description}}
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+{{range .Methods -}}
+  | {{.Name}} | [{{.RequestLongType}}]({{$url_base}}#{{.RequestFullType | anchor}}){{if .RequestStreaming}} stream{{end}} | [{{.ResponseLongType}}]({{$url_base}}#{{.ResponseFullType | anchor}}){{if .ResponseStreaming}} stream{{end}} | {{nobr .Description}} |
+{{end}}
+{{end}} <!-- end services -->
 
 {{range .Messages}}
 <a name="{{.FullName | anchor}}"></a>
@@ -43,7 +37,7 @@ This page documents the Protobuf Services and Messages which compose the Trinsic
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 {{range .Fields -}}
-  | {{.Name}} | [{{.LongType}}](#{{.FullType | anchor}}){{if eq .Label "repeated"}}[]{{end}} | {{if (index .Options "deprecated"|default false)}}**Deprecated.** {{end}}{{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+  | {{.Name}} | [{{.LongType}}]({{$url_base}}#{{.FullType | anchor}}){{if eq .Label "repeated"}}[]{{end}} | {{if (index .Options "deprecated"|default false)}}**Deprecated.** {{end}}{{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
 {{end}}
 {{end}}
 
@@ -81,19 +75,6 @@ This page documents the Protobuf Services and Messages which compose the Trinsic
   | {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{nobr .Description}}{{if .DefaultValue}} Default: `{{.DefaultValue}}`{{end}} |
 {{end}}
 {{end}} <!-- end HasExtensions -->
-
-{{range .Services}}
-<a name="{{.FullName | anchor}}"></a>
-
-### {{.Name}}
-{{.Description}}
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-{{range .Methods -}}
-  | {{.Name}} | [{{.RequestLongType}}](#{{.RequestFullType | anchor}}){{if .RequestStreaming}} stream{{end}} | [{{.ResponseLongType}}](#{{.ResponseFullType | anchor}}){{if .ResponseStreaming}} stream{{end}} | {{nobr .Description}} |
-{{end}}
-{{end}} <!-- end services -->
 
 {{end}}
 

--- a/docs/reference/proto/index.md
+++ b/docs/reference/proto/index.md
@@ -1,268 +1,127 @@
+
+
+
 # Protocol Documentation
 <a name="top"></a>
 
-## Table of Contents
-
-- [pbmse/v1/pbmse.proto](#pbmse/v1/pbmse.proto)
-    - [EncryptedMessage](#pbmse.v1.EncryptedMessage)
-    - [EncryptionHeader](#pbmse.v1.EncryptionHeader)
-    - [EncryptionRecipient](#pbmse.v1.EncryptionRecipient)
-    - [Signature](#pbmse.v1.Signature)
-    - [SignatureHeader](#pbmse.v1.SignatureHeader)
-    - [SignedMessage](#pbmse.v1.SignedMessage)
-  
-    - [EncryptionAlgorithm](#pbmse.v1.EncryptionAlgorithm)
-    - [EncryptionMode](#pbmse.v1.EncryptionMode)
-  
-- [sdk/options/v1/options.proto](#sdk/options/v1/options.proto)
-    - [ServiceOptions](#sdk.options.v1.ServiceOptions)
-  
-- [services/account/v1/account.proto](#services/account/v1/account.proto)
-    - [AccountDetails](#services.account.v1.AccountDetails)
-    - [AccountEcosystem](#services.account.v1.AccountEcosystem)
-    - [AccountProfile](#services.account.v1.AccountProfile)
-    - [InfoRequest](#services.account.v1.InfoRequest)
-    - [InfoResponse](#services.account.v1.InfoResponse)
-    - [ListDevicesRequest](#services.account.v1.ListDevicesRequest)
-    - [ListDevicesResponse](#services.account.v1.ListDevicesResponse)
-    - [RevokeDeviceRequest](#services.account.v1.RevokeDeviceRequest)
-    - [RevokeDeviceResponse](#services.account.v1.RevokeDeviceResponse)
-    - [SignInRequest](#services.account.v1.SignInRequest)
-    - [SignInResponse](#services.account.v1.SignInResponse)
-    - [TokenProtection](#services.account.v1.TokenProtection)
-  
-    - [ConfirmationMethod](#services.account.v1.ConfirmationMethod)
-  
-    - [Account](#services.account.v1.Account)
-  
-- [services/common/v1/common.proto](#services/common/v1/common.proto)
-    - [Nonce](#services.common.v1.Nonce)
-    - [ServerConfig](#services.common.v1.ServerConfig)
-  
-    - [ResponseStatus](#services.common.v1.ResponseStatus)
-  
-    - [Common](#services.common.v1.Common)
-  
-- [services/debug/v1/debug.proto](#services/debug/v1/debug.proto)
-    - [Debugging](#services.debug.v1.Debugging)
-  
-- [services/provider/v1/provider.proto](#services/provider/v1/provider.proto)
-    - [CreateEcosystemRequest](#services.provider.v1.CreateEcosystemRequest)
-    - [CreateEcosystemResponse](#services.provider.v1.CreateEcosystemResponse)
-    - [Ecosystem](#services.provider.v1.Ecosystem)
-    - [GenerateTokenRequest](#services.provider.v1.GenerateTokenRequest)
-    - [GenerateTokenResponse](#services.provider.v1.GenerateTokenResponse)
-    - [InvitationStatusRequest](#services.provider.v1.InvitationStatusRequest)
-    - [InvitationStatusResponse](#services.provider.v1.InvitationStatusResponse)
-    - [Invite](#services.provider.v1.Invite)
-    - [InviteRequest](#services.provider.v1.InviteRequest)
-    - [InviteRequest.DidCommInvitation](#services.provider.v1.InviteRequest.DidCommInvitation)
-    - [InviteResponse](#services.provider.v1.InviteResponse)
-  
-    - [InvitationStatusResponse.Status](#services.provider.v1.InvitationStatusResponse.Status)
-    - [ParticipantType](#services.provider.v1.ParticipantType)
-  
-    - [Provider](#services.provider.v1.Provider)
-  
-- [services/trust-registry/v1/trust-registry.proto](#services/trust-registry/v1/trust-registry.proto)
-    - [AddFrameworkRequest](#services.trustregistry.v1.AddFrameworkRequest)
-    - [AddFrameworkResponse](#services.trustregistry.v1.AddFrameworkResponse)
-    - [CheckIssuerStatusRequest](#services.trustregistry.v1.CheckIssuerStatusRequest)
-    - [CheckIssuerStatusResponse](#services.trustregistry.v1.CheckIssuerStatusResponse)
-    - [CheckVerifierStatusRequest](#services.trustregistry.v1.CheckVerifierStatusRequest)
-    - [CheckVerifierStatusResponse](#services.trustregistry.v1.CheckVerifierStatusResponse)
-    - [FetchDataRequest](#services.trustregistry.v1.FetchDataRequest)
-    - [FetchDataResponse](#services.trustregistry.v1.FetchDataResponse)
-    - [GovernanceFramework](#services.trustregistry.v1.GovernanceFramework)
-    - [RegisterIssuerRequest](#services.trustregistry.v1.RegisterIssuerRequest)
-    - [RegisterIssuerResponse](#services.trustregistry.v1.RegisterIssuerResponse)
-    - [RegisterVerifierRequest](#services.trustregistry.v1.RegisterVerifierRequest)
-    - [RegisterVerifierResponse](#services.trustregistry.v1.RegisterVerifierResponse)
-    - [RemoveFrameworkRequest](#services.trustregistry.v1.RemoveFrameworkRequest)
-    - [RemoveFrameworkResponse](#services.trustregistry.v1.RemoveFrameworkResponse)
-    - [SearchRegistryRequest](#services.trustregistry.v1.SearchRegistryRequest)
-    - [SearchRegistryResponse](#services.trustregistry.v1.SearchRegistryResponse)
-    - [UnregisterIssuerRequest](#services.trustregistry.v1.UnregisterIssuerRequest)
-    - [UnregisterIssuerResponse](#services.trustregistry.v1.UnregisterIssuerResponse)
-    - [UnregisterVerifierRequest](#services.trustregistry.v1.UnregisterVerifierRequest)
-    - [UnregisterVerifierResponse](#services.trustregistry.v1.UnregisterVerifierResponse)
-  
-    - [RegistrationStatus](#services.trustregistry.v1.RegistrationStatus)
-  
-    - [TrustRegistry](#services.trustregistry.v1.TrustRegistry)
-  
-- [services/universal-wallet/v1/universal-wallet.proto](#services/universal-wallet/v1/universal-wallet.proto)
-    - [DeleteItemRequest](#services.universalwallet.v1.DeleteItemRequest)
-    - [DeleteItemResponse](#services.universalwallet.v1.DeleteItemResponse)
-    - [GetItemRequest](#services.universalwallet.v1.GetItemRequest)
-    - [GetItemResponse](#services.universalwallet.v1.GetItemResponse)
-    - [InsertItemRequest](#services.universalwallet.v1.InsertItemRequest)
-    - [InsertItemResponse](#services.universalwallet.v1.InsertItemResponse)
-    - [SearchRequest](#services.universalwallet.v1.SearchRequest)
-    - [SearchResponse](#services.universalwallet.v1.SearchResponse)
-    - [UpdateItemRequest](#services.universalwallet.v1.UpdateItemRequest)
-    - [UpdateItemResponse](#services.universalwallet.v1.UpdateItemResponse)
-  
-    - [UniversalWallet](#services.universalwallet.v1.UniversalWallet)
-  
-- [services/verifiable-credentials/templates/v1/templates.proto](#services/verifiable-credentials/templates/v1/templates.proto)
-    - [CreateCredentialTemplateRequest](#services.verifiablecredentials.templates.v1.CreateCredentialTemplateRequest)
-    - [CreateCredentialTemplateRequest.FieldsEntry](#services.verifiablecredentials.templates.v1.CreateCredentialTemplateRequest.FieldsEntry)
-    - [CreateCredentialTemplateResponse](#services.verifiablecredentials.templates.v1.CreateCredentialTemplateResponse)
-    - [DeleteCredentialTemplateRequest](#services.verifiablecredentials.templates.v1.DeleteCredentialTemplateRequest)
-    - [DeleteCredentialTemplateResponse](#services.verifiablecredentials.templates.v1.DeleteCredentialTemplateResponse)
-    - [GetCredentialTemplateRequest](#services.verifiablecredentials.templates.v1.GetCredentialTemplateRequest)
-    - [GetCredentialTemplateResponse](#services.verifiablecredentials.templates.v1.GetCredentialTemplateResponse)
-    - [GetTemplateRequest](#services.verifiablecredentials.templates.v1.GetTemplateRequest)
-    - [GetTemplateResponse](#services.verifiablecredentials.templates.v1.GetTemplateResponse)
-    - [ListCredentialTemplatesRequest](#services.verifiablecredentials.templates.v1.ListCredentialTemplatesRequest)
-    - [ListCredentialTemplatesResponse](#services.verifiablecredentials.templates.v1.ListCredentialTemplatesResponse)
-    - [ListTemplatesRequest](#services.verifiablecredentials.templates.v1.ListTemplatesRequest)
-    - [ListTemplatesResponse](#services.verifiablecredentials.templates.v1.ListTemplatesResponse)
-    - [SearchCredentialTemplatesRequest](#services.verifiablecredentials.templates.v1.SearchCredentialTemplatesRequest)
-    - [SearchCredentialTemplatesResponse](#services.verifiablecredentials.templates.v1.SearchCredentialTemplatesResponse)
-    - [TemplateData](#services.verifiablecredentials.templates.v1.TemplateData)
-    - [TemplateData.FieldsEntry](#services.verifiablecredentials.templates.v1.TemplateData.FieldsEntry)
-    - [TemplateField](#services.verifiablecredentials.templates.v1.TemplateField)
-  
-    - [FieldType](#services.verifiablecredentials.templates.v1.FieldType)
-  
-    - [CredentialTemplates](#services.verifiablecredentials.templates.v1.CredentialTemplates)
-  
-- [services/verifiable-credentials/v1/verifiable-credentials.proto](#services/verifiable-credentials/v1/verifiable-credentials.proto)
-    - [CheckStatusRequest](#services.verifiablecredentials.v1.CheckStatusRequest)
-    - [CheckStatusResponse](#services.verifiablecredentials.v1.CheckStatusResponse)
-    - [CreateProofRequest](#services.verifiablecredentials.v1.CreateProofRequest)
-    - [CreateProofResponse](#services.verifiablecredentials.v1.CreateProofResponse)
-    - [IssueFromTemplateRequest](#services.verifiablecredentials.v1.IssueFromTemplateRequest)
-    - [IssueFromTemplateResponse](#services.verifiablecredentials.v1.IssueFromTemplateResponse)
-    - [IssueRequest](#services.verifiablecredentials.v1.IssueRequest)
-    - [IssueResponse](#services.verifiablecredentials.v1.IssueResponse)
-    - [SendRequest](#services.verifiablecredentials.v1.SendRequest)
-    - [SendResponse](#services.verifiablecredentials.v1.SendResponse)
-    - [UpdateStatusRequest](#services.verifiablecredentials.v1.UpdateStatusRequest)
-    - [UpdateStatusResponse](#services.verifiablecredentials.v1.UpdateStatusResponse)
-    - [VerifyProofRequest](#services.verifiablecredentials.v1.VerifyProofRequest)
-    - [VerifyProofResponse](#services.verifiablecredentials.v1.VerifyProofResponse)
-  
-    - [VerifiableCredential](#services.verifiablecredentials.v1.VerifiableCredential)
-  
-- [Scalar Value Types](#scalar-value-types)
+This page documents the Protobuf Services and Messages which compose the Trinsic API.
 
 
 
-<a name="pbmse/v1/pbmse.proto"></a>
+<a name="pbmse_v1_pbmse-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## pbmse/v1/pbmse.proto
 
 
+ <!-- end services -->
 
-<a name="pbmse.v1.EncryptedMessage"></a>
+
+<a name="pbmse-v1-EncryptedMessage"></a>
 
 ### EncryptedMessage
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| iv | [bytes](#bytes) |  |  |
-| aad | [bytes](#bytes) |  |  |
-| ciphertext | [bytes](#bytes) |  |  |
-| tag | [bytes](#bytes) |  |  |
-| recipients | [EncryptionRecipient](#pbmse.v1.EncryptionRecipient) | repeated |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| iv | [bytes](/reference/proto#bytes) |  |
+| aad | [bytes](/reference/proto#bytes) |  |
+| ciphertext | [bytes](/reference/proto#bytes) |  |
+| tag | [bytes](/reference/proto#bytes) |  |
+| recipients | [EncryptionRecipient](/reference/proto#pbmse-v1-EncryptionRecipient)[] |  |
 
 
 
 
 
 
-<a name="pbmse.v1.EncryptionHeader"></a>
+<a name="pbmse-v1-EncryptionHeader"></a>
 
 ### EncryptionHeader
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| mode | [EncryptionMode](#pbmse.v1.EncryptionMode) |  |  |
-| algorithm | [EncryptionAlgorithm](#pbmse.v1.EncryptionAlgorithm) |  |  |
-| key_id | [string](#string) |  |  |
-| sender_key_id | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| mode | [EncryptionMode](/reference/proto#pbmse-v1-EncryptionMode) |  |
+| algorithm | [EncryptionAlgorithm](/reference/proto#pbmse-v1-EncryptionAlgorithm) |  |
+| key_id | [string](/reference/proto#string) |  |
+| sender_key_id | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="pbmse.v1.EncryptionRecipient"></a>
+<a name="pbmse-v1-EncryptionRecipient"></a>
 
 ### EncryptionRecipient
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| header | [EncryptionHeader](#pbmse.v1.EncryptionHeader) |  |  |
-| content_encryption_key | [bytes](#bytes) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| header | [EncryptionHeader](/reference/proto#pbmse-v1-EncryptionHeader) |  |
+| content_encryption_key | [bytes](/reference/proto#bytes) |  |
 
 
 
 
 
 
-<a name="pbmse.v1.Signature"></a>
+<a name="pbmse-v1-Signature"></a>
 
 ### Signature
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| header | [bytes](#bytes) |  |  |
-| signature | [bytes](#bytes) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| header | [bytes](/reference/proto#bytes) |  |
+| signature | [bytes](/reference/proto#bytes) |  |
 
 
 
 
 
 
-<a name="pbmse.v1.SignatureHeader"></a>
+<a name="pbmse-v1-SignatureHeader"></a>
 
 ### SignatureHeader
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| algorithm | [string](#string) |  |  |
-| key_id | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| algorithm | [string](/reference/proto#string) |  |
+| key_id | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="pbmse.v1.SignedMessage"></a>
+<a name="pbmse-v1-SignedMessage"></a>
 
 ### SignedMessage
 JWS
 Protocol buffer message signing and encryption
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| payload | [bytes](#bytes) |  |  |
-| signatures | [Signature](#pbmse.v1.Signature) | repeated |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| payload | [bytes](/reference/proto#bytes) |  |
+| signatures | [Signature](/reference/proto#pbmse-v1-Signature)[] |  |
 
 
 
 
 
- 
+ <!-- end messages -->
 
 
-<a name="pbmse.v1.EncryptionAlgorithm"></a>
+<a name="pbmse-v1-EncryptionAlgorithm"></a>
 
 ### EncryptionAlgorithm
 
@@ -275,7 +134,7 @@ Protocol buffer message signing and encryption
 
 
 
-<a name="pbmse.v1.EncryptionMode"></a>
+<a name="pbmse-v1-EncryptionMode"></a>
 
 ### EncryptionMode
 
@@ -287,111 +146,126 @@ Protocol buffer message signing and encryption
 | ENCRYPTION_MODE_CONTENT_ENCRYPTION_KEY | 2 |  |
 
 
- 
+ <!-- end enums -->
 
- 
-
- 
+ <!-- end HasExtensions -->
 
 
 
-<a name="sdk/options/v1/options.proto"></a>
+<a name="sdk_options_v1_options-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## sdk/options/v1/options.proto
 
 
+ <!-- end services -->
 
-<a name="sdk.options.v1.ServiceOptions"></a>
+
+<a name="sdk-options-v1-ServiceOptions"></a>
 
 ### ServiceOptions
 service options
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| server_endpoint | [string](#string) |  | service endpoint |
-| server_port | [int32](#int32) |  | service port |
-| server_use_tls | [bool](#bool) |  | indicates if tls is used |
-| auth_token | [string](#string) |  | default auth token for oberon security scheme |
-| default_ecosystem | [string](#string) |  | ecosystem to use with endpoints that require it |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| server_endpoint | [string](/reference/proto#string) | service endpoint |
+| server_port | [int32](/reference/proto#int32) | service port |
+| server_use_tls | [bool](/reference/proto#bool) | indicates if tls is used |
+| auth_token | [string](/reference/proto#string) | default auth token for oberon security scheme |
+| default_ecosystem | [string](/reference/proto#string) | ecosystem to use with endpoints that require it |
 
 
 
 
 
- 
+ <!-- end messages -->
 
- 
+ <!-- end enums -->
 
- 
-
- 
+ <!-- end HasExtensions -->
 
 
 
-<a name="services/account/v1/account.proto"></a>
+<a name="services_account_v1_account-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## services/account/v1/account.proto
 
 
 
-<a name="services.account.v1.AccountDetails"></a>
+<a name="services-account-v1-Account"></a>
+
+### Service - Account
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| SignIn | [SignInRequest](/reference/proto#services-account-v1-SignInRequest) | [SignInResponse](/reference/proto#services-account-v1-SignInResponse) | Sign in to an already existing account
+
+rpc SIgnInConfirm (SignInConfirmRequest) returns (SignInConfirmResponse); |
+| Info | [InfoRequest](/reference/proto#services-account-v1-InfoRequest) | [InfoResponse](/reference/proto#services-account-v1-InfoResponse) | Get account information |
+| ListDevices | [ListDevicesRequest](/reference/proto#services-account-v1-ListDevicesRequest) | [ListDevicesResponse](/reference/proto#services-account-v1-ListDevicesResponse) | List all connected devices |
+| RevokeDevice | [RevokeDeviceRequest](/reference/proto#services-account-v1-RevokeDeviceRequest) | [RevokeDeviceResponse](/reference/proto#services-account-v1-RevokeDeviceResponse) | Revoke device access to the account's cloud wallet |
+
+ <!-- end services -->
+
+
+<a name="services-account-v1-AccountDetails"></a>
 
 ### AccountDetails
 Account Registration Details
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | Account name (optional) |
-| email | [string](#string) |  | Email account (required) |
-| sms | [string](#string) |  | SMS number including country code (optional) |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| name | [string](/reference/proto#string) | Account name (optional) |
+| email | [string](/reference/proto#string) | Email account (required) |
+| sms | [string](/reference/proto#string) | SMS number including country code (optional) |
 
 
 
 
 
 
-<a name="services.account.v1.AccountEcosystem"></a>
+<a name="services-account-v1-AccountEcosystem"></a>
 
 ### AccountEcosystem
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  |  |
-| name | [string](#string) |  |  |
-| description | [string](#string) |  |  |
-| uri | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| id | [string](/reference/proto#string) |  |
+| name | [string](/reference/proto#string) |  |
+| description | [string](/reference/proto#string) |  |
+| uri | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.account.v1.AccountProfile"></a>
+<a name="services-account-v1-AccountProfile"></a>
 
 ### AccountProfile
 Device profile containing sensitive authentication data.
 This information should be stored securely
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| profile_type | [string](#string) |  | The type of profile, used to differentiate between protocol schemes or versions |
-| auth_data | [bytes](#bytes) |  | Auth data containg information about the current device access |
-| auth_token | [bytes](#bytes) |  | Secure token issued by server used to generate zero-knowledge proofs |
-| protection | [TokenProtection](#services.account.v1.TokenProtection) |  | Token security information about the token. If token protection is enabled, implementations must supply protection secret before using the token for authentication. |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| profile_type | [string](/reference/proto#string) | The type of profile, used to differentiate between protocol schemes or versions |
+| auth_data | [bytes](/reference/proto#bytes) | Auth data containg information about the current device access |
+| auth_token | [bytes](/reference/proto#bytes) | Secure token issued by server used to generate zero-knowledge proofs |
+| protection | [TokenProtection](/reference/proto#services-account-v1-TokenProtection) | Token security information about the token. If token protection is enabled, implementations must supply protection secret before using the token for authentication. |
 
 
 
 
 
 
-<a name="services.account.v1.InfoRequest"></a>
+<a name="services-account-v1-InfoRequest"></a>
 
 ### InfoRequest
 
@@ -401,23 +275,23 @@ This information should be stored securely
 
 
 
-<a name="services.account.v1.InfoResponse"></a>
+<a name="services-account-v1-InfoResponse"></a>
 
 ### InfoResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| details | [AccountDetails](#services.account.v1.AccountDetails) |  | The account details associated with the calling request context |
-| ecosystems | [AccountEcosystem](#services.account.v1.AccountEcosystem) | repeated | any ecosystems the account has access to |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| details | [AccountDetails](/reference/proto#services-account-v1-AccountDetails) | The account details associated with the calling request context |
+| ecosystems | [AccountEcosystem](/reference/proto#services-account-v1-AccountEcosystem)[] | any ecosystems the account has access to |
 
 
 
 
 
 
-<a name="services.account.v1.ListDevicesRequest"></a>
+<a name="services-account-v1-ListDevicesRequest"></a>
 
 ### ListDevicesRequest
 
@@ -427,7 +301,7 @@ This information should be stored securely
 
 
 
-<a name="services.account.v1.ListDevicesResponse"></a>
+<a name="services-account-v1-ListDevicesResponse"></a>
 
 ### ListDevicesResponse
 
@@ -437,7 +311,7 @@ This information should be stored securely
 
 
 
-<a name="services.account.v1.RevokeDeviceRequest"></a>
+<a name="services-account-v1-RevokeDeviceRequest"></a>
 
 ### RevokeDeviceRequest
 
@@ -447,7 +321,7 @@ This information should be stored securely
 
 
 
-<a name="services.account.v1.RevokeDeviceResponse"></a>
+<a name="services-account-v1-RevokeDeviceResponse"></a>
 
 ### RevokeDeviceResponse
 
@@ -457,24 +331,24 @@ This information should be stored securely
 
 
 
-<a name="services.account.v1.SignInRequest"></a>
+<a name="services-account-v1-SignInRequest"></a>
 
 ### SignInRequest
 Request for creating new account
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| details | [AccountDetails](#services.account.v1.AccountDetails) |  | Account registration details |
-| invitation_code | [string](#string) |  | Invitation code associated with this registration This field is optional. |
-| ecosystem_id | [string](#string) |  | EcosystemId to sign in. This field is optional and will be ignored if invitation_code is passed |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| details | [AccountDetails](/reference/proto#services-account-v1-AccountDetails) | Account registration details |
+| invitation_code | [string](/reference/proto#string) | Invitation code associated with this registration This field is optional. |
+| ecosystem_id | [string](/reference/proto#string) | EcosystemId to sign in. This field is optional and will be ignored if invitation_code is passed |
 
 
 
 
 
 
-<a name="services.account.v1.SignInResponse"></a>
+<a name="services-account-v1-SignInResponse"></a>
 
 ### SignInResponse
 Response for creating new account
@@ -483,36 +357,36 @@ was sent to one of the users two-factor methods
 like email, SMS, etc.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  | The status of the response |
-| confirmation_method | [ConfirmationMethod](#services.account.v1.ConfirmationMethod) |  | Indicates if confirmation of account is required. This settings is configured globally by the server administrator. |
-| profile | [AccountProfile](#services.account.v1.AccountProfile) |  | Contains authentication data for use with the current device. This object must be stored in a secure place. It can also be protected with a PIN, but this is optional. See the docs at https://docs.trinsic.id for more information on working with authentication data. |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) | The status of the response |
+| confirmation_method | [ConfirmationMethod](/reference/proto#services-account-v1-ConfirmationMethod) | Indicates if confirmation of account is required. This settings is configured globally by the server administrator. |
+| profile | [AccountProfile](/reference/proto#services-account-v1-AccountProfile) | Contains authentication data for use with the current device. This object must be stored in a secure place. It can also be protected with a PIN, but this is optional. See the docs at https://docs.trinsic.id for more information on working with authentication data. |
 
 
 
 
 
 
-<a name="services.account.v1.TokenProtection"></a>
+<a name="services-account-v1-TokenProtection"></a>
 
 ### TokenProtection
 Token protection info
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| enabled | [bool](#bool) |  | Indicates if token is protected using a PIN, security code, HSM secret, etc. |
-| method | [ConfirmationMethod](#services.account.v1.ConfirmationMethod) |  | The method used to protect the token |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| enabled | [bool](/reference/proto#bool) | Indicates if token is protected using a PIN, security code, HSM secret, etc. |
+| method | [ConfirmationMethod](/reference/proto#services-account-v1-ConfirmationMethod) | The method used to protect the token |
 
 
 
 
 
- 
+ <!-- end messages -->
 
 
-<a name="services.account.v1.ConfirmationMethod"></a>
+<a name="services-account-v1-ConfirmationMethod"></a>
 
 ### ConfirmationMethod
 Confirmation method type for two-factor workflows
@@ -526,72 +400,67 @@ Confirmation method type for two-factor workflows
 | Other | 10 | Indicates third-party method of confirmation is required |
 
 
- 
+ <!-- end enums -->
 
- 
-
-
-<a name="services.account.v1.Account"></a>
-
-### Account
-
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| SignIn | [SignInRequest](#services.account.v1.SignInRequest) | [SignInResponse](#services.account.v1.SignInResponse) | Sign in to an already existing account
-
-rpc SIgnInConfirm (SignInConfirmRequest) returns (SignInConfirmResponse); |
-| Info | [InfoRequest](#services.account.v1.InfoRequest) | [InfoResponse](#services.account.v1.InfoResponse) | Get account information |
-| ListDevices | [ListDevicesRequest](#services.account.v1.ListDevicesRequest) | [ListDevicesResponse](#services.account.v1.ListDevicesResponse) | List all connected devices |
-| RevokeDevice | [RevokeDeviceRequest](#services.account.v1.RevokeDeviceRequest) | [RevokeDeviceResponse](#services.account.v1.RevokeDeviceResponse) | Revoke device access to the account&#39;s cloud wallet |
-
- 
+ <!-- end HasExtensions -->
 
 
 
-<a name="services/common/v1/common.proto"></a>
+<a name="services_common_v1_common-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## services/common/v1/common.proto
 
 
 
-<a name="services.common.v1.Nonce"></a>
+<a name="services-common-v1-Common"></a>
+
+### Service - Common
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Request | [.pbmse.v1.EncryptedMessage](/reference/proto#pbmse-v1-EncryptedMessage) | [.pbmse.v1.EncryptedMessage](/reference/proto#pbmse-v1-EncryptedMessage) |  |
+
+ <!-- end services -->
+
+
+<a name="services-common-v1-Nonce"></a>
 
 ### Nonce
 Nonce used to generate an oberon proof
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| timestamp | [int64](#int64) |  | UTC unix millisecond timestamp the request was made |
-| request_hash | [bytes](#bytes) |  | blake3256 hash of the request body |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| timestamp | [int64](/reference/proto#int64) | UTC unix millisecond timestamp the request was made |
+| request_hash | [bytes](/reference/proto#bytes) | blake3256 hash of the request body |
 
 
 
 
 
 
-<a name="services.common.v1.ServerConfig"></a>
+<a name="services-common-v1-ServerConfig"></a>
 
 ### ServerConfig
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| endpoint | [string](#string) |  | service endpoint |
-| port | [int32](#int32) |  | service port |
-| use_tls | [bool](#bool) |  | indicates if tls is used |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| endpoint | [string](/reference/proto#string) | service endpoint |
+| port | [int32](/reference/proto#int32) | service port |
+| use_tls | [bool](/reference/proto#bool) | indicates if tls is used |
 
 
 
 
 
- 
+ <!-- end messages -->
 
 
-<a name="services.common.v1.ResponseStatus"></a>
+<a name="services-common-v1-ResponseStatus"></a>
 
 ### ResponseStatus
 
@@ -606,142 +475,145 @@ Nonce used to generate an oberon proof
 | UNKNOWN_ERROR | 100 |  |
 
 
- 
+ <!-- end enums -->
 
- 
-
-
-<a name="services.common.v1.Common"></a>
-
-### Common
-
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| Request | [.pbmse.v1.EncryptedMessage](#pbmse.v1.EncryptedMessage) | [.pbmse.v1.EncryptedMessage](#pbmse.v1.EncryptedMessage) |  |
-
- 
+ <!-- end HasExtensions -->
 
 
 
-<a name="services/debug/v1/debug.proto"></a>
+<a name="services_debug_v1_debug-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## services/debug/v1/debug.proto
 
 
- 
 
- 
+<a name="services-debug-v1-Debugging"></a>
 
- 
-
-
-<a name="services.debug.v1.Debugging"></a>
-
-### Debugging
+### Service - Debugging
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CallEmpty | [.google.protobuf.Empty](#google.protobuf.Empty) | [.google.protobuf.Empty](#google.protobuf.Empty) |  |
-| CallEmptyAuth | [.google.protobuf.Empty](#google.protobuf.Empty) | [.google.protobuf.Empty](#google.protobuf.Empty) |  |
+| CallEmpty | [.google.protobuf.Empty](/reference/proto#google-protobuf-Empty) | [.google.protobuf.Empty](/reference/proto#google-protobuf-Empty) |  |
+| CallEmptyAuth | [.google.protobuf.Empty](/reference/proto#google-protobuf-Empty) | [.google.protobuf.Empty](/reference/proto#google-protobuf-Empty) |  |
 
- 
+ <!-- end services -->
+
+ <!-- end messages -->
+
+ <!-- end enums -->
+
+ <!-- end HasExtensions -->
 
 
 
-<a name="services/provider/v1/provider.proto"></a>
+<a name="services_provider_v1_provider-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## services/provider/v1/provider.proto
 
 
 
-<a name="services.provider.v1.CreateEcosystemRequest"></a>
+<a name="services-provider-v1-Provider"></a>
+
+### Service - Provider
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| CreateEcosystem | [CreateEcosystemRequest](/reference/proto#services-provider-v1-CreateEcosystemRequest) | [CreateEcosystemResponse](/reference/proto#services-provider-v1-CreateEcosystemResponse) | Create new ecosystem and assign the authenticated user as owner |
+| GenerateToken | [GenerateTokenRequest](/reference/proto#services-provider-v1-GenerateTokenRequest) | [GenerateTokenResponse](/reference/proto#services-provider-v1-GenerateTokenResponse) | Generates an unprotected authentication token that can be used to configure server side applications |
+| Invite | [InviteRequest](/reference/proto#services-provider-v1-InviteRequest) | [InviteResponse](/reference/proto#services-provider-v1-InviteResponse) | Invite a user to the ecosystem |
+| InvitationStatus | [InvitationStatusRequest](/reference/proto#services-provider-v1-InvitationStatusRequest) | [InvitationStatusResponse](/reference/proto#services-provider-v1-InvitationStatusResponse) | Check the invitation status |
+
+ <!-- end services -->
+
+
+<a name="services-provider-v1-CreateEcosystemRequest"></a>
 
 ### CreateEcosystemRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | Globally unique name for the Ecosystem. This name will be part of the ecosystem specific URLs and namespaces. Allowed characters are lowercase letters, numbers, underscore and hyphen. |
-| description | [string](#string) |  | Ecosystem description. This field is optional. |
-| uri | [string](#string) |  | External URL associated with your organization or ecosystem entity. This field is optional |
-| details | [services.account.v1.AccountDetails](#services.account.v1.AccountDetails) |  | The account details of the owner of the ecosystem |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| name | [string](/reference/proto#string) | Globally unique name for the Ecosystem. This name will be part of the ecosystem specific URLs and namespaces. Allowed characters are lowercase letters, numbers, underscore and hyphen. |
+| description | [string](/reference/proto#string) | Ecosystem description. This field is optional. |
+| uri | [string](/reference/proto#string) | External URL associated with your organization or ecosystem entity. This field is optional |
+| details | [services.account.v1.AccountDetails](/reference/proto#services-account-v1-AccountDetails) | The account details of the owner of the ecosystem |
 
 
 
 
 
 
-<a name="services.provider.v1.CreateEcosystemResponse"></a>
+<a name="services-provider-v1-CreateEcosystemResponse"></a>
 
 ### CreateEcosystemResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| ecosystem | [Ecosystem](#services.provider.v1.Ecosystem) |  | Details of the created ecosystem |
-| profile | [services.account.v1.AccountProfile](#services.account.v1.AccountProfile) |  | Account profile for auth of the owner of the ecosystem |
-| confirmation_method | [services.account.v1.ConfirmationMethod](#services.account.v1.ConfirmationMethod) |  | Indicates if confirmation of account is required. This settings is configured globally by the server administrator. |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| ecosystem | [Ecosystem](/reference/proto#services-provider-v1-Ecosystem) | Details of the created ecosystem |
+| profile | [services.account.v1.AccountProfile](/reference/proto#services-account-v1-AccountProfile) | Account profile for auth of the owner of the ecosystem |
+| confirmation_method | [services.account.v1.ConfirmationMethod](/reference/proto#services-account-v1-ConfirmationMethod) | Indicates if confirmation of account is required. This settings is configured globally by the server administrator. |
 
 
 
 
 
 
-<a name="services.provider.v1.Ecosystem"></a>
+<a name="services-provider-v1-Ecosystem"></a>
 
 ### Ecosystem
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  |  |
-| name | [string](#string) |  |  |
-| description | [string](#string) |  |  |
-| uri | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| id | [string](/reference/proto#string) |  |
+| name | [string](/reference/proto#string) |  |
+| description | [string](/reference/proto#string) |  |
+| uri | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.provider.v1.GenerateTokenRequest"></a>
+<a name="services-provider-v1-GenerateTokenRequest"></a>
 
 ### GenerateTokenRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| description | [string](#string) |  | Optional description to identify this token |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| description | [string](/reference/proto#string) | Optional description to identify this token |
 
 
 
 
 
 
-<a name="services.provider.v1.GenerateTokenResponse"></a>
+<a name="services-provider-v1-GenerateTokenResponse"></a>
 
 ### GenerateTokenResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| profile | [services.account.v1.AccountProfile](#services.account.v1.AccountProfile) |  | Account authentication profile that contains unprotected token |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| profile | [services.account.v1.AccountProfile](/reference/proto#services-account-v1-AccountProfile) | Account authentication profile that contains unprotected token |
 
 
 
 
 
 
-<a name="services.provider.v1.InvitationStatusRequest"></a>
+<a name="services-provider-v1-InvitationStatusRequest"></a>
 
 ### InvitationStatusRequest
 Request details for the status of onboarding
@@ -750,68 +622,68 @@ The reference_id passed is the response from the
 `Onboard` method call
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| invitation_id | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| invitation_id | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.provider.v1.InvitationStatusResponse"></a>
+<a name="services-provider-v1-InvitationStatusResponse"></a>
 
 ### InvitationStatusResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [InvitationStatusResponse.Status](#services.provider.v1.InvitationStatusResponse.Status) |  |  |
-| status_details | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [InvitationStatusResponse.Status](/reference/proto#services-provider-v1-InvitationStatusResponse-Status) |  |
+| status_details | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.provider.v1.Invite"></a>
+<a name="services-provider-v1-Invite"></a>
 
 ### Invite
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  |  |
-| code | [string](#string) |  |  |
-| created | [string](#string) |  |  |
-| accepted | [string](#string) |  |  |
-| expires | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| id | [string](/reference/proto#string) |  |
+| code | [string](/reference/proto#string) |  |
+| created | [string](/reference/proto#string) |  |
+| accepted | [string](/reference/proto#string) |  |
+| expires | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.provider.v1.InviteRequest"></a>
+<a name="services-provider-v1-InviteRequest"></a>
 
 ### InviteRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| participant | [ParticipantType](#services.provider.v1.ParticipantType) |  |  |
-| description | [string](#string) |  |  |
-| details | [services.account.v1.AccountDetails](#services.account.v1.AccountDetails) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| participant | [ParticipantType](/reference/proto#services-provider-v1-ParticipantType) |  |
+| description | [string](/reference/proto#string) |  |
+| details | [services.account.v1.AccountDetails](/reference/proto#services-account-v1-AccountDetails) |  |
 
 
 
 
 
 
-<a name="services.provider.v1.InviteRequest.DidCommInvitation"></a>
+<a name="services-provider-v1-InviteRequest-DidCommInvitation"></a>
 
 ### InviteRequest.DidCommInvitation
 
@@ -821,26 +693,26 @@ The reference_id passed is the response from the
 
 
 
-<a name="services.provider.v1.InviteResponse"></a>
+<a name="services-provider-v1-InviteResponse"></a>
 
 ### InviteResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  |  |
-| invitation_id | [string](#string) |  |  |
-| invitation_code | [string](#string) |  | Invitation Code that must be passed with the account &#39;SignIn&#39; request to correlate this user with the invitation sent. |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) |  |
+| invitation_id | [string](/reference/proto#string) |  |
+| invitation_code | [string](/reference/proto#string) | Invitation Code that must be passed with the account 'SignIn' request to correlate this user with the invitation sent. |
 
 
 
 
 
- 
+ <!-- end messages -->
 
 
-<a name="services.provider.v1.InvitationStatusResponse.Status"></a>
+<a name="services-provider-v1-InvitationStatusResponse-Status"></a>
 
 ### InvitationStatusResponse.Status
 
@@ -854,7 +726,7 @@ The reference_id passed is the response from the
 
 
 
-<a name="services.provider.v1.ParticipantType"></a>
+<a name="services-provider-v1-ParticipantType"></a>
 
 ### ParticipantType
 
@@ -865,383 +737,389 @@ The reference_id passed is the response from the
 | participant_type_organization | 1 |  |
 
 
- 
+ <!-- end enums -->
 
- 
-
-
-<a name="services.provider.v1.Provider"></a>
-
-### Provider
-
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| CreateEcosystem | [CreateEcosystemRequest](#services.provider.v1.CreateEcosystemRequest) | [CreateEcosystemResponse](#services.provider.v1.CreateEcosystemResponse) | Create new ecosystem and assign the authenticated user as owner |
-| GenerateToken | [GenerateTokenRequest](#services.provider.v1.GenerateTokenRequest) | [GenerateTokenResponse](#services.provider.v1.GenerateTokenResponse) | Generates an unprotected authentication token that can be used to configure server side applications |
-| Invite | [InviteRequest](#services.provider.v1.InviteRequest) | [InviteResponse](#services.provider.v1.InviteResponse) | Invite a user to the ecosystem |
-| InvitationStatus | [InvitationStatusRequest](#services.provider.v1.InvitationStatusRequest) | [InvitationStatusResponse](#services.provider.v1.InvitationStatusResponse) | Check the invitation status |
-
- 
+ <!-- end HasExtensions -->
 
 
 
-<a name="services/trust-registry/v1/trust-registry.proto"></a>
+<a name="services_trust-registry_v1_trust-registry-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## services/trust-registry/v1/trust-registry.proto
 
 
 
-<a name="services.trustregistry.v1.AddFrameworkRequest"></a>
+<a name="services-trustregistry-v1-TrustRegistry"></a>
+
+### Service - TrustRegistry
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| AddFramework | [AddFrameworkRequest](/reference/proto#services-trustregistry-v1-AddFrameworkRequest) | [AddFrameworkResponse](/reference/proto#services-trustregistry-v1-AddFrameworkResponse) | Adds a trust registry defintion to the ecosystem |
+| RemoveFramework | [RemoveFrameworkRequest](/reference/proto#services-trustregistry-v1-RemoveFrameworkRequest) | [RemoveFrameworkResponse](/reference/proto#services-trustregistry-v1-RemoveFrameworkResponse) |  |
+| SearchRegistry | [SearchRegistryRequest](/reference/proto#services-trustregistry-v1-SearchRegistryRequest) | [SearchRegistryResponse](/reference/proto#services-trustregistry-v1-SearchRegistryResponse) |  |
+| RegisterIssuer | [RegisterIssuerRequest](/reference/proto#services-trustregistry-v1-RegisterIssuerRequest) | [RegisterIssuerResponse](/reference/proto#services-trustregistry-v1-RegisterIssuerResponse) | Registers an authoritative issuer with a credential template |
+| RegisterVerifier | [RegisterVerifierRequest](/reference/proto#services-trustregistry-v1-RegisterVerifierRequest) | [RegisterVerifierResponse](/reference/proto#services-trustregistry-v1-RegisterVerifierResponse) | Registers an authoritative verifier with a credential template |
+| UnregisterIssuer | [UnregisterIssuerRequest](/reference/proto#services-trustregistry-v1-UnregisterIssuerRequest) | [UnregisterIssuerResponse](/reference/proto#services-trustregistry-v1-UnregisterIssuerResponse) | Removes an authoritative issuer with a credential template from the trust registry |
+| UnregisterVerifier | [UnregisterVerifierRequest](/reference/proto#services-trustregistry-v1-UnregisterVerifierRequest) | [UnregisterVerifierResponse](/reference/proto#services-trustregistry-v1-UnregisterVerifierResponse) | Removes an authoritative verifier with a presentation template from the trust registry |
+| CheckIssuerStatus | [CheckIssuerStatusRequest](/reference/proto#services-trustregistry-v1-CheckIssuerStatusRequest) | [CheckIssuerStatusResponse](/reference/proto#services-trustregistry-v1-CheckIssuerStatusResponse) |  |
+| CheckVerifierStatus | [CheckVerifierStatusRequest](/reference/proto#services-trustregistry-v1-CheckVerifierStatusRequest) | [CheckVerifierStatusResponse](/reference/proto#services-trustregistry-v1-CheckVerifierStatusResponse) |  |
+| FetchData | [FetchDataRequest](/reference/proto#services-trustregistry-v1-FetchDataRequest) | [FetchDataResponse](/reference/proto#services-trustregistry-v1-FetchDataResponse) stream |  |
+
+ <!-- end services -->
+
+
+<a name="services-trustregistry-v1-AddFrameworkRequest"></a>
 
 ### AddFrameworkRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| governance_framework | [GovernanceFramework](#services.trustregistry.v1.GovernanceFramework) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| governance_framework | [GovernanceFramework](/reference/proto#services-trustregistry-v1-GovernanceFramework) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.AddFrameworkResponse"></a>
+<a name="services-trustregistry-v1-AddFrameworkResponse"></a>
 
 ### AddFrameworkResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.CheckIssuerStatusRequest"></a>
+<a name="services-trustregistry-v1-CheckIssuerStatusRequest"></a>
 
 ### CheckIssuerStatusRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| governance_framework_uri | [string](#string) |  |  |
-| did_uri | [string](#string) |  |  |
-| x509_cert | [string](#string) |  |  |
-| credential_type_uri | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| governance_framework_uri | [string](/reference/proto#string) |  |
+| did_uri | [string](/reference/proto#string) |  |
+| x509_cert | [string](/reference/proto#string) |  |
+| credential_type_uri | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.CheckIssuerStatusResponse"></a>
+<a name="services-trustregistry-v1-CheckIssuerStatusResponse"></a>
 
 ### CheckIssuerStatusResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [RegistrationStatus](#services.trustregistry.v1.RegistrationStatus) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [RegistrationStatus](/reference/proto#services-trustregistry-v1-RegistrationStatus) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.CheckVerifierStatusRequest"></a>
+<a name="services-trustregistry-v1-CheckVerifierStatusRequest"></a>
 
 ### CheckVerifierStatusRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| governance_framework_uri | [string](#string) |  |  |
-| did_uri | [string](#string) |  |  |
-| x509_cert | [string](#string) |  |  |
-| presentation_type_uri | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| governance_framework_uri | [string](/reference/proto#string) |  |
+| did_uri | [string](/reference/proto#string) |  |
+| x509_cert | [string](/reference/proto#string) |  |
+| presentation_type_uri | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.CheckVerifierStatusResponse"></a>
+<a name="services-trustregistry-v1-CheckVerifierStatusResponse"></a>
 
 ### CheckVerifierStatusResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [RegistrationStatus](#services.trustregistry.v1.RegistrationStatus) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [RegistrationStatus](/reference/proto#services-trustregistry-v1-RegistrationStatus) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.FetchDataRequest"></a>
+<a name="services-trustregistry-v1-FetchDataRequest"></a>
 
 ### FetchDataRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| governance_framework_uri | [string](#string) |  |  |
-| query | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| governance_framework_uri | [string](/reference/proto#string) |  |
+| query | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.FetchDataResponse"></a>
+<a name="services-trustregistry-v1-FetchDataResponse"></a>
 
 ### FetchDataResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| response_json | [string](#string) |  |  |
-| has_more_results | [bool](#bool) |  |  |
-| continuation_token | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| response_json | [string](/reference/proto#string) |  |
+| has_more_results | [bool](/reference/proto#bool) |  |
+| continuation_token | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.GovernanceFramework"></a>
+<a name="services-trustregistry-v1-GovernanceFramework"></a>
 
 ### GovernanceFramework
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| governance_framework_uri | [string](#string) |  |  |
-| trust_registry_uri | [string](#string) |  |  |
-| description | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| governance_framework_uri | [string](/reference/proto#string) |  |
+| trust_registry_uri | [string](/reference/proto#string) |  |
+| description | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.RegisterIssuerRequest"></a>
+<a name="services-trustregistry-v1-RegisterIssuerRequest"></a>
 
 ### RegisterIssuerRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| did_uri | [string](#string) |  |  |
-| x509_cert | [string](#string) |  |  |
-| credential_type_uri | [string](#string) |  |  |
-| valid_from_utc | [uint64](#uint64) |  |  |
-| valid_until_utc | [uint64](#uint64) |  |  |
-| governance_framework_uri | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| did_uri | [string](/reference/proto#string) |  |
+| x509_cert | [string](/reference/proto#string) |  |
+| credential_type_uri | [string](/reference/proto#string) |  |
+| valid_from_utc | [uint64](/reference/proto#uint64) |  |
+| valid_until_utc | [uint64](/reference/proto#uint64) |  |
+| governance_framework_uri | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.RegisterIssuerResponse"></a>
+<a name="services-trustregistry-v1-RegisterIssuerResponse"></a>
 
 ### RegisterIssuerResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.RegisterVerifierRequest"></a>
+<a name="services-trustregistry-v1-RegisterVerifierRequest"></a>
 
 ### RegisterVerifierRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| did_uri | [string](#string) |  |  |
-| x509_cert | [string](#string) |  |  |
-| presentation_type_uri | [string](#string) |  |  |
-| valid_from_utc | [uint64](#uint64) |  |  |
-| valid_until_utc | [uint64](#uint64) |  |  |
-| governance_framework_uri | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| did_uri | [string](/reference/proto#string) |  |
+| x509_cert | [string](/reference/proto#string) |  |
+| presentation_type_uri | [string](/reference/proto#string) |  |
+| valid_from_utc | [uint64](/reference/proto#uint64) |  |
+| valid_until_utc | [uint64](/reference/proto#uint64) |  |
+| governance_framework_uri | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.RegisterVerifierResponse"></a>
+<a name="services-trustregistry-v1-RegisterVerifierResponse"></a>
 
 ### RegisterVerifierResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.RemoveFrameworkRequest"></a>
+<a name="services-trustregistry-v1-RemoveFrameworkRequest"></a>
 
 ### RemoveFrameworkRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| governance_framework | [GovernanceFramework](#services.trustregistry.v1.GovernanceFramework) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| governance_framework | [GovernanceFramework](/reference/proto#services-trustregistry-v1-GovernanceFramework) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.RemoveFrameworkResponse"></a>
+<a name="services-trustregistry-v1-RemoveFrameworkResponse"></a>
 
 ### RemoveFrameworkResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.SearchRegistryRequest"></a>
+<a name="services-trustregistry-v1-SearchRegistryRequest"></a>
 
 ### SearchRegistryRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| query | [string](#string) |  | SELECT c from c where c.type == &#39;GovernanceFramework&#39; |
-| continuation_token | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| query | [string](/reference/proto#string) | SELECT c from c where c.type == 'GovernanceFramework' |
+| continuation_token | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.SearchRegistryResponse"></a>
+<a name="services-trustregistry-v1-SearchRegistryResponse"></a>
 
 ### SearchRegistryResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| items_json | [string](#string) |  |  |
-| has_more | [bool](#bool) |  |  |
-| count | [int32](#int32) |  |  |
-| continuation_token | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| items_json | [string](/reference/proto#string) |  |
+| has_more | [bool](/reference/proto#bool) |  |
+| count | [int32](/reference/proto#int32) |  |
+| continuation_token | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.UnregisterIssuerRequest"></a>
+<a name="services-trustregistry-v1-UnregisterIssuerRequest"></a>
 
 ### UnregisterIssuerRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| did_uri | [string](#string) |  |  |
-| x509_cert | [string](#string) |  |  |
-| credential_type_uri | [string](#string) |  |  |
-| governance_framework_uri | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| did_uri | [string](/reference/proto#string) |  |
+| x509_cert | [string](/reference/proto#string) |  |
+| credential_type_uri | [string](/reference/proto#string) |  |
+| governance_framework_uri | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.UnregisterIssuerResponse"></a>
+<a name="services-trustregistry-v1-UnregisterIssuerResponse"></a>
 
 ### UnregisterIssuerResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.UnregisterVerifierRequest"></a>
+<a name="services-trustregistry-v1-UnregisterVerifierRequest"></a>
 
 ### UnregisterVerifierRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| did_uri | [string](#string) |  |  |
-| x509_cert | [string](#string) |  |  |
-| presentation_type_uri | [string](#string) |  |  |
-| governance_framework_uri | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| did_uri | [string](/reference/proto#string) |  |
+| x509_cert | [string](/reference/proto#string) |  |
+| presentation_type_uri | [string](/reference/proto#string) |  |
+| governance_framework_uri | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.trustregistry.v1.UnregisterVerifierResponse"></a>
+<a name="services-trustregistry-v1-UnregisterVerifierResponse"></a>
 
 ### UnregisterVerifierResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) |  |
 
 
 
 
 
- 
+ <!-- end messages -->
 
 
-<a name="services.trustregistry.v1.RegistrationStatus"></a>
+<a name="services-trustregistry-v1-RegistrationStatus"></a>
 
 ### RegistrationStatus
 
@@ -1255,292 +1133,287 @@ The reference_id passed is the response from the
 | NOT_FOUND | 10 |  |
 
 
- 
+ <!-- end enums -->
 
- 
-
-
-<a name="services.trustregistry.v1.TrustRegistry"></a>
-
-### TrustRegistry
-
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| AddFramework | [AddFrameworkRequest](#services.trustregistry.v1.AddFrameworkRequest) | [AddFrameworkResponse](#services.trustregistry.v1.AddFrameworkResponse) | Adds a trust registry defintion to the ecosystem |
-| RemoveFramework | [RemoveFrameworkRequest](#services.trustregistry.v1.RemoveFrameworkRequest) | [RemoveFrameworkResponse](#services.trustregistry.v1.RemoveFrameworkResponse) |  |
-| SearchRegistry | [SearchRegistryRequest](#services.trustregistry.v1.SearchRegistryRequest) | [SearchRegistryResponse](#services.trustregistry.v1.SearchRegistryResponse) |  |
-| RegisterIssuer | [RegisterIssuerRequest](#services.trustregistry.v1.RegisterIssuerRequest) | [RegisterIssuerResponse](#services.trustregistry.v1.RegisterIssuerResponse) | Registers an authoritative issuer with a credential template |
-| RegisterVerifier | [RegisterVerifierRequest](#services.trustregistry.v1.RegisterVerifierRequest) | [RegisterVerifierResponse](#services.trustregistry.v1.RegisterVerifierResponse) | Registers an authoritative verifier with a credential template |
-| UnregisterIssuer | [UnregisterIssuerRequest](#services.trustregistry.v1.UnregisterIssuerRequest) | [UnregisterIssuerResponse](#services.trustregistry.v1.UnregisterIssuerResponse) | Removes an authoritative issuer with a credential template from the trust registry |
-| UnregisterVerifier | [UnregisterVerifierRequest](#services.trustregistry.v1.UnregisterVerifierRequest) | [UnregisterVerifierResponse](#services.trustregistry.v1.UnregisterVerifierResponse) | Removes an authoritative verifier with a presentation template from the trust registry |
-| CheckIssuerStatus | [CheckIssuerStatusRequest](#services.trustregistry.v1.CheckIssuerStatusRequest) | [CheckIssuerStatusResponse](#services.trustregistry.v1.CheckIssuerStatusResponse) |  |
-| CheckVerifierStatus | [CheckVerifierStatusRequest](#services.trustregistry.v1.CheckVerifierStatusRequest) | [CheckVerifierStatusResponse](#services.trustregistry.v1.CheckVerifierStatusResponse) |  |
-| FetchData | [FetchDataRequest](#services.trustregistry.v1.FetchDataRequest) | [FetchDataResponse](#services.trustregistry.v1.FetchDataResponse) stream |  |
-
- 
+ <!-- end HasExtensions -->
 
 
 
-<a name="services/universal-wallet/v1/universal-wallet.proto"></a>
+<a name="services_universal-wallet_v1_universal-wallet-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## services/universal-wallet/v1/universal-wallet.proto
 
 
 
-<a name="services.universalwallet.v1.DeleteItemRequest"></a>
+<a name="services-universalwallet-v1-UniversalWallet"></a>
+
+### Service - UniversalWallet
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| GetItem | [GetItemRequest](/reference/proto#services-universalwallet-v1-GetItemRequest) | [GetItemResponse](/reference/proto#services-universalwallet-v1-GetItemResponse) | Retrieve an item from the wallet with a given item identifier |
+| Search | [SearchRequest](/reference/proto#services-universalwallet-v1-SearchRequest) | [SearchResponse](/reference/proto#services-universalwallet-v1-SearchResponse) | Search the wallet using a SQL-like syntax |
+| InsertItem | [InsertItemRequest](/reference/proto#services-universalwallet-v1-InsertItemRequest) | [InsertItemResponse](/reference/proto#services-universalwallet-v1-InsertItemResponse) | Insert an item into the wallet |
+| UpdateItem | [UpdateItemRequest](/reference/proto#services-universalwallet-v1-UpdateItemRequest) | [UpdateItemResponse](/reference/proto#services-universalwallet-v1-UpdateItemResponse) | Insert an item into the wallet |
+| DeleteItem | [DeleteItemRequest](/reference/proto#services-universalwallet-v1-DeleteItemRequest) | [DeleteItemResponse](/reference/proto#services-universalwallet-v1-DeleteItemResponse) | Delete an item from the wallet permanently |
+
+ <!-- end services -->
+
+
+<a name="services-universalwallet-v1-DeleteItemRequest"></a>
 
 ### DeleteItemRequest
 Delete item request
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| item_id | [string](#string) |  | item identifier of the record to delete |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| item_id | [string](/reference/proto#string) | item identifier of the record to delete |
 
 
 
 
 
 
-<a name="services.universalwallet.v1.DeleteItemResponse"></a>
+<a name="services-universalwallet-v1-DeleteItemResponse"></a>
 
 ### DeleteItemResponse
 Delete item response
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) |  |
 
 
 
 
 
 
-<a name="services.universalwallet.v1.GetItemRequest"></a>
+<a name="services-universalwallet-v1-GetItemRequest"></a>
 
 ### GetItemRequest
 Get item request object
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| item_id | [string](#string) |  | The item identifier |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| item_id | [string](/reference/proto#string) | The item identifier |
 
 
 
 
 
 
-<a name="services.universalwallet.v1.GetItemResponse"></a>
+<a name="services-universalwallet-v1-GetItemResponse"></a>
 
 ### GetItemResponse
 Get item response object
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| item_json | [string](#string) |  | The item data represented as stringified JSON |
-| item_type | [string](#string) |  | User set item type that described the content of this item |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| item_json | [string](/reference/proto#string) | The item data represented as stringified JSON |
+| item_type | [string](/reference/proto#string) | User set item type that described the content of this item |
 
 
 
 
 
 
-<a name="services.universalwallet.v1.InsertItemRequest"></a>
+<a name="services-universalwallet-v1-InsertItemRequest"></a>
 
 ### InsertItemRequest
 Insert item request
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| item_json | [string](#string) |  | the document to insert as stringified json |
-| item_type | [string](#string) |  | optional item type ex. &#34;VerifiableCredential&#34; |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| item_json | [string](/reference/proto#string) | the document to insert as stringified json |
+| item_type | [string](/reference/proto#string) | optional item type ex. "VerifiableCredential" |
 
 
 
 
 
 
-<a name="services.universalwallet.v1.InsertItemResponse"></a>
+<a name="services-universalwallet-v1-InsertItemResponse"></a>
 
 ### InsertItemResponse
 Insert item response
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  |  |
-| item_id | [string](#string) |  | The item identifier of the inserted record |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) |  |
+| item_id | [string](/reference/proto#string) | The item identifier of the inserted record |
 
 
 
 
 
 
-<a name="services.universalwallet.v1.SearchRequest"></a>
+<a name="services-universalwallet-v1-SearchRequest"></a>
 
 ### SearchRequest
 Search request object
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| query | [string](#string) |  |  |
-| continuation_token | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| query | [string](/reference/proto#string) |  |
+| continuation_token | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.universalwallet.v1.SearchResponse"></a>
+<a name="services-universalwallet-v1-SearchResponse"></a>
 
 ### SearchResponse
 Search response object
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| items | [string](#string) | repeated |  |
-| has_more | [bool](#bool) |  |  |
-| count | [int32](#int32) |  |  |
-| continuation_token | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| items | [string](/reference/proto#string)[] |  |
+| has_more | [bool](/reference/proto#bool) |  |
+| count | [int32](/reference/proto#int32) |  |
+| continuation_token | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.universalwallet.v1.UpdateItemRequest"></a>
+<a name="services-universalwallet-v1-UpdateItemRequest"></a>
 
 ### UpdateItemRequest
 Update item request object
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| item_id | [string](#string) |  | The item identifier |
-| item_type | [string](#string) |  | The item type that described the content of this item |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| item_id | [string](/reference/proto#string) | The item identifier |
+| item_type | [string](/reference/proto#string) | The item type that described the content of this item |
 
 
 
 
 
 
-<a name="services.universalwallet.v1.UpdateItemResponse"></a>
+<a name="services-universalwallet-v1-UpdateItemResponse"></a>
 
 ### UpdateItemResponse
 Update item response object
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  | Response status |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) | Response status |
 
 
 
 
 
- 
+ <!-- end messages -->
 
- 
+ <!-- end enums -->
 
- 
-
-
-<a name="services.universalwallet.v1.UniversalWallet"></a>
-
-### UniversalWallet
-
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| GetItem | [GetItemRequest](#services.universalwallet.v1.GetItemRequest) | [GetItemResponse](#services.universalwallet.v1.GetItemResponse) | Retrieve an item from the wallet with a given item identifier |
-| Search | [SearchRequest](#services.universalwallet.v1.SearchRequest) | [SearchResponse](#services.universalwallet.v1.SearchResponse) | Search the wallet using a SQL-like syntax |
-| InsertItem | [InsertItemRequest](#services.universalwallet.v1.InsertItemRequest) | [InsertItemResponse](#services.universalwallet.v1.InsertItemResponse) | Insert an item into the wallet |
-| UpdateItem | [UpdateItemRequest](#services.universalwallet.v1.UpdateItemRequest) | [UpdateItemResponse](#services.universalwallet.v1.UpdateItemResponse) | Insert an item into the wallet |
-| DeleteItem | [DeleteItemRequest](#services.universalwallet.v1.DeleteItemRequest) | [DeleteItemResponse](#services.universalwallet.v1.DeleteItemResponse) | Delete an item from the wallet permanently |
-
- 
+ <!-- end HasExtensions -->
 
 
 
-<a name="services/verifiable-credentials/templates/v1/templates.proto"></a>
+<a name="services_verifiable-credentials_templates_v1_templates-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## services/verifiable-credentials/templates/v1/templates.proto
 
 
 
-<a name="services.verifiablecredentials.templates.v1.CreateCredentialTemplateRequest"></a>
+<a name="services-verifiablecredentials-templates-v1-CredentialTemplates"></a>
+
+### Service - CredentialTemplates
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Create | [CreateCredentialTemplateRequest](/reference/proto#services-verifiablecredentials-templates-v1-CreateCredentialTemplateRequest) | [CreateCredentialTemplateResponse](/reference/proto#services-verifiablecredentials-templates-v1-CreateCredentialTemplateResponse) |  |
+| Get | [GetCredentialTemplateRequest](/reference/proto#services-verifiablecredentials-templates-v1-GetCredentialTemplateRequest) | [GetCredentialTemplateResponse](/reference/proto#services-verifiablecredentials-templates-v1-GetCredentialTemplateResponse) |  |
+| List | [ListCredentialTemplatesRequest](/reference/proto#services-verifiablecredentials-templates-v1-ListCredentialTemplatesRequest) | [ListCredentialTemplatesResponse](/reference/proto#services-verifiablecredentials-templates-v1-ListCredentialTemplatesResponse) |  |
+| Search | [SearchCredentialTemplatesRequest](/reference/proto#services-verifiablecredentials-templates-v1-SearchCredentialTemplatesRequest) | [SearchCredentialTemplatesResponse](/reference/proto#services-verifiablecredentials-templates-v1-SearchCredentialTemplatesResponse) |  |
+| Delete | [DeleteCredentialTemplateRequest](/reference/proto#services-verifiablecredentials-templates-v1-DeleteCredentialTemplateRequest) | [DeleteCredentialTemplateResponse](/reference/proto#services-verifiablecredentials-templates-v1-DeleteCredentialTemplateResponse) |  |
+
+ <!-- end services -->
+
+
+<a name="services-verifiablecredentials-templates-v1-CreateCredentialTemplateRequest"></a>
 
 ### CreateCredentialTemplateRequest
 Request to create new template
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  |  |
-| fields | [CreateCredentialTemplateRequest.FieldsEntry](#services.verifiablecredentials.templates.v1.CreateCredentialTemplateRequest.FieldsEntry) | repeated |  |
-| allow_additional_fields | [bool](#bool) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| name | [string](/reference/proto#string) |  |
+| fields | [CreateCredentialTemplateRequest.FieldsEntry](/reference/proto#services-verifiablecredentials-templates-v1-CreateCredentialTemplateRequest-FieldsEntry)[] |  |
+| allow_additional_fields | [bool](/reference/proto#bool) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.CreateCredentialTemplateRequest.FieldsEntry"></a>
+<a name="services-verifiablecredentials-templates-v1-CreateCredentialTemplateRequest-FieldsEntry"></a>
 
 ### CreateCredentialTemplateRequest.FieldsEntry
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [string](#string) |  |  |
-| value | [TemplateField](#services.verifiablecredentials.templates.v1.TemplateField) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| key | [string](/reference/proto#string) |  |
+| value | [TemplateField](/reference/proto#services-verifiablecredentials-templates-v1-TemplateField) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.CreateCredentialTemplateResponse"></a>
+<a name="services-verifiablecredentials-templates-v1-CreateCredentialTemplateResponse"></a>
 
 ### CreateCredentialTemplateResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| data | [TemplateData](#services.verifiablecredentials.templates.v1.TemplateData) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| data | [TemplateData](/reference/proto#services-verifiablecredentials-templates-v1-TemplateData) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.DeleteCredentialTemplateRequest"></a>
+<a name="services-verifiablecredentials-templates-v1-DeleteCredentialTemplateRequest"></a>
 
 ### DeleteCredentialTemplateRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| id | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.DeleteCredentialTemplateResponse"></a>
+<a name="services-verifiablecredentials-templates-v1-DeleteCredentialTemplateResponse"></a>
 
 ### DeleteCredentialTemplateResponse
 
@@ -1550,100 +1423,100 @@ Request to create new template
 
 
 
-<a name="services.verifiablecredentials.templates.v1.GetCredentialTemplateRequest"></a>
+<a name="services-verifiablecredentials-templates-v1-GetCredentialTemplateRequest"></a>
 
 ### GetCredentialTemplateRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| id | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.GetCredentialTemplateResponse"></a>
+<a name="services-verifiablecredentials-templates-v1-GetCredentialTemplateResponse"></a>
 
 ### GetCredentialTemplateResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| template | [TemplateData](#services.verifiablecredentials.templates.v1.TemplateData) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| template | [TemplateData](/reference/proto#services-verifiablecredentials-templates-v1-TemplateData) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.GetTemplateRequest"></a>
+<a name="services-verifiablecredentials-templates-v1-GetTemplateRequest"></a>
 
 ### GetTemplateRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| id | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.GetTemplateResponse"></a>
+<a name="services-verifiablecredentials-templates-v1-GetTemplateResponse"></a>
 
 ### GetTemplateResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| data | [TemplateData](#services.verifiablecredentials.templates.v1.TemplateData) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| data | [TemplateData](/reference/proto#services-verifiablecredentials-templates-v1-TemplateData) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.ListCredentialTemplatesRequest"></a>
+<a name="services-verifiablecredentials-templates-v1-ListCredentialTemplatesRequest"></a>
 
 ### ListCredentialTemplatesRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| query | [string](#string) |  | SELECT * FROM c WHERE c.name = &#39;Diploma&#39; |
-| continuation_token | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| query | [string](/reference/proto#string) | SELECT * FROM c WHERE c.name = 'Diploma' |
+| continuation_token | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.ListCredentialTemplatesResponse"></a>
+<a name="services-verifiablecredentials-templates-v1-ListCredentialTemplatesResponse"></a>
 
 ### ListCredentialTemplatesResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| templates | [TemplateData](#services.verifiablecredentials.templates.v1.TemplateData) | repeated |  |
-| has_more_results | [bool](#bool) |  |  |
-| continuation_token | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| templates | [TemplateData](/reference/proto#services-verifiablecredentials-templates-v1-TemplateData)[] |  |
+| has_more_results | [bool](/reference/proto#bool) |  |
+| continuation_token | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.ListTemplatesRequest"></a>
+<a name="services-verifiablecredentials-templates-v1-ListTemplatesRequest"></a>
 
 ### ListTemplatesRequest
 
@@ -1653,114 +1526,114 @@ Request to create new template
 
 
 
-<a name="services.verifiablecredentials.templates.v1.ListTemplatesResponse"></a>
+<a name="services-verifiablecredentials-templates-v1-ListTemplatesResponse"></a>
 
 ### ListTemplatesResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| templates | [TemplateData](#services.verifiablecredentials.templates.v1.TemplateData) | repeated |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| templates | [TemplateData](/reference/proto#services-verifiablecredentials-templates-v1-TemplateData)[] |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.SearchCredentialTemplatesRequest"></a>
+<a name="services-verifiablecredentials-templates-v1-SearchCredentialTemplatesRequest"></a>
 
 ### SearchCredentialTemplatesRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| query | [string](#string) |  | SELECT * FROM c WHERE c.name = &#39;Diploma&#39; |
-| continuation_token | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| query | [string](/reference/proto#string) | SELECT * FROM c WHERE c.name = 'Diploma' |
+| continuation_token | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.SearchCredentialTemplatesResponse"></a>
+<a name="services-verifiablecredentials-templates-v1-SearchCredentialTemplatesResponse"></a>
 
 ### SearchCredentialTemplatesResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| items_json | [string](#string) |  |  |
-| has_more | [bool](#bool) |  |  |
-| count | [int32](#int32) |  |  |
-| continuation_token | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| items_json | [string](/reference/proto#string) |  |
+| has_more | [bool](/reference/proto#bool) |  |
+| count | [int32](/reference/proto#int32) |  |
+| continuation_token | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.TemplateData"></a>
+<a name="services-verifiablecredentials-templates-v1-TemplateData"></a>
 
 ### TemplateData
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  |  |
-| name | [string](#string) |  |  |
-| version | [int32](#int32) |  |  |
-| fields | [TemplateData.FieldsEntry](#services.verifiablecredentials.templates.v1.TemplateData.FieldsEntry) | repeated |  |
-| allow_additional_fields | [bool](#bool) |  |  |
-| schema_uri | [string](#string) |  |  |
-| context_uri | [string](#string) |  |  |
-| ecosystem_id | [string](#string) |  |  |
-| type | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| id | [string](/reference/proto#string) |  |
+| name | [string](/reference/proto#string) |  |
+| version | [int32](/reference/proto#int32) |  |
+| fields | [TemplateData.FieldsEntry](/reference/proto#services-verifiablecredentials-templates-v1-TemplateData-FieldsEntry)[] |  |
+| allow_additional_fields | [bool](/reference/proto#bool) |  |
+| schema_uri | [string](/reference/proto#string) |  |
+| context_uri | [string](/reference/proto#string) |  |
+| ecosystem_id | [string](/reference/proto#string) |  |
+| type | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.TemplateData.FieldsEntry"></a>
+<a name="services-verifiablecredentials-templates-v1-TemplateData-FieldsEntry"></a>
 
 ### TemplateData.FieldsEntry
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [string](#string) |  |  |
-| value | [TemplateField](#services.verifiablecredentials.templates.v1.TemplateField) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| key | [string](/reference/proto#string) |  |
+| value | [TemplateField](/reference/proto#services-verifiablecredentials-templates-v1-TemplateField) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.templates.v1.TemplateField"></a>
+<a name="services-verifiablecredentials-templates-v1-TemplateField"></a>
 
 ### TemplateField
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| description | [string](#string) |  |  |
-| optional | [bool](#bool) |  |  |
-| type | [FieldType](#services.verifiablecredentials.templates.v1.FieldType) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| description | [string](/reference/proto#string) |  |
+| optional | [bool](/reference/proto#bool) |  |
+| type | [FieldType](/reference/proto#services-verifiablecredentials-templates-v1-FieldType) |  |
 
 
 
 
 
- 
+ <!-- end messages -->
 
 
-<a name="services.verifiablecredentials.templates.v1.FieldType"></a>
+<a name="services-verifiablecredentials-templates-v1-FieldType"></a>
 
 ### FieldType
 
@@ -1773,275 +1646,259 @@ Request to create new template
 | DATETIME | 4 |  |
 
 
- 
+ <!-- end enums -->
 
- 
-
-
-<a name="services.verifiablecredentials.templates.v1.CredentialTemplates"></a>
-
-### CredentialTemplates
-
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| Create | [CreateCredentialTemplateRequest](#services.verifiablecredentials.templates.v1.CreateCredentialTemplateRequest) | [CreateCredentialTemplateResponse](#services.verifiablecredentials.templates.v1.CreateCredentialTemplateResponse) |  |
-| Get | [GetCredentialTemplateRequest](#services.verifiablecredentials.templates.v1.GetCredentialTemplateRequest) | [GetCredentialTemplateResponse](#services.verifiablecredentials.templates.v1.GetCredentialTemplateResponse) |  |
-| List | [ListCredentialTemplatesRequest](#services.verifiablecredentials.templates.v1.ListCredentialTemplatesRequest) | [ListCredentialTemplatesResponse](#services.verifiablecredentials.templates.v1.ListCredentialTemplatesResponse) |  |
-| Search | [SearchCredentialTemplatesRequest](#services.verifiablecredentials.templates.v1.SearchCredentialTemplatesRequest) | [SearchCredentialTemplatesResponse](#services.verifiablecredentials.templates.v1.SearchCredentialTemplatesResponse) |  |
-| Delete | [DeleteCredentialTemplateRequest](#services.verifiablecredentials.templates.v1.DeleteCredentialTemplateRequest) | [DeleteCredentialTemplateResponse](#services.verifiablecredentials.templates.v1.DeleteCredentialTemplateResponse) |  |
-
- 
+ <!-- end HasExtensions -->
 
 
 
-<a name="services/verifiable-credentials/v1/verifiable-credentials.proto"></a>
+<a name="services_verifiable-credentials_v1_verifiable-credentials-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## services/verifiable-credentials/v1/verifiable-credentials.proto
 
 
 
-<a name="services.verifiablecredentials.v1.CheckStatusRequest"></a>
+<a name="services-verifiablecredentials-v1-VerifiableCredential"></a>
+
+### Service - VerifiableCredential
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Issue | [IssueRequest](/reference/proto#services-verifiablecredentials-v1-IssueRequest) | [IssueResponse](/reference/proto#services-verifiablecredentials-v1-IssueResponse) | Sign and issue a verifiable credential from a submitted document. The document must be a valid JSON-LD document. |
+| IssueFromTemplate | [IssueFromTemplateRequest](/reference/proto#services-verifiablecredentials-v1-IssueFromTemplateRequest) | [IssueFromTemplateResponse](/reference/proto#services-verifiablecredentials-v1-IssueFromTemplateResponse) | Sign and issue a verifiable credential from a pre-defined template. This process will also add schema validation and revocation registry entry in the credential. |
+| CheckStatus | [CheckStatusRequest](/reference/proto#services-verifiablecredentials-v1-CheckStatusRequest) | [CheckStatusResponse](/reference/proto#services-verifiablecredentials-v1-CheckStatusResponse) | Check credential status by setting the revocation value |
+| UpdateStatus | [UpdateStatusRequest](/reference/proto#services-verifiablecredentials-v1-UpdateStatusRequest) | [UpdateStatusResponse](/reference/proto#services-verifiablecredentials-v1-UpdateStatusResponse) | Update credential status by setting the revocation value |
+| CreateProof | [CreateProofRequest](/reference/proto#services-verifiablecredentials-v1-CreateProofRequest) | [CreateProofResponse](/reference/proto#services-verifiablecredentials-v1-CreateProofResponse) | Create a proof from a signed document that is a valid verifiable credential and contains a signature from which a proof can be derived. |
+| VerifyProof | [VerifyProofRequest](/reference/proto#services-verifiablecredentials-v1-VerifyProofRequest) | [VerifyProofResponse](/reference/proto#services-verifiablecredentials-v1-VerifyProofResponse) | Verifies a proof by checking the signature value, and if possible schema validation, revocation status, and issuer status against a trust registry |
+| Send | [SendRequest](/reference/proto#services-verifiablecredentials-v1-SendRequest) | [SendResponse](/reference/proto#services-verifiablecredentials-v1-SendResponse) | Sends a document directly to a user's email within the given ecosystem |
+
+ <!-- end services -->
+
+
+<a name="services-verifiablecredentials-v1-CheckStatusRequest"></a>
 
 ### CheckStatusRequest
 request object to update the status of the revocation entry
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| credential_status_id | [string](#string) |  | the credential status id |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| credential_status_id | [string](/reference/proto#string) | the credential status id |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.CheckStatusResponse"></a>
+<a name="services-verifiablecredentials-v1-CheckStatusResponse"></a>
 
 ### CheckStatusResponse
 response object for update of status of revocation entry
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| revoked | [bool](#bool) |  | indicates if the status is revoked |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| revoked | [bool](/reference/proto#bool) | indicates if the status is revoked |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.CreateProofRequest"></a>
+<a name="services-verifiablecredentials-v1-CreateProofRequest"></a>
 
 ### CreateProofRequest
 Create Proof
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| reveal_document_json | [string](#string) |  | Optional document that describes which fields should be revealed in the generated proof. If specified, this document must be a valid JSON-LD frame. If this field is not specified, a default reveal document will be used and all fields in the signed document will be revealed |
-| item_id | [string](#string) |  | The item identifier that contains a record with a verifiable credential to be used for generating the proof. |
-| document_json | [string](#string) |  | A document that contains a valid verifiable credential with an unbound signature. The proof will be derived from this document directly. The document will not be stored in the wallet. |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| reveal_document_json | [string](/reference/proto#string) | Optional document that describes which fields should be revealed in the generated proof. If specified, this document must be a valid JSON-LD frame. If this field is not specified, a default reveal document will be used and all fields in the signed document will be revealed |
+| item_id | [string](/reference/proto#string) | The item identifier that contains a record with a verifiable credential to be used for generating the proof. |
+| document_json | [string](/reference/proto#string) | A document that contains a valid verifiable credential with an unbound signature. The proof will be derived from this document directly. The document will not be stored in the wallet. |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.CreateProofResponse"></a>
+<a name="services-verifiablecredentials-v1-CreateProofResponse"></a>
 
 ### CreateProofResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| proof_document_json | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| proof_document_json | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.IssueFromTemplateRequest"></a>
+<a name="services-verifiablecredentials-v1-IssueFromTemplateRequest"></a>
 
 ### IssueFromTemplateRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| template_id | [string](#string) |  |  |
-| values_json | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| template_id | [string](/reference/proto#string) |  |
+| values_json | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.IssueFromTemplateResponse"></a>
+<a name="services-verifiablecredentials-v1-IssueFromTemplateResponse"></a>
 
 ### IssueFromTemplateResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| document_json | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| document_json | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.IssueRequest"></a>
+<a name="services-verifiablecredentials-v1-IssueRequest"></a>
 
 ### IssueRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| document_json | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| document_json | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.IssueResponse"></a>
+<a name="services-verifiablecredentials-v1-IssueResponse"></a>
 
 ### IssueResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| signed_document_json | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| signed_document_json | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.SendRequest"></a>
+<a name="services-verifiablecredentials-v1-SendRequest"></a>
 
 ### SendRequest
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| email | [string](#string) |  |  |
-| did_uri | [string](#string) |  |  |
-| didcomm_invitation_json | [string](#string) |  |  |
-| document_json | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| email | [string](/reference/proto#string) |  |
+| did_uri | [string](/reference/proto#string) |  |
+| didcomm_invitation_json | [string](/reference/proto#string) |  |
+| document_json | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.SendResponse"></a>
+<a name="services-verifiablecredentials-v1-SendResponse"></a>
 
 ### SendResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.UpdateStatusRequest"></a>
+<a name="services-verifiablecredentials-v1-UpdateStatusRequest"></a>
 
 ### UpdateStatusRequest
 request object to update the status of the revocation entry
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| credential_status_id | [string](#string) |  | the credential status id |
-| revoked | [bool](#bool) |  | indicates if the status is revoked |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| credential_status_id | [string](/reference/proto#string) | the credential status id |
+| revoked | [bool](/reference/proto#bool) | indicates if the status is revoked |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.UpdateStatusResponse"></a>
+<a name="services-verifiablecredentials-v1-UpdateStatusResponse"></a>
 
 ### UpdateStatusResponse
 response object for update of status of revocation entry
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [services.common.v1.ResponseStatus](#services.common.v1.ResponseStatus) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| status | [services.common.v1.ResponseStatus](/reference/proto#services-common-v1-ResponseStatus) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.VerifyProofRequest"></a>
+<a name="services-verifiablecredentials-v1-VerifyProofRequest"></a>
 
 ### VerifyProofRequest
 Verify Proof
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| proof_document_json | [string](#string) |  |  |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| proof_document_json | [string](/reference/proto#string) |  |
 
 
 
 
 
 
-<a name="services.verifiablecredentials.v1.VerifyProofResponse"></a>
+<a name="services-verifiablecredentials-v1-VerifyProofResponse"></a>
 
 ### VerifyProofResponse
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| is_valid | [bool](#bool) |  | Indicates if the proof is valid |
-| validation_messages | [string](#string) | repeated | Validation messages that describe invalid verifications based on different factors, such as schema validation, proof verification, revocation registry membership, etc. If the proof is not valid, this field will contain detailed results where this verification failed. |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| is_valid | [bool](/reference/proto#bool) | Indicates if the proof is valid |
+| validation_messages | [string](/reference/proto#string)[] | Validation messages that describe invalid verifications based on different factors, such as schema validation, proof verification, revocation registry membership, etc. If the proof is not valid, this field will contain detailed results where this verification failed. |
 
 
 
 
 
- 
+ <!-- end messages -->
 
- 
+ <!-- end enums -->
 
- 
-
-
-<a name="services.verifiablecredentials.v1.VerifiableCredential"></a>
-
-### VerifiableCredential
-
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| Issue | [IssueRequest](#services.verifiablecredentials.v1.IssueRequest) | [IssueResponse](#services.verifiablecredentials.v1.IssueResponse) | Sign and issue a verifiable credential from a submitted document. The document must be a valid JSON-LD document. |
-| IssueFromTemplate | [IssueFromTemplateRequest](#services.verifiablecredentials.v1.IssueFromTemplateRequest) | [IssueFromTemplateResponse](#services.verifiablecredentials.v1.IssueFromTemplateResponse) | Sign and issue a verifiable credential from a pre-defined template. This process will also add schema validation and revocation registry entry in the credential. |
-| CheckStatus | [CheckStatusRequest](#services.verifiablecredentials.v1.CheckStatusRequest) | [CheckStatusResponse](#services.verifiablecredentials.v1.CheckStatusResponse) | Check credential status by setting the revocation value |
-| UpdateStatus | [UpdateStatusRequest](#services.verifiablecredentials.v1.UpdateStatusRequest) | [UpdateStatusResponse](#services.verifiablecredentials.v1.UpdateStatusResponse) | Update credential status by setting the revocation value |
-| CreateProof | [CreateProofRequest](#services.verifiablecredentials.v1.CreateProofRequest) | [CreateProofResponse](#services.verifiablecredentials.v1.CreateProofResponse) | Create a proof from a signed document that is a valid verifiable credential and contains a signature from which a proof can be derived. |
-| VerifyProof | [VerifyProofRequest](#services.verifiablecredentials.v1.VerifyProofRequest) | [VerifyProofResponse](#services.verifiablecredentials.v1.VerifyProofResponse) | Verifies a proof by checking the signature value, and if possible schema validation, revocation status, and issuer status against a trust registry |
-| Send | [SendRequest](#services.verifiablecredentials.v1.SendRequest) | [SendResponse](#services.verifiablecredentials.v1.SendResponse) | Sends a document directly to a user&#39;s email within the given ecosystem |
-
- 
+ <!-- end HasExtensions -->
 
 
 
@@ -2064,4 +1921,3 @@ Verify Proof
 | <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
 | <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
 | <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
-


### PR DESCRIPTION
- Fix links to other messages being local to the current page URL
  - Necessary for proper injection into other markdown documents
- Remove in-page Table of Contents
  - We already have a ToC in the sidebar.
- Move Services to beginning of each of file, from end
  - IMO, it makes sense to see the Service, and all the calls it defines, _before_ the types which are referenced by that Service definition.
- Prefix Service names with "Service - " to easily distinguish from messages
  - Just a markdown change, nothing with the actual names or protos has changed