### PR TITLE
Create `CredentialService.spec.ts` test to fix code injection

### DIFF
--- a/docs/reference/services/credential-service.md
+++ b/docs/reference/services/credential-service.md
@@ -24,7 +24,7 @@ Then you can supply it to SDK:
 === "TypeScript"
     <!--codeinclude-->
     ```typescript
-    [Issue Credential](../../../web/test/VaccineDemoShared.ts) inside_block:issueCredential
+    [Issue Credential](../../../web/test/CredentialService.spec.ts) inside_block:issueCredential
     ```
     <!--/codeinclude-->
 

--- a/web/test/CredentialService.spec.ts
+++ b/web/test/CredentialService.spec.ts
@@ -1,0 +1,41 @@
+import { AccountService, CredentialService, IssueRequest, IssueResponse, ServiceOptions } from "../src";
+// @ts-ignore
+import vaccineCertUnsigned from "./data/vaccination-certificate-unsigned.json";
+import {getTestServerOptions, set20SecTimeout} from "./env";
+
+
+let options: ServiceOptions = getTestServerOptions();
+
+describe("CredentialService Unit Tests", () => {
+  set20SecTimeout()
+  beforeAll(async () => {
+    let service = new AccountService(options);
+    options.authToken = await service.signIn();
+  });
+
+  it("Issue Credential From Template", async () => {
+    let credentialService = new CredentialService(options);
+    let accountService = new AccountService(options);
+
+    //Get account info so we can compare issued DID etc.
+    let info = await accountService.info();
+
+    //Set issuer DID of credential
+    let vaccineCert = Object.assign({}, vaccineCertUnsigned, {issuer: info.publicDid});
+    let credentialJSON = JSON.stringify(vaccineCert);
+
+    // issueCredential() {
+    const issueResponse = await credentialService.issueCredential(
+        IssueRequest.fromPartial({ documentJson: credentialJSON })
+    );
+    // }
+
+    expect(issueResponse?.signedDocumentJson).not.toBeNull();
+    const credential = JSON.parse(issueResponse?.signedDocumentJson);
+
+    expect(credential).not.toBeNull();
+    expect(credential.proof).not.toBeNull();
+    expect(credential.credentialSubject).toEqual(vaccineCert.credentialSubject);
+    expect(credential.issuer).toBe(info.publicDid);
+  });
+});


### PR DESCRIPTION
`credential-service.md` is currently targeting `VaccineDemoShared.ts` for its `issueCredential()` sample code.

However, `VaccineDemoShared.ts`, by nature of being a walkthrough-specific test suite, should be isolated and only referenced from the walkthrough itself. (Additionally, this walkthrough now issues from templates, not from a raw JSON-LD credential, so the sample code doesn't even exist to inject any longer).


This PR creates a new test file, `CredentialService.spec.ts`, which reimplements the test of issuing a raw JSON-LD credential. It also changes `credential-service.md` to inject from this test file.
