### PR TITLE
Fix ambiguous injection targets in `trust-registry-service.md` and `wallet-service.md`

### DIFF
--- a/docs/reference/services/trust-registry-service.md
+++ b/docs/reference/services/trust-registry-service.md
@@ -70,28 +70,28 @@ Finally, each entity must be registered on a specific governance framework.
 === "C#"
     <!--codeinclude-->
     ```csharp
-    [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:registerIssuer
+    [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:registerIssuerSample
     ```
     <!--/codeinclude-->
 
 === "Python"
     <!--codeinclude-->
     ```python
-    [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:registerIssuer
+    [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:registerIssuerSample
     ```
     <!--/codeinclude-->
 
 === "Go"
     <!--codeinclude-->
     ```golang
-    [RegisterIssuer](../../../go/services/services_test.go) inside_block:registerIssuer
+    [RegisterIssuer](../../../go/services/services_test.go) inside_block:registerIssuerSample
     ```
     <!--/codeinclude-->
 
 === "Java"
     <!--codeinclude-->
     ```java
-    [RegisterIssuer](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:registerIssuer
+    [RegisterIssuer](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:registerIssuerSample
     ```
     <!--/codeinclude-->
 
@@ -108,28 +108,28 @@ Finally, each entity must be registered on a specific governance framework.
 === "C#"
     <!--codeinclude-->
     ```csharp
-    [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:registerVerifier
+    [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:registerVerifierSample
     ```
     <!--/codeinclude-->
 
 === "Python"
     <!--codeinclude-->
     ```python
-    [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:registerVerifier
+    [Insert Item Wallet](../../../python/samples/trustregistry_demo.py) inside_block:registerVerifierSample
     ```
     <!--/codeinclude-->
 
 === "Go"
     <!--codeinclude-->
     ```golang
-    [RegisterIssuer](../../../go/services/services_test.go) inside_block:registerVerifier
+    [RegisterIssuer](../../../go/services/services_test.go) inside_block:registerVerifierSample
     ```
     <!--/codeinclude-->
 
 === "Java"
     <!--codeinclude-->
     ```java
-    [RegisterIssuer](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:registerVerifier
+    [RegisterIssuer](../../../java/src/test/java/trinsic/TrustRegistryDemo.java) inside_block:registerVerifierSample
     ```
     <!--/codeinclude-->
 

--- a/docs/reference/services/wallet-service.md
+++ b/docs/reference/services/wallet-service.md
@@ -87,35 +87,35 @@ The default query used in the commands below returns a full wallet result set. T
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
-    [SearchWallet](../../../web/test/WalletService.test.ts) inside_block:searchWallet
+    [SearchWallet](../../../web/test/WalletService.test.ts) inside_block:searchWalletBasic
     ```
     <!--/codeinclude-->
 
 === "C#"
     <!--codeinclude-->
     ```csharp
-    [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:searchWallet
+    [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:searchWalletBasic
     ```
     <!--/codeinclude-->
 
 === "Python"
     <!--codeinclude-->
     ```python
-    [Insert Item Wallet](../../../python/samples/vaccine_demo.py) inside_block:searchWallet
+    [Insert Item Wallet](../../../python/samples/vaccine_demo.py) inside_block:searchWalletBasic
     ```
     <!--/codeinclude-->
 
 === "Go"
     <!--codeinclude-->
     ```golang
-    [RegisterIssuer](../../../go/services/services_test.go) inside_block:searchWallet
+    [RegisterIssuer](../../../go/services/services_test.go) inside_block:searchWalletBasic
     ```
     <!--/codeinclude-->
 
 === "Java"
     <!--codeinclude-->
     ```java
-    [RegisterIssuer](../../../java/src/test/java/trinsic/VaccineDemo.java) inside_block:searchWallet
+    [RegisterIssuer](../../../java/src/test/java/trinsic/VaccineDemo.java) inside_block:searchWalletBasic
     ```
     <!--/codeinclude-->
 

--- a/dotnet/Tests/Tests.cs
+++ b/dotnet/Tests/Tests.cs
@@ -117,7 +117,7 @@ public class Tests
         var insertItemResponse = await walletService.InsertItemAsync(new() {ItemJson = credential.SignedDocumentJson});
         var itemId = insertItemResponse.ItemId;
         // }
-        // searchWallet() {
+        // searchWalletBasic() {
         var walletItems = await walletService.SearchAsync(new());
         // }
         _testOutputHelper.WriteLine($"Last wallet item:\n{walletItems.Items.Last()}");

--- a/dotnet/Tests/Tests.cs
+++ b/dotnet/Tests/Tests.cs
@@ -177,7 +177,7 @@ public class Tests
         // }
         
 
-        // registerIssuer() {
+        // registerIssuerSample() {
         await service.RegisterIssuerAsync(new() {
             DidUri = "did:example:test",
             GovernanceFrameworkUri = "https://example.com",
@@ -185,7 +185,7 @@ public class Tests
         });
         // }
 
-        // registerVerifier() {
+        // registerVerifierSample() {
         await service.RegisterVerifierAsync(new() {
             DidUri = "did:example:test",
             GovernanceFrameworkUri = "https://example.com",

--- a/go/services/services_test.go
+++ b/go/services/services_test.go
@@ -146,7 +146,7 @@ func TestVaccineCredentialsDemo(t *testing.T) {
 	fmt.Println("item id", itemID)
 	// }
 
-	// searchWallet() {
+	// searchWalletBasic() {
 	items, err := walletService.Search(context.Background(), &sdk.SearchRequest{})
 	// }
 	// searchWalletSQL() {

--- a/go/services/services_test.go
+++ b/go/services/services_test.go
@@ -221,7 +221,7 @@ func TestTrustRegistryDemo(t *testing.T) {
 	})
 	// }
 
-	// registerIssuer() {
+	// registerIssuerSample() {
 	registerIssuerResponse, err := service.RegisterIssuer(context.Background(), &sdk.RegisterIssuerRequest{
 		Authority:              &sdk.RegisterIssuerRequest_DidUri{DidUri: didURI},
 		CredentialTypeUri:      typeURI,
@@ -232,7 +232,7 @@ func TestTrustRegistryDemo(t *testing.T) {
 		return
 	}
 
-	// registerVerifier() {
+	// registerVerifierSample() {
 	registerVerifierResponse, err := service.RegisterVerifier(context.Background(), &sdk.RegisterVerifierRequest{
 		Authority:              &sdk.RegisterVerifierRequest_DidUri{DidUri: didURI},
 		PresentationTypeUri:    typeURI,

--- a/java/src/test/java/trinsic/TrustRegistryDemo.java
+++ b/java/src/test/java/trinsic/TrustRegistryDemo.java
@@ -27,11 +27,11 @@ public class TrustRegistryDemo {
         var frameworkResponse = service.registerGovernanceFramework(TrustRegistryOuterClass.AddFrameworkRequest.newBuilder().setGovernanceFramework(TrustRegistryOuterClass.GovernanceFramework.newBuilder().setGovernanceFrameworkUri(frameworkUri).build()).build()).get();
         // }
 
-        // registerIssuer() {
+        // registerIssuerSample() {
         service.registerIssuer(TrustRegistryOuterClass.RegisterIssuerRequest.newBuilder()
                 .setDidUri(didUri).setGovernanceFrameworkUri(frameworkUri).setCredentialTypeUri(typeUri).build());
         // }
-        // registerVerifier() {
+        // registerVerifierSample() {
         service.registerVerifier(TrustRegistryOuterClass.RegisterVerifierRequest.newBuilder().setDidUri(didUri).setGovernanceFrameworkUri(frameworkUri).setPresentationTypeUri(typeUri).build());
         // }
         // checkIssuerStatus() {

--- a/java/src/test/java/trinsic/VaccineDemo.java
+++ b/java/src/test/java/trinsic/VaccineDemo.java
@@ -69,7 +69,7 @@ public class VaccineDemo {
         System.out.println("item id = " + itemId);
         // }
 
-        // searchWallet() {
+        // searchWalletBasic() {
         var searchResponse = walletService.search(UniversalWalletOuterClass.SearchRequest.getDefaultInstance()).get();	
         // }
         // searchWalletSQL() {

--- a/python/samples/trustregistry_demo.py
+++ b/python/samples/trustregistry_demo.py
@@ -39,7 +39,7 @@ async def trustregistry_demo():
     )
     # }
 
-    # registerIssuer() {
+    # registerIssuerSample() {
     await service.register_issuer(
         request=RegisterIssuerRequest(
             did_uri=did_example_test,
@@ -49,7 +49,7 @@ async def trustregistry_demo():
     )
     # }
 
-    # registerVerifier() {
+    # registerVerifierSample() {
     await service.register_verifier(
         request=RegisterVerifierRequest(
             did_uri=did_example_test,

--- a/python/samples/vaccine_demo.py
+++ b/python/samples/vaccine_demo.py
@@ -108,7 +108,7 @@ async def vaccine_demo():
     item_id = insert_response.item_id
     # }
     print(f"item id = {item_id}")
-    # searchWallet() {
+    # searchWalletBasic() {
     wallet_items = await wallet_service.search()
     # }
     # searchWalletSQL() {


### PR DESCRIPTION
## `trust-registry-service.md`

We were injecting `registerIssuer()` and `registerVerifier()`, which was not a unique token -- this caused `unregisterIssuer()` and `unregisterVerifier()` to also be included.

Additionally, for Go, this also caused a `// Do absolutely nothing` comment to be included, because there was a block whose preceding line contained the token `registerIssuer` / `registerVerifier`.

I renamed these to `registerIssuerSample()` and `registerVerifierSample()`

<img src="https://user-images.githubusercontent.com/1294419/166825718-b1a0879c-86eb-4985-b924-dc2d9a543335.png" width="400"/>

## `wallet-service.md`

We were injecting `searchWallet()` which was ambiguous with `searchWalletSQL()`. Same problematic result as above.

Renamed it to `searchWalletBasic()`
