### PR TITLE
[cli] Add machine readable output format

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2245,7 +2245,6 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
- "indexmap",
  "okapi",
  "prost 0.9.0",
  "prost-types 0.9.0",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,6 @@ yaml-rust = "0.4"
 colored = "2"
 blake3 = "1.2"
 bytes = "1.1"
-indexmap = "1.8"
 
 [build-dependencies]
 tonic-build = { version = "0.6", features = ["prost", "rustfmt"] }

--- a/cli/rustfmt.toml
+++ b/cli/rustfmt.toml
@@ -1,5 +1,5 @@
 max_width = 150
 reorder_imports = true
-indent_style = "Block"
-binop_separator = "Back"
+# indent_style = "Block"
+# binop_separator = "Back"
 use_try_shorthand = true

--- a/cli/src/cli.yaml
+++ b/cli/src/cli.yaml
@@ -287,9 +287,15 @@ subcommands:
         - invitation_status:
             about: Check invitation status
 args:
+  - json:
+      long: json
+      short: j
+      help: Prints output in machine readable JSON format
+      takes_value: false
+      required: false
   - debug:
       long: debug
       short: d
-      help: (Optional) Print debug information.
+      help: Prints debug information
       takes_value: false
       required: false

--- a/cli/src/macros.rs
+++ b/cli/src/macros.rs
@@ -6,7 +6,6 @@ macro_rules! dict {
     ($($key:expr => $value:expr,)+) => { dict!($($key => $value),+) };
     ($($key:expr => $value:expr),*) => {
         {
-            let _cap = dict!(@count $($key),*);
             let mut _map = std::collections::BTreeMap::new();
             $(
                 _map.insert($key, $value);

--- a/cli/src/macros.rs
+++ b/cli/src/macros.rs
@@ -1,4 +1,22 @@
 #[macro_export]
+macro_rules! dict {
+    (@single $($x:tt)*) => (());
+    (@count $($rest:expr),*) => (<[()]>::len(&[$(dict!(@single $rest)),*]));
+
+    ($($key:expr => $value:expr,)+) => { dict!($($key => $value),+) };
+    ($($key:expr => $value:expr),*) => {
+        {
+            let _cap = dict!(@count $($key),*);
+            let mut _map = std::collections::BTreeMap::new();
+            $(
+                _map.insert($key, $value);
+            )*
+            _map
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! grpc_channel {
     ($x:expr) => {
         Channel::from_shared(&$x.options)?.connect().await?

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -63,10 +63,14 @@ fn main() {
     match parser::parse(&matches) {
         Ok(service) => match services::execute(&service, config) {
             Ok(output) => {
-                println!("{}", "ok".bold().green());
-                for (key, value) in output.iter() {
-                    print!("{} {} ", key.bold().yellow(), "→".bold().bright_black());
-                    println!("{}", value);
+                if matches.is_present("json") {
+                    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+                } else {
+                    println!("{}", "ok".bold().green());
+                    for (key, value) in output.iter() {
+                        print!("{} {} ", key.bold().yellow(), "→".bold().bright_black());
+                        println!("{}", serde_json::to_string_pretty(&value).unwrap());
+                    }
                 }
             }
             Err(err) => {

--- a/cli/src/services/account.rs
+++ b/cli/src/services/account.rs
@@ -1,8 +1,8 @@
 use super::config::CliConfig;
-use super::Output;
+use super::{Item, Output};
 use crate::parser::account::{Command, InfoArgs, SignInArgs};
 use crate::proto::services::account::v1::login_response::Response;
-use crate::MessageFormatter;
+use crate::utils::to_value;
 use crate::{
     error::Error,
     grpc_channel, grpc_client, grpc_client_with_auth,
@@ -52,7 +52,7 @@ async fn sign_in(args: &SignInArgs, config: CliConfig) -> Result<Output, Error> 
     new_config.save()?;
 
     let mut output = Output::new();
-    output.insert("auth token".into(), new_config.options.auth_token);
+    output.insert("auth token".into(), Item::String(new_config.options.auth_token));
 
     Ok(output)
 }
@@ -92,7 +92,7 @@ async fn info(_args: &InfoArgs, config: CliConfig) -> Result<Output, Error> {
     let response = client.info(request).await?.into_inner();
 
     let mut output = Output::new();
-    output.insert("account data".into(), response.to_string_pretty()?);
+    output.insert("account data".into(), Item::Json(to_value(&response)?));
 
     Ok(output)
 }

--- a/cli/src/services/config.rs
+++ b/cli/src/services/config.rs
@@ -1,4 +1,5 @@
 use crate::{
+    dict,
     error::Error,
     parser::config::ConfigCommand,
     proto::{
@@ -10,7 +11,6 @@ use crate::{
 use bytes::Bytes;
 use clap::ArgMatches;
 use colored::Colorize;
-use indexmap::indexmap;
 use okapi::{proto::security::CreateOberonProofRequest, Oberon};
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -73,7 +73,7 @@ impl Into<Bytes> for &ServiceOptions {
 
 use crate::DEBUG;
 
-use super::Output;
+use super::{Item, Output};
 
 impl From<&ArgMatches<'_>> for CliConfig {
     fn from(matches: &ArgMatches<'_>) -> Self {
@@ -186,13 +186,13 @@ pub(crate) fn execute(args: &ConfigCommand) -> Result<Output, Error> {
 fn print() -> Result<Output, Error> {
     let config = CliConfig::init()?.options;
 
-    Ok(indexmap! {
-        "path".into() => data_path()?.join(CONFIG_FILENAME).to_string_lossy().into(),
-        "server endpoint".into() => config.server_endpoint,
-        "server port".into() => config.server_port.to_string(),
-        "server use tls".into() => config.server_use_tls.to_string(),
-        "auth token".into() => config.auth_token,
-        "default ecosystem".into() => config.default_ecosystem
+    Ok(dict! {
+        "path".into() => Item::String(data_path()?.join(CONFIG_FILENAME).to_string_lossy().into()),
+        "server endpoint".into() => Item::String(config.server_endpoint),
+        "server port".into() => Item::String(config.server_port.to_string()),
+        "server use tls".into() => Item::String(config.server_use_tls.to_string()),
+        "auth token".into() => Item::String(config.auth_token),
+        "default ecosystem".into() => Item::String(config.default_ecosystem)
     })
 }
 

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -47,17 +47,3 @@ pub(crate) enum Item {
     String(String),
     Json(Value),
 }
-//type Output = IndexMap<String, String>;
-
-// impl Serialize for Output {
-//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-//     where
-//         S: serde::Serializer,
-//     {
-//         let mut map = serializer.serialize_map(Some(self.len()))?;
-//         for (key, value) in self {
-//             map.serialize_entry(key, value)?;
-//         }
-//         map.end()
-//     }
-// }

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -6,7 +6,10 @@ mod trustregistry;
 mod vc;
 mod wallet;
 
-use indexmap::IndexMap;
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use serde_json::Value;
 
 use self::config::CliConfig;
 use crate::error::Error;
@@ -36,5 +39,25 @@ pub(crate) enum Service<'a> {
     Unknown,
 }
 
-// type Output = BTreeMap<String, String>;
-type Output = IndexMap<String, String>;
+type Output = BTreeMap<String, Item>;
+
+#[derive(Serialize, Debug, PartialEq)]
+#[serde(untagged)]
+pub(crate) enum Item {
+    String(String),
+    Json(Value),
+}
+//type Output = IndexMap<String, String>;
+
+// impl Serialize for Output {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//     where
+//         S: serde::Serializer,
+//     {
+//         let mut map = serializer.serialize_map(Some(self.len()))?;
+//         for (key, value) in self {
+//             map.serialize_entry(key, value)?;
+//         }
+//         map.end()
+//     }
+// }

--- a/cli/src/utils/mod.rs
+++ b/cli/src/utils/mod.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Local, Utc};
+use serde::Serialize;
 use serde_json::{json, Value};
 use std::fs::{create_dir_all, OpenOptions};
 use std::io::{stdin, stdout, BufRead, Read, Write};
@@ -40,6 +41,14 @@ pub fn read_line(out: Option<&str>) -> String {
 
 pub(crate) fn prettify_json(json: &String) -> Result<String, Error> {
     Ok(serde_json::to_string_pretty(&serde_json::from_str::<Value>(json)?)?)
+}
+
+pub(crate) fn as_value(json: &String) -> Result<Value, Error> {
+    Ok(serde_json::from_str::<Value>(json)?)
+}
+
+pub(crate) fn to_value(message: &impl Serialize) -> Result<Value, Error> {
+    Ok(serde_json::from_slice::<Value>(&serde_json::to_vec(message)?)?)
 }
 
 pub(crate) fn write_file<P: AsRef<Path>>(path: P, data: &[u8]) -> Result<(), Error> {


### PR DESCRIPTION
Adds support for `--json` or `-j` flag to `trinsic` command which formats all output as JSON without color, suitable for processing with tools, like `jq` or `ConvertFrom-Json`

Bash
```bash
authToken=`trinsic --json config | jq -r '.["auth token"]'`
```

PowerShell
```pwsh
$config = trinsic --json config | ConvertFrom-Json
echo $config.'auth token'
```