### PR TITLE
Build protobuf documentation reference during docs release action

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -19,5 +19,6 @@ jobs:
           pip install -r ./docs/requirements.txt
           pip install -r ./python/requirements.txt
           pip install git+https://${{ secrets.MKDOCS_INSIDERS_TOKEN }}@github.com/squidfunk/mkdocs-material-insiders.git
+      - run: python ./devops/generate_proto_files.py --language docs # Generate protobuf documentation files
       - run: mkdocs gh-deploy --remote-branch gh-pages --site-dir ./docs-html --force
 

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -18,6 +18,7 @@ jobs:
       - run: |
           pip install -r ./docs/requirements.txt
           pip install -r ./python/requirements.txt
+          pip install -r ./devops/requirements.txt
           pip install git+https://${{ secrets.MKDOCS_INSIDERS_TOKEN }}@github.com/squidfunk/mkdocs-material-insiders.git
       - run: python ./devops/generate_proto_files.py --language docs # Generate protobuf documentation files
       - run: mkdocs gh-deploy --remote-branch gh-pages --site-dir ./docs-html --force


### PR DESCRIPTION
Modifies the `release-docs` GitHub action to build the Protobuf reference markdown file before building and shipping the docs.

Without this step, said Protobuf Reference will only be updated when a developer manually executes `devops/generate_proto_files.py` and pushes the file to the repo.


Thoughts:
- Maybe this should only happen when we release a new tagged version of the SDK?
  - Ensures that newer proto files, which haven't been released in the SDK yet, are not documented before they should be.