### PR TITLE
Change `include_section()` macro to load file contents itself, and require full filename

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ This macro includes a section from another markdown file.
 Usage: `{{ include_section(file_name: str, section_name: str, include_heading: bool=False) }}`
 
 - `file_name` is the path, _relative to the docs root_, of the markdown file you wish to include a section from
+    - For example, to include a section from `sdk/docs/learn/intro.md`, you would use the path `learn/intro.md`
 - `section_name` is the name of the section you wish to include
 - `include_heading` controls whether or not to include the heading itself
 

--- a/docs/reference/services/wallet-service.md
+++ b/docs/reference/services/wallet-service.md
@@ -20,7 +20,7 @@ Trinsic supports the ability to insert verifiable credentials into a wallet simp
 
 When using an SDK to perform this operation, you will need to supply an [Insert Item Request](../proto/#insertitemrequest) object that follows the structure below:
 
-{{ include_section('reference/proto/', 'InsertItemRequest') }}
+{{ proto_obj('InsertItemRequest') }}
 
 Then you can supply it to the SDKs:
 
@@ -61,7 +61,7 @@ Then you can supply it to the SDKs:
 
 The output of this method will be a unique `itemId` that can be used as input where required. The response model looks like this:
 
-{{ include_section('reference/proto/', 'InsertItemResponse') }}
+{{ proto_obj('InsertItemResponse') }}
 
 ## Search / Query
 


### PR DESCRIPTION
The current implementation of the `include_section()` macro attempts to load page contents from the in-memory cache of already-loaded pages provided by the mkdocs environment.

However, mkdocs seems to load and process files breadth-first, so there is no guarantee the target page contents will be accessible from wherever this macro is called. For example, given the following directory structure:

```
- docs/
  - folder/
    - bar.md
  - foo.md
```

If `foo.md` attempts to use `include_section()` with a target of `folder/bar.md`, it will fail -- because while the Page will exist in `env.variables['navigation'].pages`, its `markdown` will be `None` because it has not been processed yet. 


I came across this issue when I was attempting to add a section to `docs/reference/index.md` explaining how to instantiate Service classes in each language, which failed because I was trying to include the `ServiceOptions` protobuf object, which exists in `docs/reference/proto/index.md` -- which had not yet been loaded.

This PR makes the following changes:
- `file_name` argument of `include_section()` must now be a full path with extension, instead of a relative URL that is matched against Page URLs
  - Example: `reference/proto/` -> `reference/proto/index.md`
- `include_section()` will now load the contents of the specified file itself, instead of looking for it in `env.variables['navigation'].pages`
- Updated `wallet-service.md` to use `proto_obj()` in two instances