### PR TITLE
Docs: Service Page Passes

### DIFF
--- a/docs/_static/extra.css
+++ b/docs/_static/extra.css
@@ -40,6 +40,12 @@ input {
 }
 
 
+/** Improve spacing of <hr/> between service page sections **/
+.md-typeset hr + h2,.md-typeset hr + h3 {
+    margin-top: 0em;
+}
+
+
 /***********************************************************
  * Protobuf Object Inclusion Macro Styles  ( proto_message() )
  ***********************************************************/

--- a/docs/learn/trust-registries.md
+++ b/docs/learn/trust-registries.md
@@ -1,0 +1,14 @@
+# Trust Registries
+
+In many real-world credential exchange scenarios, a credential holder or verifier has the question “How do I know the issuer of this credential is trustworthy?”
+
+Credential holders may also be uneasy about sharing information with a verifier if trust in the verifier has not been established.
+
+These problems can be solved by having a trusted third party vouch for the trustworthiness of a credential exchange participant.
+
+A trust registry is a list of authorized issuers and verifiers in the ecosystem and the types of credentials and passes they are authorized to issue and verify.
+
+## Specification
+The Trust over IP Foundation has a [specification](https://github.com/trustoverip/tswg-trust-registry-tf) for an interoperable trust registry. 
+
+Our implementation is based off of this spec.

--- a/docs/reference/services/account-service.md
+++ b/docs/reference/services/account-service.md
@@ -14,7 +14,9 @@ The Account Service allows you to create and sign in to accounts.
 
     These are effectively API keys; they should be kept safe and never published.
 
-### Sign In
+---
+
+## Sign In
 
 Sign in to an existing account, or create a new one.
 
@@ -75,7 +77,10 @@ This operation, if successful, returns an authentication token string.
 
     In the future, we will provide an SDK call to determine if an authentication token is protected.
 
-### Get Account Info
+
+---
+
+## Get Account Info
 
 Returns the account information (name, email address, phone number, etc.) used to create the currently-active account profile.
 
@@ -131,8 +136,9 @@ Returns the account information (name, email address, phone number, etc.) used t
 
     When using the SDK, this will return information for the authentication token stored in the `AccountService` instance's `ServiceOptions.AuthToken` field, which will be the account most recently logged in to, unless you have manually set this value yourself.
 
+---
 
-### Protect Account Profile
+## Protect Account Profile
 Protects the specified account profile with a security code. It is not possible to execute this call using the CLI.
 
 === "TypeScript"
@@ -182,8 +188,9 @@ Protects the specified account profile with a security code. It is not possible 
 
     Specifically, Trinsic is using Oberon to handle access tokens; protection and unprotection is handled using the blinding/unblinding features of Oberon.
 
+---
 
-### Unprotect Account Profile
+## Unprotect Account Profile
 Unprotects the specified account profile using the given code. It is not possible to execute this call using the CLI.
 
 The profile must have been previously protected using the same code that is being used to unprotect it. Profiles can be protected using any arbitrary code via the [Protect](#protect-account-profile) method.

--- a/docs/reference/services/provider-service.md
+++ b/docs/reference/services/provider-service.md
@@ -1,13 +1,20 @@
 # Provider Service
 
-The Provider Service helps ecosystem providers with data management and onboarding. This service requires a security profile with administrative authorization access. This can be obtained during the deployment of your ecosystem infrastructure.
+The Provider Service helps ecosystem providers with data management and onboarding. 
+
+!!! warning "Named / Production Ecosystems"
+    During the beta period, anyone may create an ecosystem with any name. As we move toward general availability of the platform, we will restrict the creation of named / production ecosystems.
+
+    Once this shift occurs, named ecosystems (suitable for production) will be created for you by Trinsic as part of your onboarding process.
+
+    Ecosystems with auto-generated names may be created by anyone for testing purposes, but these **may not** be used in production -- doing so is an unauthorized use of Trinsic's platform.
 
 
 ---
 
 ## Create Ecosystem
 
-Creates a new provider ecosystem
+Creates a new ecosystem, along with a root controlling account.
 
 {{proto_sample_start()}}
     === "Trinsic CLI"
@@ -51,6 +58,7 @@ Creates a new provider ecosystem
 
 {{ proto_method_tabs("services.provider.v1.Provider.CreateEcosystem") }}
 
+
 <!-- 
 // This call is not yet implemented
 ## List Ecosystems
@@ -66,120 +74,10 @@ The response model is of type [List Ecosystem Response](../proto/index.md#listec
 {{ proto_message('services.provider.v1.ListEcosystemResponse') }} 
 -->
 
+<!--
 
----
+Excluding invitation documentation pending re-thinking
 
-## Invite Participant
+To revert this, find the contents of this file before 6/9/2022 :~)
 
-Users can be added as participants in an ecosystem by sending an invitation and a security code. This code can be sent directly to the invitee using existing platforms or via email, SMS, etc.
-When users accept this invitation, they should do so using the service methods as described in [creating wallet with provider invitation](/reference/services/wallet-service/#create-wallet-with-provider-invitation)
-
-In Trinsic Ecosystems, participants can be Individuals or Organizations. This distinction is important, as providers have the ability to apply restrictions on what functionalities can be invoked by these participants. Additionally, Organizations have the ability to write their DID Document to a public ledger. Currently, the supported ledger is Sovrin, with ION and Element still in development.
-
-{{ proto_sample_start() }}
-    === "Trinsic CLI"
-        ```bash
-        trinsic provider invite --organization --method-email admin@faber.edu
-
-        trinsic provider invite --person --method-email alice@faber.edu
-        ```
-
-    === "TypeScript"
-        ```typescript
-        import { ProviderService, ParticipantType } from "@trinsic/trinsic";
-
-        const providerService = new ProviderService();
-
-        let inviteRequest = new InviteRequest();
-        inviteRequest.setParticipant(ParticipantType.PARTICIPANT_TYPE_ORGANIZATION);
-        inviteRequest.setEmail("admin@faber.edu");
-
-        const inviteResponse = await providerService.inviteParticipant(inviteRequest);
-
-        console.log(inviteResponse.getInvitationId());
-        ```
-
-    === "C#"
-        <!--codeinclude-->
-        ```csharp
-        [InviteRequest](../../../dotnet/Tests/Tests.cs) inside_block:inviteParticipant
-        ```
-        <!--/codeinclude-->
-
-    === "Python"
-        <!--codeinclude-->
-        ```python
-        [InviteRequest](../../../python/samples/ecosystem_demo.py) inside_block:inviteParticipant
-        ```
-        <!--/codeinclude-->
-
-    === "Go"
-        <!--codeinclude-->
-        ```golang
-        [InviteRequest](../../../go/services/services_test.go) inside_block:inviteParticipant
-        ```
-        <!--/codeinclude-->
-
-    === "Java"
-        <!--codeinclude-->
-        ```java
-        [InviteRequest](../../../java/src/test/java/trinsic/EcosystemsDemo.java) inside_block:inviteParticipant
-        ```
-        <!--/codeinclude-->
-
-{{ proto_method_tabs("services.provider.v1.Provider.Invite") }}
-
-The `invitation_code` in the response contains is security code that users must supply when creating their wallet. If the email method is used during onboarding, participants will receive this code in their email.
-
----
-
-## Check Invitation Status
-
-User invitation status can be checked with the provided `invitation id`. It returns an `InvitationStatusResponse` object.
-
-{{ proto_sample_start() }}
-    === "Trinsic CLI"
-        ```bash
-        trinsic provider invitation_status <INVITATION_ID>
-        ```
-
-    === "TypeScript"
-        ```typescript
-        import { ProviderService, ParticipantType } from "@trinsic/trinsic";
-
-        const providerService = new ProviderService();
-
-        const inviteResponse = await providerService.invitationStatus("INVITATION ID");
-
-        console.log(inviteResponse.getInvitationId());
-        ```
-
-    === "C#"
-        <!--codeinclude-->
-        ```csharp
-        [InvitationStatus](../../../dotnet/Tests/Tests.cs) inside_block:invitationStatus
-        ```
-        <!--/codeinclude-->
-
-    === "Python"
-        <!--codeinclude-->
-        ```python
-        [InvitationStatus](../../../python/samples/ecosystem_demo.py) inside_block:invitationStatus
-        ```
-        <!--/codeinclude-->
-
-    === "Go"
-        <!--codeinclude-->
-        ```golang
-        [InvitationStatus](../../../go/services/services_test.go) inside_block:invitationStatus
-        ```
-        <!--/codeinclude-->
-
-    === "Java"
-        <!--codeinclude-->
-        ```java
-        [InvitationStatus](../../../java/src/test/java/trinsic/EcosystemsDemo.java) inside_block:invitationStatus
-        ```
-        <!--/codeinclude-->
-
-{{ proto_method_tabs("services.provider.v1.Provider.InvitationStatus") }}
+-->

--- a/docs/reference/services/provider-service.md
+++ b/docs/reference/services/provider-service.md
@@ -2,10 +2,12 @@
 
 The Provider Service helps ecosystem providers with data management and onboarding. This service requires a security profile with administrative authorization access. This can be obtained during the deployment of your ecosystem infrastructure.
 
+
+---
+
 ## Create Ecosystem
 
 Creates a new provider ecosystem
-
 
 {{proto_sample_start()}}
     === "Trinsic CLI"
@@ -64,9 +66,10 @@ The response model is of type [List Ecosystem Response](../proto/index.md#listec
 {{ proto_message('services.provider.v1.ListEcosystemResponse') }} 
 -->
 
-## Onboarding
 
-### Invite Participant
+---
+
+## Invite Participant
 
 Users can be added as participants in an ecosystem by sending an invitation and a security code. This code can be sent directly to the invitee using existing platforms or via email, SMS, etc.
 When users accept this invitation, they should do so using the service methods as described in [creating wallet with provider invitation](/reference/services/wallet-service/#create-wallet-with-provider-invitation)
@@ -128,7 +131,9 @@ In Trinsic Ecosystems, participants can be Individuals or Organizations. This di
 
 The `invitation_code` in the response contains is security code that users must supply when creating their wallet. If the email method is used during onboarding, participants will receive this code in their email.
 
-### Check Invitation Status
+---
+
+## Check Invitation Status
 
 User invitation status can be checked with the provided `invitation id`. It returns an `InvitationStatusResponse` object.
 

--- a/docs/reference/services/template-service.md
+++ b/docs/reference/services/template-service.md
@@ -9,6 +9,7 @@ The Template Service allows you to manage and search [Credential Templates](/lea
 
     You aren't required to use templates; if you produce valid JSON-LD VCs yourself, they can be issued through Trinsic.
 
+---
 
 ## Create Template
 
@@ -59,6 +60,8 @@ In the background, Trinsic will also generate and save a valid JSON-LD Context a
 
 {{ proto_method_tabs("services.verifiablecredentials.templates.v1.CredentialTemplates.Create") }}
 
+---
+
 ## Get Template
 
 Fetches a template definition by `id`.
@@ -100,6 +103,8 @@ Fetches a template definition by `id`.
 
 {{ proto_method_tabs("services.verifiablecredentials.templates.v1.CredentialTemplates.Get") }}
 
+---
+
 ## Delete Template
 
 Deletes a credential template by `id`.
@@ -139,6 +144,8 @@ Deletes a credential template by `id`.
         <!--/codeinclude-->
 
 {{ proto_method_tabs("services.verifiablecredentials.templates.v1.CredentialTemplates.Delete") }}
+
+---
 
 ## Search Templates
 

--- a/docs/reference/services/trust-registry-service.md
+++ b/docs/reference/services/trust-registry-service.md
@@ -1,25 +1,17 @@
-# Trust Registry
+# Trust Registry Service
 
-In many real-world credential exchange scenarios, a credential holder or verifier has the question “How do I know the issuer of this credential is trustworthy?”
+The Trust Registry Service exposes functionality for managing [Trust Registries](/learn/trust-registries) -- lists of authorized issuers for the various credential types within an ecosystem.
 
-Credential holders may also be uneasy about sharing information with a verifier if trust in the verifier has not been established.
+!!! warning "Under Construction"
+    This section -- and the underlying API -- is under active development.
 
-These problems can be solved by having a trusted third party vouch for the trustworthiness of a credential exchange participant.
+    We are working to define exactly how Trust Registries will be implemented within our platform; this page and API may change as we do so.
 
-A trust registry is a list of authorized issuers and verifiers in the ecosystem and the types of credentials and passes they are authorized to issue and verify.
+---
 
-<diagram/>
+## Create Governance Framework
 
-## Specification
-The Trust over IP Foundation has a specification for an interoperable trust registry. 
-This defines an API interface so that trust registries can be queried in the same way.
-Our implementation is based off of this [trust registry spec](https://github.com/trustoverip/tswg-trust-registry-tf).
-
-## API Reference
-
-### Create a Ecosystem Governance Framework
-
-An ecosystem governance framework is useful because it provides a good basis for verifying issuers and verifiers. It's a json-ld document that lists the issuers and verifiers. These issuers and verifiers are identified by a decentralized identifier. The governance framework is signified by an identifier as well. This can be used to represent the governance framework outside in the credential that it comes in. 
+Creates a Governance Framework and attaches it to the current ecosystem.
 
 {{ proto_sample_start() }}
     === "Trinsic CLI"
@@ -57,10 +49,11 @@ An ecosystem governance framework is useful because it provides a good basis for
 
 {{ proto_method_tabs("services.trustregistry.v1.TrustRegistry.AddFramework") }}
 
+---
 
-### Register Issuers
-Each entity on the governance framework, whether an issuer or a verifier, is represented by a decentralized identifier. These entities are registered to either issue or verify specific credential types. A credential type is represented as a fully qualified `type` URI, of the kind found in a JSON-LD Verifiable Credential.
-Finally, each entity must be registered on a specific governance framework. 
+## Register Issuer
+
+Registers an authorized issuer for a specific credential type (identified by its `schema_uri`).
 
 {{ proto_sample_start() }}
     === "Trinsic CLI"
@@ -101,9 +94,12 @@ Finally, each entity must be registered on a specific governance framework.
 
 {{ proto_method_tabs("services.trustregistry.v1.TrustRegistry.RegisterMember") }}
 
+---
 
-### Unregister Issuers
-To unregister an issuer, include the credential type, the did, and the ecosystem governance framework. The credential type will be unregistered from that issuer.
+## Unregister Issuer
+
+Unregisters an issuer for a specific credential type (identified by its `schema_uri`).
+
 
 {{ proto_sample_start() }}
     === "Trinsic CLI"
@@ -144,10 +140,10 @@ To unregister an issuer, include the credential type, the did, and the ecosystem
 
 {{ proto_method_tabs("services.trustregistry.v1.TrustRegistry.UnregisterMember") }}
 
+---
 
-
-### Check Issuer Status
-Check the status of an issuer for a credential type within a given governance framework. Returns all historical data for the given input parameter.
+## Check Issuer Status
+Check the status of an issuer for a specific credential type.
 
 {{ proto_sample_start() }}
     === "Trinsic CLI"
@@ -188,8 +184,10 @@ Check the status of an issuer for a credential type within a given governance fr
 
 {{ proto_method_tabs("services.trustregistry.v1.TrustRegistry.GetMembershipStatus") }}
 
-### Search
-Search the registry for authoritative issuer and verifiers using a custom query in a SQL format.
+---
+
+## Search
+Search the registry for registered issuers using a SQL query.
 
 {{ proto_sample_start() }}
 
@@ -228,7 +226,9 @@ Search the registry for authoritative issuer and verifiers using a custom query 
     
 {{ proto_method_tabs("services.trustregistry.v1.TrustRegistry.SearchRegistry") }}
 
-### Cache Offline Registry File
+---
+
+## Cache Offline Registry File
 
 === "Trinsic CLI"
     ```bash

--- a/docs/reference/services/wallet-service.md
+++ b/docs/reference/services/wallet-service.md
@@ -10,12 +10,15 @@ The wallet service is the main interface for interacting with a cloud wallet.
 !!! info "Wallet Standard"
     This service is designed to follow the recommendations of the [Universal Wallet 2020 <small>:material-open-in-new:</small>](https://w3c-ccg.github.io/universal-wallet-interop-spec/){target=_blank} specification by the W3C Community Credentials Group.
 
+---
 
 ## Create Wallet
 
 A wallet is created whenever an account is created.
 
 Therefore, to create a wallet, you'll need to [create a new account](./account-service.md#sign-in).
+
+---
 
 ## Insert Item
 
@@ -73,6 +76,7 @@ Stores a credential (or any other JSON object) in a wallet.
 
     Otherwise, ensure its `item_type` is _not_ `VerifiableCredential`.
 
+---
 
 ## Search Wallet
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
       - Wallets: learn/wallets.md
       - Templates: learn/templates.md
       - Credentials: learn/credentials.md
+      - Trust Registries: learn/trust-registries.md
       - Standards: learn/standards.md
     - Tutorials:
       - Build a Vaccine Card: walkthroughs/vaccination.md


### PR DESCRIPTION
Resolves #647 

**Major Changes**

- Cleanup pass on `credential-service.md`, `trust-registry-service.md`, `provider-service.md`
- Added an `<hr/>` element between all major sections (method definitions) in all Service pages
- Removed documentation of ecosystem invitations, as this is in flux
- Cleaned up Trust Registries Service page
  - Added "under construction" banner to indicate highly-volatile nature of API
  - Moved some explanatory text to dedicated `Learn -> Trust Registries` page
  - General cleanup in line with other pages