### PR TITLE
Remove ligatures from doc fonts

### DIFF
--- a/docs/_static/extra.css
+++ b/docs/_static/extra.css
@@ -12,7 +12,13 @@ h1, h2, h3 {
     --md-primary-fg-color:        #006BE5;
     --md-primary-fg-color--light: #B3D6FF;
     --md-primary-fg-color--dark:  #003B80;
-  }
+
+    font-variant-ligatures: none;
+}
+
+input {
+    font-variant-ligatures: none;
+}
 
 [data-md-color-scheme="slate"] {
     --md-hue: 200; /* [0, 360] */


### PR DESCRIPTION
This PR removes ligatures from the code blocks and search bar.

This means that certain pairs of characters, such as `=>`, `->`, `//`, etc. will no longer be merged together to produce fancy arrows / custom characters.

Ligatures may be fine for any individual developer's personal environment, but they are out of place in a documentation site.

Resolves #650 


### Before

<img src="https://user-images.githubusercontent.com/1294419/168674709-35632fa1-7f37-4bd2-99d4-50f1f2eea7cb.png" width="600">

### After

<img src="https://user-images.githubusercontent.com/1294419/168674740-3a594732-7bac-4aa2-add9-d70a7b1c27d3.png" width="600">
