### PR TITLE
Account Service documentation updates

### DIFF
--- a/docs/reference/services/wallet-service.md
+++ b/docs/reference/services/wallet-service.md
@@ -2,6 +2,11 @@
 
 The wallet service is the main interface for interacting with a cloud wallet. The service endpoints are designed to closely match the recommendations of the [Universal Wallet 2020 <small>:material-open-in-new:</small>](https://w3c-ccg.github.io/universal-wallet-interop-spec/){target=_blank} specification by W3C Community Credentials Group. The service exposes a gRPC interface and a set of data contracts as described in the specification. Our intention with this design is to bring it closer to interoperability as more implementations of this wallet appear in production.
 
+!!! question "Wallets vs Accounts"
+    Wallets and accounts are related and often interchangeable -- each account has an associated wallet, and operations on a wallet are performed using an account's access token.
+
+    Every account has exactly one wallet. 
+
 
 ## Create Wallet
 


### PR DESCRIPTION
- Added information explaining difference (or, rather, lack thereof) between Accounts and Wallets to the Account Service and Wallet Service documentation pages.
- Updated Account Service documentation to explain the nature of Authentication Tokens being opaque, serialized representations of account details + actual auth tokens.
  - Previously, documentation said that an account profile would be returned on a sign-in call; updated to state that an authentication token string will be returned instead.
- Added information about what a "protected" account profile is
- Added warning to make it clear that a sign-in response will return a _protected_ authentication token if signing in to a non-anonymous account
- Misc. updates to prose throughout 