### PR TITLE
Documentation updates

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,3 +18,52 @@ Our SDK is broken down into the following services:
 - [Template Service](./services/template-service.md)
 - [Trust Registry Service](./services/trust-registry-service.md)
 - [Wallet Service](./services/wallet-service.md)
+
+ 
+### Using an SDK Service
+
+If you are using one of the Trinsic SDKs, you will need to create an instance of a service in order to use it.
+
+=== "TypeScript"
+    ```typescript
+    const accountService = new AccountService();
+    ```
+
+=== "C#"
+    <!--codeinclude-->
+    ```csharp
+    [CreateProof](../../dotnet/Tests/Tests.cs) inside_block:accountServiceConstructor
+    ```
+    <!--/codeinclude-->
+
+=== "Python"
+    <!--codeinclude-->
+    ```python
+    [Insert Item Wallet](../../python/tests/test_trinsic_services.py) inside_block:accountServiceConstructor
+    ```
+    <!--/codeinclude-->
+
+=== "Go"
+    <!--codeinclude-->
+    ```golang
+    [CreateEcosystem](../../go/services/account_service_test.go) inside_block:accountServiceConstructor
+    ```
+    <!--/codeinclude-->
+
+=== "Java"
+    <!--codeinclude-->
+    ```java
+    [CreateEcosystem](../../java/src/test/java/trinsic/AccountServiceTest.java) inside_block:accountServiceConstructor
+    ```
+    <!--/codeinclude-->
+
+=== "Ruby"
+    ```ruby
+    account_service = Trinsic::AccountService.new(nil, Trinsic::trinsic_prod_server)
+    ```
+
+All service constructors also accept a [ServiceOptions](../proto/index.md#serviceoptions) object as an argument, allowing you to specify a default ecosystem and other configuration properties.
+
+{{ proto_obj('ServiceOptions') }}
+
+The exact structure of this object will depend on the language you are working with. You can always rely on your editor's intellisense when in doubt. 

--- a/docs/reference/services/account-service.md
+++ b/docs/reference/services/account-service.md
@@ -3,56 +3,6 @@
 When you need to manage trinsic account, you will most definitely interface with the Account Service. Below you will find information on how to work with
 the different procedures pertinent to the account service.
 
-### Construct Instance
-
-If you are using one of Trinsic SDK's, you will need to create an instance of the Account Service in order to use its different procedures/calls. Below you 
-will find how to instantiate the Account Service with default settings, by simply calling the constructor without passing any parameters.
-
-=== "TypeScript"
-    ```typescript
-    const accountService = new AccountService();
-    ```
-
-=== "C#"
-    <!--codeinclude-->
-    ```csharp
-    [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:accountServiceConstructor
-    ```
-    <!--/codeinclude-->
-
-=== "Python"
-    <!--codeinclude-->
-    ```python
-    [Insert Item Wallet](../../../python/tests/test_trinsic_services.py) inside_block:accountServiceConstructor
-    ```
-    <!--/codeinclude-->
-
-=== "Go"
-    <!--codeinclude-->
-    ```golang
-    [CreateEcosystem](../../../go/services/account_service_test.go) inside_block:accountServiceConstructor
-    ```
-    <!--/codeinclude-->
-
-=== "Java"
-    <!--codeinclude-->
-    ```java
-    [CreateEcosystem](../../../java/src/test/java/trinsic/AccountServiceTest.java) inside_block:accountServiceConstructor
-    ```
-    <!--/codeinclude-->
-
-=== "Ruby"
-    ```ruby
-    account_service = Trinsic::AccountService.new(nil, Trinsic::trinsic_prod_server)
-    ```
-
-The constructor also accepts an `options` object as an argument. It follows the same structure of [ServiceOptions](../proto/index.md#serviceoptions), with the following
-properties:
-
-{{ proto_obj('ServiceOptions') }}
-
-The exact structure of such object will depend on the language you are working with. You can always rely on your editor's intellisense when in doubt. 
-
 ### Sign In
 
 Create login credentials by signing into an existing account or creating a new one. As part of this procedure, you must provide a 

--- a/docs/reference/services/provider-service.md
+++ b/docs/reference/services/provider-service.md
@@ -1,6 +1,75 @@
 # Provider Service
 
-This service helps ecosystem providers with data management and onboarding. This service requires a security profile with administrative authorization access. This can be obtained during the deployment of your ecosystem infrastructure.
+The Provider Service helps ecosystem providers with data management and onboarding. This service requires a security profile with administrative authorization access. This can be obtained during the deployment of your ecosystem infrastructure.
+
+## Create Ecosystem
+
+Creates a new provider ecosystem
+
+=== "Trinsic CLI"
+    ```bash
+    trinsic provider create-ecosystem --name <ECOSYSTEM_NAME> --email <OWNER_EMAIL>
+    ```
+
+When using one of the SDKs, you must supply a [Create Ecosystem Request](../proto/index.md#createecosystemrequest) object.
+
+{{ proto_obj('CreateEcosystemRequest') }}
+
+Then you can supply it to SDK:
+
+=== "TypeScript"
+    <!--codeinclude-->
+    ```typescript
+    [CreateEcosystem](../../../node/test/ProviderService.ts) inside_block:createEcosystem
+    ```
+    <!--/codeinclude-->
+
+=== "C#"
+    <!--codeinclude-->
+    ```csharp
+    [CreateEcosystem](../../../dotnet/Tests/Tests.cs) inside_block:createEcosystem
+    ```
+    <!--/codeinclude-->
+
+=== "Python"
+    <!--codeinclude-->
+    ```python
+    [CreateEcosystem](../../../python/samples/ecosystem_demo.py) inside_block:createEcosystem
+    ```
+    <!--/codeinclude-->
+
+=== "Go"
+    <!--codeinclude-->
+    ```golang
+    [CreateEcosystem](../../../go/services/services_test.go) inside_block:createEcosystem
+    ```
+    <!--/codeinclude-->
+
+=== "Java"
+    <!--codeinclude-->
+    ```java
+    [CreateEcosystem](../../../java/src/test/java/trinsic/EcosystemsDemo.java) inside_block:createEcosystem
+    ```
+    <!--/codeinclude-->
+
+The response model is of type [Create Ecosystem Response](../proto/index.md#createecosystemresponse):
+
+{{ proto_obj('CreateEcosystemResponse') }}
+
+<!-- 
+// This call is not yet implemented
+## List Ecosystems
+
+Lists all available ecosystem for the current authentication context.
+
+When using one of the SDKs, you must supply an [List Ecosystem Request](../proto/index.md#listecosystemrequest) object. This object follows the model below:
+
+{{ proto_obj('ListEcosystemRequest') }}
+
+The response model is of type [List Ecosystem Response](../proto/index.md#listecosystemresponse):
+
+{{ proto_obj('ListEcosystemResponse') }} 
+-->
 
 ## Onboarding
 
@@ -130,72 +199,3 @@ Then you can supply it to SDK:
 The response model is of type [Invitation Status Response](../proto/index.md#invitationstatusresponse):
 
 {{ proto_obj('InvitationStatusResponse') }}
-
-## Create Ecosystem
-
-Creates a new provider ecosystem
-
-=== "Trinsic CLI"
-    ```bash
-    trinsic provider create-ecosystem --name <ECOSYSTEM_NAME> --email <OWNER_EMAIL>
-    ```
-
-When using one of the SDKs, you must supply an [Create Ecosystem Request](../proto/index.md#createecosystemrequest) object. This object follows the model below:
-
-{{ proto_obj('CreateEcosystemRequest') }}
-
-Then you can supply it to SDK:
-
-=== "TypeScript"
-    <!--codeinclude-->
-    ```typescript
-    [CreateEcosystem](../../../node/test/ProviderService.ts) inside_block:createEcosystem
-    ```
-    <!--/codeinclude-->
-
-=== "C#"
-    <!--codeinclude-->
-    ```csharp
-    [CreateEcosystem](../../../dotnet/Tests/Tests.cs) inside_block:createEcosystem
-    ```
-    <!--/codeinclude-->
-
-=== "Python"
-    <!--codeinclude-->
-    ```python
-    [CreateEcosystem](../../../python/samples/ecosystem_demo.py) inside_block:createEcosystem
-    ```
-    <!--/codeinclude-->
-
-=== "Go"
-    <!--codeinclude-->
-    ```golang
-    [CreateEcosystem](../../../go/services/services_test.go) inside_block:createEcosystem
-    ```
-    <!--/codeinclude-->
-
-=== "Java"
-    <!--codeinclude-->
-    ```java
-    [CreateEcosystem](../../../java/src/test/java/trinsic/EcosystemsDemo.java) inside_block:createEcosystem
-    ```
-    <!--/codeinclude-->
-
-The response model is of type [Create Ecosystem Response](../proto/index.md#createecosystemresponse):
-
-{{ proto_obj('CreateEcosystemResponse') }}
-
-<!-- 
-// This call is not yet implemented
-## List Ecosystems
-
-Lists all available ecosystem for the current authentication context.
-
-When using one of the SDKs, you must supply an [List Ecosystem Request](../proto/index.md#listecosystemrequest) object. This object follows the model below:
-
-{{ proto_obj('ListEcosystemRequest') }}
-
-The response model is of type [List Ecosystem Response](../proto/index.md#listecosystemresponse):
-
-{{ proto_obj('ListEcosystemResponse') }} 
--->

--- a/docs/reference/services/trust-registry-service.md
+++ b/docs/reference/services/trust-registry-service.md
@@ -125,7 +125,7 @@ Finally, each entity must be registered on a specific governance framework.
 
 === "Trinsic CLI"
     ```bash
-    trinsic trust-registry register-issuer \
+    trinsic trust-registry register-verifier \
         --egf http://hl7.org/fhir \
         --credential-type https://w3id.org/vaccination#VaccinationCertificate \
         --did did:example:fabre
@@ -175,7 +175,7 @@ Finally, each entity must be registered on a specific governance framework.
 
 
 ### Unregister Issuers
-To unregister an entity, include the credential type, the did, and the ecosystem governance framework. The credential type will be unregistered from that issuer.
+To unregister an issuer, include the credential type, the did, and the ecosystem governance framework. The credential type will be unregistered from that issuer.
 
 === "Trinsic CLI"
     ```bash
@@ -229,11 +229,11 @@ To unregister an entity, include the credential type, the did, and the ecosystem
 
 
 ### Unregister Verifiers
-To unregister an entity, include the credential type, the did, and the ecosystem governance framework. The credential type will be unregistered from that issuer.
+To unregister a verifier, include the credential type, the did, and the ecosystem governance framework. The credential type will be unregistered from that verifier.
 
 === "Trinsic CLI"
     ```bash
-    trinsic trust-registry unregister-issuer \
+    trinsic trust-registry unregister-verifier \
         --egf http://hl7.org/fhir \
         --credential-type https://w3id.org/vaccination#VaccinationCertificate \
         --did did:example:fabre


### PR DESCRIPTION
- Move information about instantiating instances of SDK Services from the `Account Service` page to the `SDK Overview` page
  - Also slightly rewrote prose of this section
- Moved information about the Create Ecosystem call from the bottom of the `Provider Service` page to the top
- Fixed erroneous references to `issuers` on the `Trust Registry` page (adding/removing verifiers used issuer text and CLI command)