### PR TITLE
Fix erroneous authentication for `login()`, `loginConfirm()`

### DIFF
--- a/dart/lib/src/service_base.dart
+++ b/dart/lib/src/service_base.dart
@@ -16,8 +16,8 @@ class MetadataInterceptor extends ClientInterceptor {
   static const skipRoutes = [
     "/services.account.v1.Account/SignIn",
     "/services.provider.v1.Provider/CreateEcosystem",
-    "/services.provider.v1.Provider/LogIn",
-    "/services.provider.v1.Provider/LogInConfirm",
+    "/services.provider.v1.Provider/Login",
+    "/services.provider.v1.Provider/LoginConfirm",
   ];
   late ServiceBase serviceContext;
   MetadataInterceptor(ServiceBase base) {

--- a/go/services/account_service.go
+++ b/go/services/account_service.go
@@ -153,11 +153,7 @@ func (a *accountBase) Protect(authtoken, securityCode string) (string, error) {
 }
 
 func (a *accountBase) Login(userContext context.Context, request *account.LoginRequest) (*account.LoginResponse, error) {
-	md, err := a.GetMetadataContext(userContext, request)
-	if err != nil {
-		return nil, err
-	}
-	response, err := a.client.Login(md, request)
+	response, err := a.client.Login(userContext, request)
 	if err != nil {
 		return nil, err
 	}
@@ -178,14 +174,8 @@ func (a *accountBase) LoginConfirm(userContext context.Context, challenge []byte
 		ConfirmationCodeHashed: codeHash.Digest,
 	}
 
-	// Generate metadata
-	md, err := a.GetMetadataContext(userContext, request)
-	if err != nil {
-		return "", err
-	}
-
 	// Send request
-	response, err := a.client.LoginConfirm(md, request)
+	response, err := a.client.LoginConfirm(userContext, request)
 	if err != nil {
 		return "", err
 	}

--- a/java/src/main/java/trinsic/services/AccountService.java
+++ b/java/src/main/java/trinsic/services/AccountService.java
@@ -103,7 +103,7 @@ public class AccountService extends ServiceBase {
 
   public ListenableFuture<AccountOuterClass.LoginResponse> login(
       AccountOuterClass.LoginRequest request) throws InvalidProtocolBufferException, DidException {
-    return withMetadata(stub, request).login(request);
+    return stub.login(request);
   }
 
   public ListenableFuture<String> loginConfirm(ByteString challenge, String authCode)
@@ -121,7 +121,7 @@ public class AccountService extends ServiceBase {
             .setConfirmationCodeHashed(hashed)
             .build();
 
-    var response = withMetadata(stub, request).loginConfirm(request);
+    var response = stub.loginConfirm(request);
 
     return Futures.transform(
         response,

--- a/java/src/main/java/trinsic/services/AccountServiceKt.kt
+++ b/java/src/main/java/trinsic/services/AccountServiceKt.kt
@@ -81,7 +81,7 @@ class AccountServiceKt(options: Options.ServiceOptions?) : ServiceBase(options) 
 
   @Throws(InvalidProtocolBufferException::class, DidException::class)
   suspend fun login(request: LoginRequest): LoginResponse {
-    return withMetadata(stub, request).login(request)
+    return stub.login(request)
   }
 
   @Throws(InvalidProtocolBufferException::class, DidException::class)
@@ -99,7 +99,7 @@ class AccountServiceKt(options: Options.ServiceOptions?) : ServiceBase(options) 
             .setConfirmationCodeHashed(hashed)
             .build()
 
-    val response = withMetadata(stub, request).loginConfirm(request)
+    val response = stub.loginConfirm(request)
     var authToken = Base64.getUrlEncoder().encodeToString(response.profile.toByteArray())
 
     if (response.profile.protection.enabled) {

--- a/python/trinsic/service_base.py
+++ b/python/trinsic/service_base.py
@@ -17,8 +17,8 @@ from trinsic.trinsic_util import trinsic_config, create_channel
 
 _skip_routes = [
     "/services.account.v1.Account/SignIn",
-    "/services.account.v1.Account/LogIn",
-    "/services.account.v1.Account/LogInConfirm",
+    "/services.account.v1.Account/Login",
+    "/services.account.v1.Account/LoginConfirm",
     "/services.provider.v1.Provider/CreateEcosystem",
 ]
 

--- a/ruby/lib/services/account_service.rb
+++ b/ruby/lib/services/account_service.rb
@@ -54,7 +54,7 @@ module Trinsic
     def login_confirm(challenge, auth_code)
       hashed = Okapi::Hashing.blake3_hash(Okapi::Hashing::V1::Blake3HashRequest.new(data: auth_code))
       request = Account::LoginConfirmRequest.new(challenge: challenge, confirmation_code_hashed: hashed.digest)
-      response = @client.login_confirm(request, metadata: metadata(request))
+      response = @client.login_confirm(request)
       return nil if response.profile.nil?
 
       profile = response.profile

--- a/web/src/AccountService.ts
+++ b/web/src/AccountService.ts
@@ -145,11 +145,7 @@ export class AccountService extends ServiceBase {
           email: "",
           invitationCode: "",
         });
-        let response = await this.client.login(request, {
-          metadata: await this.getMetadata(
-            ListDevicesRequest.encode(request).finish()
-          ),
-        });
+        let response = await this.client.login(request);
         if (response.profile === undefined) {
             throw new Error("undefined profile returned");
         }


### PR DESCRIPTION
In `Go`, `Java`, `Kotlin`, `Ruby`, `Python`,  and `Dart`, the `login()` / `loginConfirm()` functions were building authentication metadata for the requests, causing an error (as there will not necessarily be an auth token present)