### PR TITLE
Add OIDC documentation first pass

### DIFF
--- a/docs/reference/other/openid.md
+++ b/docs/reference/other/openid.md
@@ -1,0 +1,113 @@
+# OpenID Credential Exchange Service
+
+## Overview
+Trinsic provides an [OpenID Connect <small>:material-open-in-new:</small>](https://openid.net/connect/){target=_blank} ("OIDC") service which enables verifiers to request credentials from a user's cloud wallet in a simple and secure way.
+
+This service does not require the use of Trinsic's SDKs in the user's browser, and is therefore lightweight and easy to integrate.
+
+!!! info "Credential Issuance"
+    Currently, Trinsic's OpenID Connect service only enables the sharing of a credential between holder and verifier. We plan to support issuance through this service at a later date.
+
+    In the meantime, use the [InsertItem](../services/wallet-service.md#insert-item) SDK call to store credentials in a holder's wallet.
+
+
+## Integration
+
+### OpenID Connect Protocol
+
+Because this is an OpenID Connect service, any compliant library may be used -- as long as it enables you to specify additional custom query parameters on the initial outbound URL.
+
+!!! note "OIDC Flow Implementation"
+
+    The specifics of the OpenID Connect protocol -- and how to implement it -- are out of scope for this documentation.
+
+    If you would like to see an example implementation of a verification flow against this service, see the [sample](#sample) below.
+
+### Configuration
+
+Configure your OIDC library with the following parameters:
+
+- `authority`
+    - Must be `https://connect.trinsic.cloud/`
+- `response_type`
+    - Must be `code`
+- `scope`
+    - Must be `openid`
+- `client_id`
+    - Any string which uniquely represents your client application
+    - In future, we may require registration of client IDs with Trinsic
+- `redirect_uri`
+    - The URI your user should be redirected to once they have completed (or canceled) the flow
+- **Additional Query Parameters**
+    - `trinsic:ecosystem`
+        - Name of Ecosystem to fetch credentials from
+        - Only credentials which were issued within this Ecosystem may be returned
+    - `trinsic:schema`
+        - Comma-separated list of Schema URLs
+        - Only credentials which match one of these schemas may be returned
+
+### Response Data
+
+Once the user has returned to your redirect URL, exchange the authorization code (added to your redirect URI as a query parameter named `code`) for an identity token using your OIDC library.
+
+You will receive a JSON object of the following form:
+
+```json
+{
+    "id_token": "{JWT containing same data as vp_token}",
+    "access_token":"invalid",
+    "token_type":"Bearer",
+    "vp_token":{
+        "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/bbs/v1",
+            ...
+        ],
+        "id":"{UUID of Holder Wallet}",
+        "type":[
+            ...,
+            "VerifiableCredential"
+        ],
+        "credentialSchema":{
+            ...
+        },
+        "credentialStatus":{
+            ...
+        },
+        "credentialSubject":{
+            ...
+        },
+        "issuanceDate":"{Issue date of credential}",
+        "issuer":"{DID of Issuer}",
+        "proof":{
+            ...
+        }
+    }
+}
+```
+
+!!! info "Credential Format"
+    Note that the above data has been modified for brevity. 
+
+    The `@context` and `type` arrays will contain additional entries which are specific to the credential.
+
+
+### Verify the Received Proof
+
+`vp_token` is a Verifiable Proof; before making use of its data, you must verify it. 
+
+This is as simple as [passing the proof to the Verify Proof call](../../services/credential-service/#verify-proof).
+
+
+!!! warning "Always Verify"
+    It may be tempting to simply take the data in `vp_token` and act upon it without first verifying the proof.
+
+    **Always verify the proof** before making use of its data. 
+
+    Without verification, the received proof is of no more value than an unsubstantiated claim made by your user.
+
+## Sample
+
+If you'd like to see how to implement a basic OIDC flow against this service, or just want to see it in action, check out our [client-side verification flow example <small>:material-open-in-new:</small>](https://replit.com/@trinsic/oidc-sample){target=_blank}.
+
+You'll need to fork the repl and follow the instructions in `README.md`.

--- a/docs/reference/other/openid.md
+++ b/docs/reference/other/openid.md
@@ -96,7 +96,7 @@ You will receive a JSON object of the following form:
 
 `vp_token` is a Verifiable Proof; before making use of its data, you must verify it. 
 
-This is as simple as [passing the proof to the Verify Proof call](../../services/credential-service/#verify-proof).
+This proof can be verified with any library that supports VC verifications for BBS+ signatures. It can also be verified using Transit's SDK; this is as simple as [passing the proof to the Verify Proof call](../../services/credential-service/#verify-proof).
 
 
 !!! warning "Always Verify"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,8 @@ nav:
       - Trust Registry Service: reference/services/trust-registry-service.md
       - Wallet Service: reference/services/wallet-service.md
       - Protocol Buffers Reference: reference/proto/index.md
+    - Other Services:
+      - OpenID Credential Exchange: reference/other/openid.md
   - Tools & SDKs:
     - Trinsic CLI: cli/index.md
     - Client-Side SDKs:


### PR DESCRIPTION
This PR adds documentation for the OIDC Service, under `Learn -> Other Services -> OpenID Credential Exchange`

Resolves #613 

**Notes**
- This page does not explain the OIDC flow itself -- rather, it simply tells users to use an OIDC library for their language of choice.
- This is a first pass, intended to make the information available.


**Future Work**
- Iterate on this page
  - Improve `Configuration` section
  - Add more detail to `Response Data` section
  - Maybe detail OIDC flow; maybe leave that out of scope. I'm not sure on this one.
- Explain the intricacies of server-driven vs. client-driven flow
  - Instruct users that client-driven has limited trust
  - Go over how to implement server-driven appropriately, through proper session management and use of `code_verifier/code_challenge` and `state`.
  - Even if we don't document the OIDC Protocol itself, I think we should still cover this specific area. It's important that we encourage healthy and secure patterns of implementation.
- Create OIDC Tutorial
  - Using a client library, create a basic implementation against this service from scratch.