### PR TITLE
Webhook method documentation, pending samples

### DIFF
--- a/docs/reference/services/account-service.md
+++ b/docs/reference/services/account-service.md
@@ -234,3 +234,30 @@ Most commonly, this method is used on a protected profile received from the [Sig
     ```ruby
     account_profile = account_service.unprotect(protected_profile, '1234')
     ```
+
+---
+
+## Authorize Webhook
+
+Authorizes the ecosystem provider to receive webhooks pertaining to this wallet.
+
+{{ proto_sample_start() }}
+    === "Trinsic CLI"
+        > Sample coming soon
+
+    === "TypeScript"
+        > Sample coming soon
+
+    === "C#"
+        > Sample coming soon
+
+    === "Python"
+        > Sample coming soon
+
+    === "Go"
+        > Sample coming soon
+
+    === "Java"
+        > Sample coming soon
+
+{{ proto_method_tabs("services.account.v1.Account.AuthorizeWebhook") }}

--- a/docs/reference/services/provider-service.md
+++ b/docs/reference/services/provider-service.md
@@ -1,6 +1,6 @@
 # Provider Service
 
-The Provider Service helps ecosystem providers with data management and onboarding. 
+The Provider Service enables the creation and management of ecosystems and webhooks.
 
 !!! warning "Named / Production Ecosystems"
     During the beta period, anyone may create an ecosystem with any name. As we move toward general availability of the platform, we will restrict the creation of named / production ecosystems.
@@ -58,6 +58,121 @@ Creates a new ecosystem, along with a root controlling account.
 
 {{ proto_method_tabs("services.provider.v1.Provider.CreateEcosystem") }}
 
+---
+
+## Update Ecosystem
+
+Updates an ecosystem's `description` or `uri`.
+
+{{proto_sample_start()}}
+    === "Trinsic CLI"
+        > Sample coming soon
+
+    === "TypeScript"
+        > Sample coming soon
+
+    === "C#"
+        > Sample coming soon
+
+    === "Python"
+        > Sample coming soon
+
+    === "Go"
+        > Sample coming soon
+
+    === "Java"
+        > Sample coming soon
+
+{{ proto_method_tabs("services.provider.v1.Provider.UpdateEcosystem") }}
+
+---
+
+## Get Ecosystem Info
+
+Fetches information about an ecosystem.
+
+{{ proto_sample_start() }}
+    === "Trinsic CLI"
+        > Sample coming soon
+
+    === "TypeScript"
+        > Sample coming soon
+
+    === "C#"
+        > Sample coming soon
+
+    === "Python"
+        > Sample coming soon
+
+    === "Go"
+        > Sample coming soon
+
+    === "Java"
+        > Sample coming soon
+
+{{ proto_method_tabs("services.provider.v1.Provider.EcosystemInfo") }}
+
+---
+
+## Add Webhook
+
+Adds a webhook to an ecosystem.
+
+{{ proto_sample_start() }}
+    === "Trinsic CLI"
+        > Sample coming soon
+
+    === "TypeScript"
+        > Sample coming soon
+
+    === "C#"
+        > Sample coming soon
+
+    === "Python"
+        > Sample coming soon
+
+    === "Go"
+        > Sample coming soon
+
+    === "Java"
+        > Sample coming soon
+
+{{ proto_method_tabs("services.provider.v1.Provider.AddWebhook") }}
+
+!!! warning "Webhook Limits"
+    At present, an ecosystem can have no more than 10 webhooks.
+
+!!! tip "Wallet Webhook Events"
+    In order to receive webhooks for events which occur on a wallet, an additional authorization step must be performed.
+
+    See [AuthorizeWebhook](/reference/services/account-service#authorize-webhook) for more info.
+
+---
+
+## Delete Webhook
+
+Deletes a webhook from an ecosystem.
+
+{{ proto_sample_start() }}
+    === "Trinsic CLI"
+        > Sample coming soon
+
+    === "TypeScript"
+        > Sample coming soon
+
+    === "C#"
+        > Sample coming soon
+
+    === "Python"
+        > Sample coming soon
+
+    === "Go"
+        > Sample coming soon
+
+    === "Java"
+        > Sample coming soon
+
+{{ proto_method_tabs("services.provider.v1.Provider.DeleteWebhook") }}
 
 <!-- 
 // This call is not yet implemented


### PR DESCRIPTION
- Adds documentation for Webhook-related methods
  - `AddWebhook`, `DeleteWebhook` in `provider-service.md`
  - `AuthorizeWebhook` in `account-service.md`
- Adds documentation for `UpdateEcosystem`, `EcosystemInfo` calls in `provider-service.md`
- Slight tweaks to `provider-service.md` prose


Samples are still pending for all these calls -- should be done AFTER the uniservice changes, as all our samples/tests must be updated regardless