### PR TITLE
Add all CLI commands from #769

### DIFF
--- a/cli/src/cli.yaml
+++ b/cli/src/cli.yaml
@@ -70,6 +70,14 @@ subcommands:
                   takes_value: true
                   required: false
                   help: (Optional) The ecosystem name or id to sign in
+        - authorize-webhook:
+            about: Authorizes ecosystem provider to receive webhooks for current account
+            args:
+              - events:
+                  long: events
+                  help: Comma-separated list of events to authorize, or "*" for all events
+                  takes_value: true
+                  required: true
         - info:
             about: Show account information
   - wallet:
@@ -255,6 +263,47 @@ subcommands:
                   help: Alias to use with this authentication profile
                   takes_value: true
                   required: false
+        - update-ecosystem:
+            about: Updates ecosystem description or URI
+            args:
+              - description:
+                  long: description
+                  help: New description for the ecosystem
+                  takes_value: true
+                  required: false
+              - uri:
+                  long: uri
+                  help: New URI for the ecosystem
+                  takes_value: true
+                  required: false
+        - ecosystem-info:
+            about: Fetches information about the current ecosystem
+        - add-webhook:
+            about: Adds a webhook to the ecosystem
+            args:
+              - url:
+                  long: url
+                  help: Destination URL of webhook
+                  takes_value: true
+                  required: true
+              - secret:
+                  long: secret
+                  help: Secret phrase used to sign and verify webhook payloads
+                  takes_value: true
+                  required: true
+              - events:
+                  long: events
+                  help: Comma-separated list of events webhook should receive, or "*" for all (default "*")
+                  takes_value: true
+                  required: false
+        - delete-webhook:
+            about: Deletes a webhook from the ecosystem
+            args:
+              - webhook-id:
+                  long: webhook-id
+                  help: ID of webhook to delete
+                  takes_value: true
+                  required: true
         - invite:
             about: Send an invitation
             args:

--- a/cli/src/parser/account.rs
+++ b/cli/src/parser/account.rs
@@ -7,6 +7,8 @@ pub(crate) fn parse<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> 
         sign_in(&args.subcommand_matches("login").expect("Error parsing request"))
     } else if args.is_present("info") {
         info(&args.subcommand_matches("info").expect("Error parsing request"))
+    } else if args.is_present("authorize-webhook") {
+        authorize_webhook(&args.subcommand_matches("authorize-webhook").expect("Error parsing request"))
     } else {
         Err(Error::MissingArguments)
     }
@@ -24,10 +26,25 @@ fn info<'a>(_args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
     Ok(Command::Info(InfoArgs {}))
 }
 
+fn authorize_webhook<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
+    // Get the events arg
+    let events_val: &'a str = args.value_of("events").unwrap();
+
+    // Split on comma
+    let split = events_val.split(",");
+
+    // Fill a Vec<String> with the split contents
+    let mut events = vec![];
+    events.extend(split.into_iter().map(|x| x.into()));
+
+    Ok(Command::AuthorizeWebhook(AuthorizeWebhookArgs { events }))
+}
+
 #[derive(Debug, PartialEq)]
 pub enum Command<'a> {
     SignIn(SignInArgs<'a>),
     Info(InfoArgs),
+    AuthorizeWebhook(AuthorizeWebhookArgs),
 }
 
 #[derive(Debug, PartialEq)]
@@ -39,3 +56,8 @@ pub struct SignInArgs<'a> {
 
 #[derive(Debug, PartialEq)]
 pub struct InfoArgs {}
+
+#[derive(Debug, PartialEq)]
+pub struct AuthorizeWebhookArgs {
+    pub events: Vec<String>,
+}

--- a/cli/src/parser/provider.rs
+++ b/cli/src/parser/provider.rs
@@ -5,8 +5,16 @@ use std::fmt::{self, Display, Formatter};
 pub(crate) fn parse<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
     if args.is_present("create-ecosystem") {
         create_ecosystem(&args.subcommand_matches("create-ecosystem").expect("Error parsing request"))
+    } else if args.is_present("update-ecosystem") {
+        update_ecosystem(&args.subcommand_matches("update-ecosystem").expect("Error parsing request"))
+    } else if args.is_present("ecosystem-info") {
+        ecosystem_info()
     } else if args.is_present("invite") {
         invite(&args.subcommand_matches("invite").expect("Error parsing request"))
+    } else if args.is_present("add-webhook") {
+        add_webhook(&args.subcommand_matches("add-webhook").expect("Error parsing request"))
+    } else if args.is_present("delete-webhook") {
+        delete_webhook(&args.subcommand_matches("delete-webhook").expect("Error parsing request"))
     } else {
         Err(Error::MissingArguments)
     }
@@ -20,6 +28,47 @@ fn create_ecosystem<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> 
     };
 
     Ok(Command::CreateEcosystem(ecosystem))
+}
+
+fn update_ecosystem<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
+    if !args.is_present("description") && !args.is_present("uri") {
+        return Err(Error::MissingArguments);
+    }
+
+    let args = UpdateEcosystemArgs {
+        description: args.value_of("description").map(|x| x.into()),
+        uri: args.value_of("uri").map(|x| x.into()),
+    };
+
+    Ok(Command::UpdateEcosystem(args))
+}
+
+fn ecosystem_info<'a>() -> Result<Command<'a>, Error> {
+    Ok(Command::EcosystemInfo)
+}
+
+fn add_webhook<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
+    // Get the events arg
+    let events_val: &'a str = args.value_of("events").unwrap_or("*");
+
+    // Split on comma
+    let split = events_val.split(",");
+
+    // Fill a Vec<String> with the split contents
+    let mut events = vec![];
+    events.extend(split.into_iter().map(|x| x.into()));
+
+    Ok(Command::AddWebhook(AddWebhookArgs {
+        url: args.value_of("url").map(|x| x.into()).unwrap(),
+        secret: args.value_of("secret").map(|x| x.into()).unwrap(),
+        events,
+    }))
+}
+
+fn delete_webhook<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
+    Ok(Command::DeleteWebhook(DeleteWebhookArgs {
+        webhook_id: args.value_of("webhook-id").map(|x| x.into()).unwrap(),
+    }))
 }
 
 fn invite<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
@@ -43,6 +92,10 @@ fn invite<'a>(args: &'a ArgMatches<'_>) -> Result<Command<'a>, Error> {
 #[derive(Debug, PartialEq)]
 pub enum Command<'a> {
     CreateEcosystem(CreateEcosystemArgs),
+    UpdateEcosystem(UpdateEcosystemArgs),
+    EcosystemInfo,
+    AddWebhook(AddWebhookArgs),
+    DeleteWebhook(DeleteWebhookArgs),
     Invite(InviteArgs<'a>),
     InvitationStatus,
 }
@@ -52,6 +105,24 @@ pub struct CreateEcosystemArgs {
     pub name: Option<String>,
     pub email: Option<String>,
     pub alias: String,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct UpdateEcosystemArgs {
+    pub description: Option<String>,
+    pub uri: Option<String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct AddWebhookArgs {
+    pub url: String,
+    pub secret: String,
+    pub events: Vec<String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct DeleteWebhookArgs {
+    pub webhook_id: String,
 }
 
 #[derive(Debug, PartialEq)]

--- a/cli/src/services/account.rs
+++ b/cli/src/services/account.rs
@@ -106,15 +106,11 @@ async fn authorize_webhook(args: &AuthorizeWebhookArgs, config: CliConfig) -> Re
 
     let req = AuthorizeWebhookRequest { events: args.events.clone() };
 
-    let req2 = AuthorizeWebhookRequest { events: args.events.clone() };
-
     let request = tonic::Request::new(req);
 
     let _response = client.authorize_webhook(request).await?.into_inner();
 
-    Ok(dict! {
-        "request".into() => Item::Json(to_value(&req2)?)
-    })
+    Ok(Output::new())
 }
 
 pub(crate) fn unprotect(profile: &mut AccountProfile, code: Vec<u8>) {

--- a/cli/src/services/provider.rs
+++ b/cli/src/services/provider.rs
@@ -1,5 +1,6 @@
 use super::Output;
 use super::{super::parser::provider::*, Item};
+use crate::proto::services::provider::v1::{AddWebhookRequest, DeleteWebhookRequest, EcosystemInfoRequest, UpdateEcosystemRequest};
 use crate::utils::to_value;
 use crate::{
     dict,
@@ -20,6 +21,10 @@ pub(crate) fn execute(args: &Command, config: CliConfig) -> Result<Output, Error
     match args {
         Command::Invite(args) => invite(args, &config),
         Command::CreateEcosystem(args) => create_ecosystem(args, &config),
+        Command::UpdateEcosystem(args) => update_ecosystem(args, &config),
+        Command::EcosystemInfo => ecosystem_info(&config),
+        Command::AddWebhook(args) => add_webhook(args, &config),
+        Command::DeleteWebhook(args) => delete_webhook(args, &config),
         Command::InvitationStatus => todo!(),
     }
 }
@@ -72,5 +77,73 @@ async fn create_ecosystem(args: &CreateEcosystemArgs, config: &CliConfig) -> Res
         "ecosystem".into() => Item::Json(to_value(&response.ecosystem
             .ok_or(Error::InvalidArgument("expected ecosystem object in response".to_string()))?)?),
         "auth token".into() => Item::String(auth_token)
+    })
+}
+
+#[tokio::main]
+async fn update_ecosystem(args: &UpdateEcosystemArgs, config: &CliConfig) -> Result<Output, Error> {
+    let mut client = grpc_client_with_auth!(ProviderClient<Channel>, config.to_owned());
+
+    let request = tonic::Request::new(UpdateEcosystemRequest {
+        description: args.description.as_ref().map_or(String::default(), |x| x.to_owned()),
+        uri: args.uri.as_ref().map_or(String::default(), |x| x.to_owned()),
+    });
+
+    let response = client.update_ecosystem(request).await?.into_inner();
+
+    Ok(dict! {
+        "ecosystem".into() => Item::Json(to_value(
+                &response.ecosystem.ok_or(Error::InvalidArgument("expected ecosystem object in response".to_string()))?
+        )?)
+    })
+}
+
+#[tokio::main]
+async fn ecosystem_info(config: &CliConfig) -> Result<Output, Error> {
+    let mut client = grpc_client_with_auth!(ProviderClient<Channel>, config.to_owned());
+
+    let request = tonic::Request::new(EcosystemInfoRequest {});
+    let response = client.ecosystem_info(request).await?.into_inner();
+
+    Ok(dict! {
+        "ecosystem".into() => Item::Json(to_value(
+                &response.ecosystem.ok_or(Error::InvalidArgument("expected ecosystem object in response".to_string()))?
+        )?)
+    })
+}
+
+#[tokio::main]
+async fn add_webhook(args: &AddWebhookArgs, config: &CliConfig) -> Result<Output, Error> {
+    let mut client = grpc_client_with_auth!(ProviderClient<Channel>, config.to_owned());
+
+    let request = tonic::Request::new(AddWebhookRequest {
+        events: args.events.clone(),
+        destination_url: args.url.clone(),
+        secret: args.secret.clone(),
+    });
+
+    let response = client.add_webhook(request).await?.into_inner();
+
+    Ok(dict! {
+        "ecosystem".into() => Item::Json(to_value(
+                &response.ecosystem.ok_or(Error::InvalidArgument("expected ecosystem object in response".to_string()))?
+        )?)
+    })
+}
+
+#[tokio::main]
+async fn delete_webhook(args: &DeleteWebhookArgs, config: &CliConfig) -> Result<Output, Error> {
+    let mut client = grpc_client_with_auth!(ProviderClient<Channel>, config.to_owned());
+
+    let request = tonic::Request::new(DeleteWebhookRequest {
+        webhook_id: args.webhook_id.clone(),
+    });
+
+    let response = client.delete_webhook(request).await?.into_inner();
+
+    Ok(dict! {
+        "ecosystem".into() => Item::Json(to_value(
+                &response.ecosystem.ok_or(Error::InvalidArgument("expected ecosystem object in response".to_string()))?
+        )?)
     })
 }

--- a/cli/src/services/trustregistry.rs
+++ b/cli/src/services/trustregistry.rs
@@ -136,7 +136,7 @@ async fn add_framework(args: &AddFrameworkArgs, config: &CliConfig) -> Result<Ou
 
     let response = client.add_framework(request).await?.into_inner();
 
-    Ok(dict!{
+    Ok(dict! {
         "response".into() => Item::Json(to_value(&response)?)
     })
 }


### PR DESCRIPTION
This PR adds the following CLI commands:

- `account authorize-webhook`
- `provider update-ecosystem`
- `provider ecosystem-info`
- `provider add-webhook`
- `provider delete-webhook`


Closes #769