### PR TITLE
Walkthrough: temporarily set `batchNumber` to string type

### DIFF
--- a/docs/walkthroughs/vaccination.md
+++ b/docs/walkthroughs/vaccination.md
@@ -288,7 +288,7 @@ Templates are simply a list of the fields that a credential can have.
             "description": "Last name of vaccine recipient"
         },
         "batchNumber":{
-            "type": "number",
+            "type": "string",
             "description": "Batch number of vaccine"
         },
         "countryOfVaccination":{

--- a/dotnet/Tests/Samples/VaccineWalkthroughTests.cs
+++ b/dotnet/Tests/Samples/VaccineWalkthroughTests.cs
@@ -76,7 +76,7 @@ public class VaccineWalkthroughTests
 
         templateRequest.Fields.Add("firstName", new() { Description = "First name of vaccine recipient" });
         templateRequest.Fields.Add("lastName", new() { Description = "Last name of vaccine recipient" });
-        templateRequest.Fields.Add("batchNumber", new() { Description = "Batch number of vaccine", Type = FieldType.Number });
+        templateRequest.Fields.Add("batchNumber", new() { Description = "Batch number of vaccine", Type = FieldType.String });
         templateRequest.Fields.Add("countryOfVaccination", new() { Description = "Country in which the subject was vaccinated" });
 
         // Create template

--- a/go/examples/vaccine_test.go
+++ b/go/examples/vaccine_test.go
@@ -17,7 +17,7 @@ func defineTemplate(templateService services.CredentialTemplateService, t *testi
 	templateRequest := &template.CreateCredentialTemplateRequest{Name: "VaccinationCertificate", AllowAdditionalFields: false, Fields: make(map[string]*template.TemplateField)}
 	templateRequest.Fields["firstName"] = &template.TemplateField{Description: "First name of vaccine recipient"}
 	templateRequest.Fields["lastName"] = &template.TemplateField{Description: "Last name of vaccine recipient"}
-	templateRequest.Fields["batchNumber"] = &template.TemplateField{Description: "Batch number of vaccine", Type: template.FieldType_NUMBER}
+	templateRequest.Fields["batchNumber"] = &template.TemplateField{Description: "Batch number of vaccine", Type: template.FieldType_STRING}
 	templateRequest.Fields["countryOfVaccination"] = &template.TemplateField{Description: "Country in which the subject was vaccinated"}
 
 	createdTemplate, _ := templateService.Create(context.Background(), templateRequest)
@@ -71,12 +71,12 @@ func TestVaccineDemo(t *testing.T) {
 	valuesStruct := struct {
 		FirstName            string
 		LastName             string
-		batchNumber          int
+		batchNumber          string
 		countryOfVaccination string
 	}{
 		FirstName:            "Allison",
 		LastName:             "Allisonne",
-		batchNumber:          123454321,
+		batchNumber:          "123454321",
 		countryOfVaccination: "US",
 	}
 	values, _ := json.Marshal(valuesStruct)

--- a/java/src/test/java/trinsic/VaccineDemo.java
+++ b/java/src/test/java/trinsic/VaccineDemo.java
@@ -133,7 +133,7 @@ public class VaccineDemo {
         var valuesMap = new HashMap<String, Object>();
         valuesMap.put("firstName", "Allison");
         valuesMap.put("lastName", "Allissonne");
-        valuesMap.put("batchNumber", 123454321);
+        valuesMap.put("batchNumber", "123454321");
         valuesMap.put("countryOfVaccination", "US");
 
         //Serialize values to JSON
@@ -167,7 +167,7 @@ public class VaccineDemo {
                 .setDescription("Last name of vaccine recipient")
                 .build());
         fields.put("batchNumber", Templates.TemplateField.newBuilder()
-                .setType(Templates.FieldType.NUMBER)
+                .setType(Templates.FieldType.STRING)
                 .setDescription("Batch number of vaccine")
                 .build());
         fields.put("countryOfVaccination", Templates.TemplateField.newBuilder()

--- a/python/samples/vaccine_demo.py
+++ b/python/samples/vaccine_demo.py
@@ -151,7 +151,7 @@ async def do_template(template_service: TemplateService) -> TemplateData:
             fields={
                 "firstName": TemplateField(description="First name of vaccine recipient"),
                 "lastName": TemplateField(description="Last name of vaccine recipient"),
-                "batchNumber": TemplateField(description="Batch number of vaccine", type=FieldType.NUMBER),
+                "batchNumber": TemplateField(description="Batch number of vaccine", type=FieldType.STRING),
                 "countryOfVaccination": TemplateField(description="Country in which the subject was vaccinated"),
             },
         )

--- a/ruby/test/vaccine_demo.rb
+++ b/ruby/test/vaccine_demo.rb
@@ -15,7 +15,7 @@ def do_template(template_service)
                                                                       allow_additional_fields: false)
   request.fields['firstName'] = Trinsic::Template_V1::TemplateField.new(description: 'First name of vaccine recipient')
   request.fields['lastName'] = Trinsic::Template_V1::TemplateField.new(description: 'Last name of vaccine recipient')
-  request.fields['batchNumber'] = Trinsic::Template_V1::TemplateField.new(description: 'Batch number of vaccine', type: Trinsic::Template_V1::FieldType::NUMBER)
+  request.fields['batchNumber'] = Trinsic::Template_V1::TemplateField.new(description: 'Batch number of vaccine', type: Trinsic::Template_V1::FieldType::STRING)
   request.fields['countryOfVaccination'] = Trinsic::Template_V1::TemplateField.new(description: 'Country in which the subject was vaccinated')
 
   template = template_service.create(request)

--- a/web/test/VaccineDemoShared.ts
+++ b/web/test/VaccineDemoShared.ts
@@ -115,7 +115,7 @@ async function doTemplate(templateService: TemplateService): Promise<TemplateDat
   });
 
   const batchNumberField = TemplateField.fromPartial({
-    type: FieldType.NUMBER,
+    type: FieldType.STRING,
     description: "Batch number of vaccine"
   });
 


### PR DESCRIPTION
There is currently a bug in prod (which has been fixed in dev) that causes verification of credentials to fail if a field is defined as a Number type.

Because the walkthrough runs against prod, until a new version of prod is deployed, the walkthrough is invalid.

This PR makes the walkthrough valid against the current version of prod.


When ready, this PR can be simply reverted.