### PR TITLE
protoc is already set up, don't download it for typescript release

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -36,10 +36,6 @@ jobs:
           githubToken: ${{ secrets.API_GITHUB_TOKEN }}
           overrideVersion: ${{ github.event.inputs.packageVersion }}
       - run: |
-          curl -L https://github.com/grpc/grpc-web/releases/download/1.2.1/protoc-gen-grpc-web-1.2.1-linux-x86_64 --output protoc-gen-grpc-web
-          chmod +x protoc-gen-grpc-web
-          $env:PATH += ":$PWD"
-
           npm install
           npm run build
           npm test


### PR DESCRIPTION
It's setup right here:
https://github.com/trinsic-id/sdk/pull/641/files#diff-787777221fa50b865a5480a2e74b1525e227d6e3b711cb1abc1992048845a2eaR30-R32