### PR TITLE
.NET 1.6.0 tests + `LoginConfirm` overloads

### DIFF
--- a/docs/reference/services/account-service.md
+++ b/docs/reference/services/account-service.md
@@ -155,6 +155,31 @@ Returns the account information (name, email address, phone number, etc.) used t
 
 ---
 
+## Authorize Webhook
+
+Authorizes the ecosystem provider to receive webhooks pertaining to this wallet.
+
+{{ proto_sample_start() }}
+    === "Trinsic CLI"
+        > Sample coming soon
+    === "TypeScript"
+        > Sample coming soon
+    === "C#"
+        <!--codeinclude-->
+        ```csharp
+        [AuthorizeWebhook](../../../dotnet/Tests/Tests.cs) inside_block:authorizeWebhook
+        ```
+        <!--/codeinclude-->
+    === "Python"
+        > Sample coming soon
+    === "Go"
+        > Sample coming soon
+    === "Java"
+        > Sample coming soon
+{{ proto_method_tabs("services.account.v1.Account.AuthorizeWebhook") }}
+
+---
+
 ## Protect Account Profile
 Protects the specified account profile with a security code. It is not possible to execute this call using the CLI.
 

--- a/docs/reference/services/account-service.md
+++ b/docs/reference/services/account-service.md
@@ -16,67 +16,84 @@ The Account Service allows you to create and sign in to accounts.
 
 ---
 
-## Sign In
+## Login
 
-Sign in to an existing account, or create a new one.
+Attempts the first step of the login process for the specified account, creating it if it does not already exist.
 
-If no account details are passed to this method, an anonymous account will be created.
+Trinsic will response with a `challenge`, and send an authentication code to the account's email address.
+
+The authentication code must be passed along with `challenge` to [LoginConfirm](#login-confirm) to finalize the login.
 
 {{ proto_sample_start() }}
     === "Trinsic CLI" 
-        ```bash
-        trinsic account login --email <PROFILE_EMAIL> --name <PROFILE_NAME>
-        ```
+        > Sample coming soon
 
     === "TypeScript"
-        ```typescript
-        const allison = (await accountService.signIn()).getProfile();
-        ```
+        > Sample coming soon
 
     === "C#"
         <!--codeinclude-->
         ```csharp
-        [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:accountServiceSignIn
+        [LoginRequest](../../../dotnet/Tests/Tests.cs) inside_block:loginRequest
         ```
         <!--/codeinclude-->
 
     === "Python"
-        <!--codeinclude-->
-        ```python
-        [Insert Item Wallet](../../../python/tests/test_trinsic_services.py) inside_block:accountServiceSignIn
-        ```
-        <!--/codeinclude-->
+        > Sample coming soon
 
     === "Go"
-        <!--codeinclude-->
-        ```golang
-        [CreateEcosystem](../../../go/services/account_service_test.go) inside_block:accountServiceSignIn
-        ```
-        <!--/codeinclude-->
+        > Sample coming soon
 
     === "Java"
+        > Sample coming soon
+
+    === "Ruby"
+        > Sample coming soon
+
+{{ proto_method_tabs("services.account.v1.Account.Login") }}
+
+!!! tip "Anonymous Login"
+    Anonymous accounts are accounts which are not tied to any email or phone number, and do not require any authentication. They are typically used for testing and prototypes.
+
+    To create an anonymous account, use the `TrinsicService.LoginAnonymous()` method.
+
+---
+
+## Login Confirm
+
+Finalizes the login process.
+
+You must pass `challenge` as it was received in response to [Login](#login), along with the confirmation code that was sent in an email.
+
+Our SDK will take care of hashing the confirmation code for you.
+
+{{ proto_sample_start() }}
+    === "Trinsic CLI" 
+        > Sample coming soon
+
+    === "TypeScript"
+        > Sample coming soon
+
+    === "C#"
         <!--codeinclude-->
-        ```java
-        [CreateEcosystem](../../../java/src/test/java/trinsic/AccountServiceTest.java) inside_block:accountServiceSignIn
+        ```csharp
+        [LoginConfirm](../../../dotnet/Tests/Tests.cs) inside_block:loginConfirm
         ```
         <!--/codeinclude-->
 
+    === "Python"
+        > Sample coming soon
+
+    === "Go"
+        > Sample coming soon
+
+    === "Java"
+        > Sample coming soon
+
     === "Ruby"
-        ```ruby
-        allison = account_service.sign_in(nil).profile
-        ```
+        > Sample coming soon
 
-{{ proto_method_tabs("services.account.v1.Account.SignIn") }}
-
-This operation, if successful, returns an authentication token string.
-
-!!! warning "Protected Authentication Tokens"
-    If you are attempting to login to a non-anonymous account (by specifying an email address or phone number), the authentication token returned will be _protected_, and cannot be used until it has been unprotected.
-
-    Trinsic will have sent a security code to the account's email address or phone number; this security code must be used with the [Unprotect](#unprotect-account-profile) call to receive a usable authentication token.
-
-    In the future, we will provide an SDK call to determine if an authentication token is protected.
-
+{{ proto_method_tabs("services.account.v1.Account.LoginConfirm") }}
 
 ---
 
@@ -234,3 +251,71 @@ Most commonly, this method is used on a protected profile received from the [Sig
     ```ruby
     account_profile = account_service.unprotect(protected_profile, '1234')
     ```
+
+---
+
+## \[Deprecated\] Sign In
+
+!!! danger "Deprecated"
+    This endpoint is deprecated, and will be removed in the near future.
+
+    Please use [Login](#login) and [LoginConfirm](#login-confirm).
+
+Sign in to an existing account, or create a new one.
+
+If no account details are passed to this method, an anonymous account will be created.
+
+{{ proto_sample_start() }}
+    === "Trinsic CLI" 
+        ```bash
+        trinsic account login --email <PROFILE_EMAIL> --name <PROFILE_NAME>
+        ```
+
+    === "TypeScript"
+        ```typescript
+        const allison = (await accountService.signIn()).getProfile();
+        ```
+
+    === "C#"
+        <!--codeinclude-->
+        ```csharp
+        [CreateProof](../../../dotnet/Tests/Tests.cs) inside_block:accountServiceSignIn
+        ```
+        <!--/codeinclude-->
+
+    === "Python"
+        <!--codeinclude-->
+        ```python
+        [Insert Item Wallet](../../../python/tests/test_trinsic_services.py) inside_block:accountServiceSignIn
+        ```
+        <!--/codeinclude-->
+
+    === "Go"
+        <!--codeinclude-->
+        ```golang
+        [CreateEcosystem](../../../go/services/account_service_test.go) inside_block:accountServiceSignIn
+        ```
+        <!--/codeinclude-->
+
+    === "Java"
+        <!--codeinclude-->
+        ```java
+        [CreateEcosystem](../../../java/src/test/java/trinsic/AccountServiceTest.java) inside_block:accountServiceSignIn
+        ```
+        <!--/codeinclude-->
+
+    === "Ruby"
+        ```ruby
+        allison = account_service.sign_in(nil).profile
+        ```
+
+{{ proto_method_tabs("services.account.v1.Account.SignIn") }}
+
+This operation, if successful, returns an authentication token string.
+
+!!! warning "Protected Authentication Tokens"
+    If you are attempting to login to a non-anonymous account (by specifying an email address or phone number), the authentication token returned will be _protected_, and cannot be used until it has been unprotected.
+
+    Trinsic will have sent a security code to the account's email address or phone number; this security code must be used with the [Unprotect](#unprotect-account-profile) call to receive a usable authentication token.
+
+    In the future, we will provide an SDK call to determine if an authentication token is protected.

--- a/docs/reference/services/provider-service.md
+++ b/docs/reference/services/provider-service.md
@@ -72,7 +72,11 @@ Updates an ecosystem's `description` or `uri`.
         > Sample coming soon
 
     === "C#"
-        > Sample coming soon
+        <!--codeinclude-->
+        ```csharp
+        [UpdateEcosystem](../../../dotnet/Tests/Tests.cs) inside_block:updateEcosystem
+        ```
+        <!--/codeinclude-->
 
     === "Python"
         > Sample coming soon
@@ -99,7 +103,11 @@ Fetches information about an ecosystem.
         > Sample coming soon
 
     === "C#"
-        > Sample coming soon
+        <!--codeinclude-->
+        ```csharp
+        [EcosystemInfo](../../../dotnet/Tests/Tests.cs) inside_block:ecosystemInfo
+        ```
+        <!--/codeinclude-->
 
     === "Python"
         > Sample coming soon
@@ -126,7 +134,11 @@ Adds a webhook to an ecosystem.
         > Sample coming soon
 
     === "C#"
-        > Sample coming soon
+        <!--codeinclude-->
+        ```csharp
+        [AddWebhook](../../../dotnet/Tests/Tests.cs) inside_block:addWebhook
+        ```
+        <!--/codeinclude-->
 
     === "Python"
         > Sample coming soon
@@ -161,7 +173,11 @@ Deletes a webhook from an ecosystem.
         > Sample coming soon
 
     === "C#"
-        > Sample coming soon
+        <!--codeinclude-->
+        ```csharp
+        [DeleteWebhook](../../../dotnet/Tests/Tests.cs) inside_block:deleteWebhook
+        ```
+        <!--/codeinclude-->
 
     === "Python"
         > Sample coming soon

--- a/dotnet/Trinsic/AccountService.cs
+++ b/dotnet/Trinsic/AccountService.cs
@@ -155,18 +155,82 @@ public class AccountService : ServiceBase
     /// Finalizes login from a previous `LoginRequest`.
     /// </summary>
     /// <param name="request"></param>
-    /// <returns></returns>
-    public async Task<LoginConfirmResponse> LoginConfirmAsync(LoginConfirmRequest request) {
-        return await Client.LoginConfirmAsync(request);
+    /// <returns>Auth token on success; null on failure</returns>
+    public async Task<string?> LoginConfirmAsync(LoginConfirmRequest request) {
+        var response = await Client.LoginConfirmAsync(request);
+
+        // If profile is protected, or response is invalid, return null
+        if (response?.Profile?.Protection?.Enabled ?? true)
+        {
+            return null;
+        }
+
+        var token = Base64Url.Encode(response.Profile.ToByteArray());
+
+        await TokenProvider.SaveAsync(token);
+        return token;
     }
 
     /// <summary>
     /// Finalizes login from a previous `LoginRequest`.
     /// </summary>
     /// <param name="request"></param>
-    /// <returns></returns>
-    public LoginConfirmResponse LoginConfirm(LoginConfirmRequest request) {
-        return Client.LoginConfirm(request);
+    /// <returns>Auth token on success; null on failure</returns>
+    public string? LoginConfirm(LoginConfirmRequest request) {
+        var response = Client.LoginConfirm(request);
+
+        // If profile is protected, or response is invalid, return null
+        if (response?.Profile?.Protection?.Enabled ?? true)
+        {
+            return null;
+        }
+
+        var token = Base64Url.Encode(response.Profile.ToByteArray());
+
+        TokenProvider.Save(token);
+        return token;
+    }
+
+    /// <summary>
+    /// Creates an anonymous account in the current ecosystem
+    /// </summary>
+    /// <returns>Auth token for newly-created account; null on failure</returns>
+    public string? LoginAnonymous() {
+        var response = Login(new());
+
+        // `Profile` is returned on anonymous login only
+        if (response.ResponseCase != LoginResponse.ResponseOneofCase.Profile)
+            return null;
+
+        // If profile is protected, this is clearly not an anonymous login
+        if (response.Profile?.Protection?.Enabled ?? true)
+            return null;
+
+        var token = Base64Url.Encode(response.Profile.ToByteArray());
+        TokenProvider.Save(token);
+
+        return token;
+    }
+
+    /// <summary>
+    /// Creates an anonymous account in the current ecosystem
+    /// </summary>
+    /// <returns>Auth token for newly-created account; null on failure</returns>
+    public async Task<string?> LoginAnonymousAsync() {
+        var response = await LoginAsync(new());
+
+        // `Profile` is returned on anonymous login only
+        if (response.ResponseCase != LoginResponse.ResponseOneofCase.Profile)
+            return null;
+
+        // If profile is protected, this is clearly not an anonymous login
+        if (response.Profile?.Protection?.Enabled ?? true)
+            return null;
+
+        var token = Base64Url.Encode(response.Profile.ToByteArray());
+        await TokenProvider.SaveAsync(token);
+
+        return token;
     }
 
     /// <summary>

--- a/dotnet/Trinsic/AccountService.cs
+++ b/dotnet/Trinsic/AccountService.cs
@@ -174,6 +174,25 @@ public class AccountService : ServiceBase
     /// <summary>
     /// Finalizes login from a previous `LoginRequest`.
     /// </summary>
+    /// <param name="challenge">Challenge received from call to `Login`</param>
+    /// <param name="authCode">Plaintext authentication code sent to account email</param>
+    /// <returns>Auth token on success; null on failure</returns>
+    public async Task<string?> LoginConfirmAsync(ByteString challenge, string authCode) {
+        var hashed = Okapi.Hashing.Blake3.Hash(
+            new() {
+                Data = ByteString.CopyFromUtf8(authCode)
+            }
+        );
+
+        return await LoginConfirmAsync(new() {
+            Challenge = challenge,
+            ConfirmationCodeHashed = hashed.Digest
+        });
+    }
+
+    /// <summary>
+    /// Finalizes login from a previous `LoginRequest`.
+    /// </summary>
     /// <param name="request"></param>
     /// <returns>Auth token on success; null on failure</returns>
     public string? LoginConfirm(LoginConfirmRequest request) {
@@ -189,6 +208,25 @@ public class AccountService : ServiceBase
 
         TokenProvider.Save(token);
         return token;
+    }
+
+    /// <summary>
+    /// Finalizes login from a previous `LoginRequest`.
+    /// </summary>
+    /// <param name="challenge">Challenge received from call to `Login`</param>
+    /// <param name="authCode">Plaintext authentication code sent to account email</param>
+    /// <returns>Auth token on success; null on failure</returns>
+    public string? LoginConfirm(ByteString challenge, string authCode) {
+        var hashed = Okapi.Hashing.Blake3.Hash(
+            new() {
+                Data = ByteString.CopyFromUtf8(authCode)
+            }
+        );
+
+        return LoginConfirm(new() {
+            Challenge = challenge,
+            ConfirmationCodeHashed = hashed.Digest
+        });
     }
 
     /// <summary>

--- a/dotnet/Trinsic/Trinsic.xml
+++ b/dotnet/Trinsic/Trinsic.xml
@@ -70,14 +70,42 @@
             Finalizes login from a previous `LoginRequest`.
             </summary>
             <param name="request"></param>
-            <returns></returns>
+            <returns>Auth token on success; null on failure</returns>
+        </member>
+        <member name="M:Trinsic.AccountService.LoginConfirmAsync(Google.Protobuf.ByteString,System.String)">
+            <summary>
+            Finalizes login from a previous `LoginRequest`.
+            </summary>
+            <param name="challenge">Challenge received from call to `Login`</param>
+            <param name="authCode">Plaintext authentication code sent to account email</param>
+            <returns>Auth token on success; null on failure</returns>
         </member>
         <member name="M:Trinsic.AccountService.LoginConfirm(Trinsic.Services.Account.V1.LoginConfirmRequest)">
             <summary>
             Finalizes login from a previous `LoginRequest`.
             </summary>
             <param name="request"></param>
-            <returns></returns>
+            <returns>Auth token on success; null on failure</returns>
+        </member>
+        <member name="M:Trinsic.AccountService.LoginConfirm(Google.Protobuf.ByteString,System.String)">
+            <summary>
+            Finalizes login from a previous `LoginRequest`.
+            </summary>
+            <param name="challenge">Challenge received from call to `Login`</param>
+            <param name="authCode">Plaintext authentication code sent to account email</param>
+            <returns>Auth token on success; null on failure</returns>
+        </member>
+        <member name="M:Trinsic.AccountService.LoginAnonymous">
+            <summary>
+            Creates an anonymous account in the current ecosystem
+            </summary>
+            <returns>Auth token for newly-created account; null on failure</returns>
+        </member>
+        <member name="M:Trinsic.AccountService.LoginAnonymousAsync">
+            <summary>
+            Creates an anonymous account in the current ecosystem
+            </summary>
+            <returns>Auth token for newly-created account; null on failure</returns>
         </member>
         <member name="M:Trinsic.AccountService.GetInfoAsync">
             <summary>


### PR DESCRIPTION
- Adds documentation sections for `Login`, `LoginConfirm`, `AddWebhook`, `DeleteWebhook`, `AuthorizeWebhook`, `UpdateEcosystem`, `EcosystemInfo`
- Adds overload for `LoginConfirm` which handles hashing of auth code for caller
- Adds tests for `AddWebhook`, `RemoveWebhook`, `AuthorizeWebhook`, `Login`, `LoginConfirm`, `UpdateEcosystem`, `EcosystemInfo`
- Rewrites all tests, and vaccine walkthrough, to use uniservice