### PR TITLE
Vaccine Walkthrough C# Test Suite & Serialization Rewording

### DIFF
--- a/docs/walkthroughs/vaccination.md
+++ b/docs/walkthroughs/vaccination.md
@@ -103,7 +103,7 @@ The first step is to create an [ecosystem](/learn/ecosystems/), within which eve
 === "C#"
     <!--codeinclude-->
     ```csharp
-    [Create Ecosystem](../../dotnet/Tests/Tests.cs) inside_block:createEcosystem
+    [Create Ecosystem](../../dotnet/Tests/Samples/VaccineWalkthroughTests.cs) inside_block:createEcosystem
     ```
     <!--/codeinclude-->
 
@@ -242,17 +242,11 @@ The clinic's account will **issue** the credential, Allison's account will **hol
 === "C#"
     <!--codeinclude-->
     ```csharp
-    [Setup Wallets](../../dotnet/Tests/Tests.cs) inside_block:setupActors
+    [Setup Wallets](../../dotnet/Tests/Samples/VaccineWalkthroughTests.cs) inside_block:setupActors
     ```
     <!--/codeinclude-->
 
-    If you would like to save the account for future use, simply write the auth token to storage. Take care to store it in a secure location.
-
-    <!--codeinclude-->
-    ```csharp
-    [Save and Load Profile](../../dotnet/Tests/Tests.cs) inside_block:storeAndRecallProfile
-    ```
-    <!--/codeinclude-->
+    If you would like to save an account for future use, simply write the auth token to storage. Take care to store it in a secure location.
 
 === "Python"
     <!--codeinclude-->
@@ -261,13 +255,7 @@ The clinic's account will **issue** the credential, Allison's account will **hol
     ```
     <!--/codeinclude-->
 
-    If you would like to save the account for future use, simply write the auth token to storage. Take care to store it in a secure location.
-
-    <!--codeinclude-->
-    ```python
-    [Save and Load Profile](../../python/samples/vaccine_demo.py) inside_block:storeAndRecallProfile
-    ```
-    <!--/codeinclude-->
+    If you would like to save an account for future use, simply write the auth token to storage. Take care to store it in a secure location.
 
 === "Java"
     <!--codeinclude-->
@@ -276,13 +264,7 @@ The clinic's account will **issue** the credential, Allison's account will **hol
     ```
     <!--/codeinclude-->
 
-    If you would like to save the account for future use, simply write the auth token to storage. Take care to store it in a secure location.
-
-    <!--codeinclude-->
-    ```java
-    [Save and Load Profile](../../java/src/test/java/trinsic/VaccineDemo.java) inside_block:storeAndRecallProfile
-    ```
-    <!--/codeinclude-->
+    If you would like to save an account for future use, simply write the auth token to storage. Take care to store it in a secure location.
     
 === "Go"
     <!--codeinclude-->
@@ -291,13 +273,7 @@ The clinic's account will **issue** the credential, Allison's account will **hol
     ```
     <!--/codeinclude-->
 
-    If you would like to save the account for future use, simply write the auth token to storage. Take care to store it in a secure location.
-
-    <!--codeinclude-->
-    ```go
-    [Save and Load Profile](../../go/services/services_test.go) inside_block:storeAndRecallProfile
-    ```
-    <!--/codeinclude-->
+    If you would like to save an account for future use, simply write the auth token to storage. Take care to store it in a secure location.
 
 
 !!! note "Further Reading"
@@ -356,7 +332,7 @@ Templates are simply a list of the fields that a credential can have.
 === "C#"
     <!--codeinclude-->
     ```csharp
-    [Create Template](../../dotnet/Tests/Tests.cs) inside_block:createTemplate
+    [Create Template](../../dotnet/Tests/Samples/VaccineWalkthroughTests.cs) inside_block:createTemplate
     ```
     <!--/codeinclude-->
 
@@ -428,7 +404,7 @@ To issue a vaccine certificate, we'll use the template we created in the last st
 
 === "C#"
     <!--codeinclude-->
-    [C#](../../dotnet/Tests/Tests.cs) inside_block:issueCredential
+    [C#](../../dotnet/Tests/Samples/VaccineWalkthroughTests.cs) inside_block:issueCredential
     <!--/codeinclude-->
 
 === "Python"
@@ -519,7 +495,7 @@ Once Allison receives the credential, she or her wallet application can store it
 === "C#"
     <!--codeinclude-->
     ```csharp
-    [Store Credential](../../dotnet/Tests/Tests.cs) inside_block:storeCredential
+    [Store Credential](../../dotnet/Tests/Samples/VaccineWalkthroughTests.cs) inside_block:storeCredential
     ```
     <!--/codeinclude-->
 
@@ -576,7 +552,7 @@ Let's use the [CreateProof](../../reference/services/credential-service/#create-
 === "C#"
     <!--codeinclude-->
     ```csharp
-    [Share Credential](../../dotnet/Tests/Tests.cs) inside_block:shareCredential
+    [Share Credential](../../dotnet/Tests/Samples/VaccineWalkthroughTests.cs) inside_block:shareCredential
     ```
     <!--/codeinclude-->
 
@@ -634,7 +610,7 @@ Once the airline receives the proof, they can now verify it to ensure its authen
 === "C#"
     <!--codeinclude-->
     ```csharp
-    [Verify Credential](../../dotnet/Tests/Tests.cs) inside_block:verifyCredential
+    [Verify Credential](../../dotnet/Tests/Samples/VaccineWalkthroughTests.cs) inside_block:verifyCredential
     ```
     <!--/codeinclude-->
 
@@ -672,7 +648,7 @@ Once the airline receives the proof, they can now verify it to ensure its authen
     [web](https://github.com/trinsic-id/sdk/tree/main/web/test/VaccineDemoShared.ts)    
 
 === "C#"
-    This sample is available in our [dotnet](https://github.com/trinsic-id/sdk/blob/main/dotnet/Tests/Tests.cs#L42) directory. 
+    This sample is available in our [dotnet](https://github.com/trinsic-id/sdk/blob/main/dotnet/Tests/Samples/VaccineWalkthroughTests.cs) SDK repository. 
 
     <!-- TODO: include working replit embed -->
 

--- a/dotnet/Tests/Samples/VaccineWalkthroughTests.cs
+++ b/dotnet/Tests/Samples/VaccineWalkthroughTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Trinsic;
+using Trinsic.Sdk.Options.V1;
+using Trinsic.Services.Common.V1;
+using Trinsic.Services.VerifiableCredentials.Templates.V1;
+using Xunit;
+using Xunit.Abstractions;
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
+#pragma warning disable CS0618
+
+namespace Tests;
+
+[SuppressMessage("ReSharper", "MethodHasAsyncOverload")]
+public class VaccineWalkthroughTests
+{
+    private const string DefaultEndpoint = "staging-internal.trinsic.cloud";
+    private const int DefaultPort = 443;
+    private const bool DefaultUseTls = true;
+
+    private readonly ITestOutputHelper _testOutputHelper;
+    private readonly ServiceOptions _options;
+
+    public VaccineWalkthroughTests(ITestOutputHelper testOutputHelper) {
+        _testOutputHelper = testOutputHelper;
+
+        _options = new() {
+            ServerEndpoint = Environment.GetEnvironmentVariable("TEST_SERVER_ENDPOINT") ?? DefaultEndpoint,
+            ServerPort = int.TryParse(Environment.GetEnvironmentVariable("TEST_SERVER_PORT"), out var port) ? port : DefaultPort,
+            ServerUseTls = bool.TryParse(Environment.GetEnvironmentVariable("TEST_SERVER_USE_TLS"), out var tls) ? tls : DefaultUseTls
+        };
+
+        _testOutputHelper.WriteLine($"Testing endpoint: {_options.FormatUrl()}");
+    }
+
+    [Fact(DisplayName = "Vaccine Walkthrough")]
+    public async Task TestWalkthrough() {
+        // createEcosystem() {
+        var providerService = new ProviderService(_options);
+
+        var (ecosystem, _) = await providerService.CreateEcosystemAsync(new());
+        var ecosystemId = ecosystem?.Id;
+        // }
+
+        ecosystemId.Should().NotBeNullOrEmpty();
+
+        // Set default ecosystem
+        providerService.Options.DefaultEcosystem = _options.DefaultEcosystem = ecosystemId;
+
+        // setupActors() {
+        var accountService = new AccountService(_options);
+
+        var allison = await accountService.SignInAsync(new() { EcosystemId = ecosystemId });
+        var clinic = await accountService.SignInAsync(new() { EcosystemId = ecosystemId });
+        var airline = await accountService.SignInAsync(new() { EcosystemId = ecosystemId });
+        // }
+
+        allison.Should().NotBeNullOrEmpty();
+        clinic.Should().NotBeNullOrEmpty();
+        airline.Should().NotBeNullOrEmpty();
+
+        // createTemplate() {
+        // Create a TemplateService instance
+        var templateService = new TemplateService(_options);
+
+        // Prepare request to create template
+        CreateCredentialTemplateRequest templateRequest = new() {
+            Name = "VaccinationCertificate",
+            AllowAdditionalFields = false
+        };
+
+        templateRequest.Fields.Add("firstName", new() { Description = "First name of vaccine recipient" });
+        templateRequest.Fields.Add("lastName", new() { Description = "Last name of vaccine recipient" });
+        templateRequest.Fields.Add("batchNumber", new() { Description = "Batch number of vaccine" });
+        templateRequest.Fields.Add("countryOfVaccination", new() { Description = "Country in which the subject was vaccinated" });
+
+        // Create template
+        var template = await templateService.CreateAsync(templateRequest);
+        var templateId = template?.Data?.Id;
+        // }
+
+
+        templateId.Should().NotBeNullOrEmpty();
+
+
+        // issueCredential() {
+        var credentialService = new CredentialsService(_options);
+
+        // Set active profile to 'clinic' so we can issue credential signed
+        // with the clinic's signing keys
+        credentialService.Options.AuthToken = clinic;
+
+        // Prepare credential values
+        var credentialValues = new Dictionary<string, string>() {
+            { "firstName", "Allison" },
+            { "lastName", "Allisonne" },
+            { "batchNumber", "123454321" },
+            { "countryOfVaccination", "US" }
+        };
+
+        // Issue credential
+        var issueResponse = await credentialService.IssueFromTemplateAsync(new() {
+            TemplateId = templateId,
+            ValuesJson = JsonSerializer.Serialize(credentialValues)
+        });
+
+        var signedCredential = issueResponse?.DocumentJson;
+        // }
+
+        signedCredential.Should().NotBeNullOrEmpty();
+
+        // storeCredential() {
+        var walletService = new WalletService(_options);
+
+        // Set active profile to 'allison' so we can manage her cloud wallet
+        walletService.Options.AuthToken = allison;
+
+        // Insert credential into Allison's wallet
+        var insertItemResponse = await walletService.InsertItemAsync(new() {
+            ItemJson = signedCredential
+        });
+
+        var itemId = insertItemResponse?.ItemId;
+        // }
+
+        itemId.Should().NotBeNullOrEmpty();
+
+
+        // shareCredential() {
+        // Set active profile to 'allison' so we can create a proof using her key
+        credentialService.Options.AuthToken = allison;
+
+        // Build a proof for the signed credential
+        var proofResponse = await credentialService.CreateProofAsync(new() {
+            ItemId = itemId
+        });
+
+        var proofJSON = proofResponse?.ProofDocumentJson;
+        // }
+
+        proofJSON.Should().NotBeNullOrEmpty();
+
+        // verifyCredential() {
+        // Verify that Allison has provided a valid proof
+        var verifyResponse = await credentialService.VerifyProofAsync(new() {
+            ProofDocumentJson = proofJSON
+        });
+
+        bool credentialValid = verifyResponse?.IsValid ?? false;
+        // }
+
+        credentialValid.Should().BeTrue();
+
+        _testOutputHelper.WriteLine($"Proof: {proofJSON}");
+    }
+}

--- a/dotnet/Tests/Tests.csproj
+++ b/dotnet/Tests/Tests.csproj
@@ -10,10 +10,11 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.2.0"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
-        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="FluentAssertions" Version="6.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+        <PackageReference Include="System.Collections" Version="4.3.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -28,7 +29,7 @@
         </PackageReference>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\Trinsic\Trinsic.csproj"/>
+        <ProjectReference Include="..\Trinsic\Trinsic.csproj" />
     </ItemGroup>
     <ItemGroup>
         <None Include="..\..\devops\testdata\vaccination-certificate-unsigned.jsonld">

--- a/dotnet/Trinsic/Trinsic.xml
+++ b/dotnet/Trinsic/Trinsic.xml
@@ -223,6 +223,43 @@
             blake3256 hash of the request body
             </summary>
         </member>
+        <member name="P:Trinsic.Services.Common.V1.Common.Descriptor">
+            <summary>Service descriptor</summary>
+        </member>
+        <member name="T:Trinsic.Services.Common.V1.Common.CommonBase">
+            <summary>Base class for server-side implementations of Common</summary>
+        </member>
+        <member name="T:Trinsic.Services.Common.V1.Common.CommonClient">
+            <summary>Client for Common</summary>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.CommonClient.#ctor(Grpc.Core.ChannelBase)">
+            <summary>Creates a new client for Common</summary>
+            <param name="channel">The channel to use to make remote calls.</param>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.CommonClient.#ctor(Grpc.Core.CallInvoker)">
+            <summary>Creates a new client for Common that uses a custom <c>CallInvoker</c>.</summary>
+            <param name="callInvoker">The callInvoker to use to make remote calls.</param>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.CommonClient.#ctor">
+            <summary>Protected parameterless constructor to allow creation of test doubles.</summary>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.CommonClient.#ctor(Grpc.Core.ClientBase.ClientBaseConfiguration)">
+            <summary>Protected constructor to allow creation of configured clients.</summary>
+            <param name="configuration">The client configuration.</param>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.CommonClient.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)">
+            <summary>Creates a new instance of client from given <c>ClientBaseConfiguration</c>.</summary>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.BindService(Trinsic.Services.Common.V1.Common.CommonBase)">
+            <summary>Creates service definition that can be registered with a server</summary>
+            <param name="serviceImpl">An object implementing the server-side handling logic.</param>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.BindService(Grpc.Core.ServiceBinderBase,Trinsic.Services.Common.V1.Common.CommonBase)">
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
+            Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
+            <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
+            <param name="serviceImpl">An object implementing the server-side handling logic.</param>
+        </member>
         <member name="T:Trinsic.Services.Account.V1.AccountReflection">
             <summary>Holder for reflection information generated from services/account/v1/account.proto</summary>
         </member>


### PR DESCRIPTION
- Vaccine walkthrough snippets for .NET are now injected from `dotnet/Tests/Samples/VaccineWalkthroughTests.cs`
- Removed sample code demonstrating the saving of account profiles to disk
  - They're just strings; people can figure that out on their own
  - Made more sense when they were actual objects