### PR TITLE
Vaccine Walkthrough `batchNumber` field type

### DIFF
--- a/docs/walkthroughs/vaccination.md
+++ b/docs/walkthroughs/vaccination.md
@@ -311,7 +311,7 @@ Templates are simply a list of the fields that a credential can have.
             "description": "Last name of vaccine recipient"
         },
         "batchNumber":{
-            "type": "string",
+            "type": "number",
             "description": "Batch number of vaccine"
         },
         "countryOfVaccination":{

--- a/dotnet/Tests/Samples/VaccineWalkthroughTests.cs
+++ b/dotnet/Tests/Samples/VaccineWalkthroughTests.cs
@@ -76,7 +76,7 @@ public class VaccineWalkthroughTests
 
         templateRequest.Fields.Add("firstName", new() { Description = "First name of vaccine recipient" });
         templateRequest.Fields.Add("lastName", new() { Description = "Last name of vaccine recipient" });
-        templateRequest.Fields.Add("batchNumber", new() { Description = "Batch number of vaccine" });
+        templateRequest.Fields.Add("batchNumber", new() { Description = "Batch number of vaccine", Type = FieldType.Number });
         templateRequest.Fields.Add("countryOfVaccination", new() { Description = "Country in which the subject was vaccinated" });
 
         // Create template

--- a/go/examples/vaccine_test.go
+++ b/go/examples/vaccine_test.go
@@ -17,7 +17,7 @@ func defineTemplate(templateService services.CredentialTemplateService, t *testi
 	templateRequest := &template.CreateCredentialTemplateRequest{Name: "VaccinationCertificate", AllowAdditionalFields: false, Fields: make(map[string]*template.TemplateField)}
 	templateRequest.Fields["firstName"] = &template.TemplateField{Description: "First name of vaccine recipient"}
 	templateRequest.Fields["lastName"] = &template.TemplateField{Description: "Last name of vaccine recipient"}
-	templateRequest.Fields["batchNumber"] = &template.TemplateField{Description: "Batch number of vaccine"}
+	templateRequest.Fields["batchNumber"] = &template.TemplateField{Description: "Batch number of vaccine", Type: template.FieldType_NUMBER}
 	templateRequest.Fields["countryOfVaccination"] = &template.TemplateField{Description: "Country in which the subject was vaccinated"}
 
 	createdTemplate, _ := templateService.Create(context.Background(), templateRequest)

--- a/python/samples/vaccine_demo.py
+++ b/python/samples/vaccine_demo.py
@@ -65,7 +65,7 @@ async def vaccine_demo():
     values = json.dumps(
         {
             "firstName": "Allison",
-            "lastName": Allisonne,
+            "lastName": "Allisonne",
             "batchNumber": "123454321",
             "countryOfVaccination": "US",
         }

--- a/python/samples/vaccine_demo.py
+++ b/python/samples/vaccine_demo.py
@@ -9,6 +9,7 @@ from trinsic.proto.services.verifiablecredentials.templates.v1 import (
     CreateCredentialTemplateRequest,
     TemplateData,
     TemplateField,
+    FieldType
 )
 from trinsic.proto.services.verifiablecredentials.v1 import (
     IssueFromTemplateRequest,
@@ -64,7 +65,7 @@ async def vaccine_demo():
     values = json.dumps(
         {
             "firstName": "Allison",
-            "lastName": "Allisonne",
+            "lastName": Allisonne,
             "batchNumber": "123454321",
             "countryOfVaccination": "US",
         }
@@ -148,10 +149,10 @@ async def do_template(template_service: TemplateService) -> TemplateData:
             name="VaccinationCertificate",
             allow_additional_fields=False,
             fields={
-                "firstName": TemplateField(description="Given name"),
-                "lastName": TemplateField(),
-                "batchNumber": TemplateField(description=""),
-                "countryOfVaccination": TemplateField(description=""),
+                "firstName": TemplateField(description="First name of vaccine recipient"),
+                "lastName": TemplateField(description="Last name of vaccine recipient"),
+                "batchNumber": TemplateField(description="Batch number of vaccine", type=FieldType.NUMBER),
+                "countryOfVaccination": TemplateField(description="Country in which the subject was vaccinated"),
             },
         )
     )

--- a/ruby/test/vaccine_demo.rb
+++ b/ruby/test/vaccine_demo.rb
@@ -15,7 +15,7 @@ def do_template(template_service)
                                                                       allow_additional_fields: false)
   request.fields['firstName'] = Trinsic::Template_V1::TemplateField.new(description: 'First name of vaccine recipient')
   request.fields['lastName'] = Trinsic::Template_V1::TemplateField.new(description: 'Last name of vaccine recipient')
-  request.fields['batchNumber'] = Trinsic::Template_V1::TemplateField.new(description: 'Batch number of vaccine')
+  request.fields['batchNumber'] = Trinsic::Template_V1::TemplateField.new(description: 'Batch number of vaccine', type: Trinsic::Template_V1::FieldType::NUMBER)
   request.fields['countryOfVaccination'] = Trinsic::Template_V1::TemplateField.new(description: 'Country in which the subject was vaccinated')
 
   template = template_service.create(request)

--- a/web/test/VaccineDemoShared.ts
+++ b/web/test/VaccineDemoShared.ts
@@ -115,7 +115,7 @@ async function doTemplate(templateService: TemplateService): Promise<TemplateDat
   });
 
   const batchNumberField = TemplateField.fromPartial({
-    type: FieldType.STRING,
+    type: FieldType.NUMBER,
     description: "Batch number of vaccine"
   });
 


### PR DESCRIPTION
This PR ensures the `batchNumber` field is of type `NUMBER` in all languages