### PR TITLE
1.6.0 CLI Command Documentation + Hide Ruby Samples

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -57,11 +57,6 @@ If you are using one of the Trinsic SDKs, you will need to create an instance of
     ```
     <!--/codeinclude-->
 
-=== "Ruby"
-    ```ruby
-    account_service = Trinsic::AccountService.new(nil, Trinsic::trinsic_prod_server)
-    ```
-
 All service constructors also accept a [ServiceOptions](../proto/index.md#serviceoptions) object as an argument, allowing you to specify a default ecosystem and other configuration properties.
 
 {{ proto_message('sdk.options.v1.ServiceOptions') }}

--- a/docs/reference/services/account-service.md
+++ b/docs/reference/services/account-service.md
@@ -65,9 +65,6 @@ The authentication code must be passed along with `challenge` to [LoginConfirm](
         ```
         <!--/codeinclude-->
 
-    === "Ruby"
-        > Sample coming soon
-
 {{ proto_method_tabs("services.account.v1.Account.Login") }}
 
 !!! tip "Anonymous Login"
@@ -128,9 +125,6 @@ Our SDK will take care of hashing the confirmation code for you.
         ```
         <!--/codeinclude-->
 
-    === "Ruby"
-        > Sample coming soon
-
 {{ proto_method_tabs("services.account.v1.Account.LoginConfirm") }}
 
 ---
@@ -178,10 +172,6 @@ Returns the account information (name, email address, phone number, etc.) used t
         ```
         <!--/codeinclude-->
 
-    === "Ruby"
-        ```ruby
-        info = account_service.get_info()
-        ```
 {{ proto_method_tabs("services.account.v1.Account.Info") }}
 
 !!! note
@@ -280,11 +270,6 @@ Protects the specified account profile with a security code. It is not possible 
     ```
     <!--/codeinclude-->
 
-=== "Ruby"
-    ```ruby
-    protected_profile = account_service.protect(account_profile, '1234')
-    ```
-
 !!! info
     In this context, "protection" refers to a cryptographic operation on the authorization token for an account.
 
@@ -340,10 +325,6 @@ Most commonly, this method is used on a protected profile received from the [Sig
     ```
     <!--/codeinclude-->
 
-=== "Ruby"
-    ```ruby
-    account_profile = account_service.unprotect(protected_profile, '1234')
-    ```
 
 ---
 
@@ -396,11 +377,6 @@ If no account details are passed to this method, an anonymous account will be cr
         [CreateEcosystem](../../../java/src/test/java/trinsic/AccountServiceTest.java) inside_block:accountServiceSignIn
         ```
         <!--/codeinclude-->
-
-    === "Ruby"
-        ```ruby
-        allison = account_service.sign_in(nil).profile
-        ```
 
 {{ proto_method_tabs("services.account.v1.Account.SignIn") }}
 

--- a/docs/reference/services/account-service.md
+++ b/docs/reference/services/account-service.md
@@ -189,7 +189,9 @@ Authorizes the ecosystem provider to receive webhooks pertaining to this wallet.
 
 {{ proto_sample_start() }}
     === "Trinsic CLI"
-        > CLI support for this endpoint coming soon
+        ```bash
+        trinsic account authorize-webhook --events "*"
+        ```
 
     === "TypeScript"
         <!--codeinclude-->

--- a/docs/reference/services/credential-service.md
+++ b/docs/reference/services/credential-service.md
@@ -317,13 +317,6 @@ Verifies a proof for validity and authenticity. Only supports BBS+ Signatures at
         ```
         <!--/codeinclude-->
 
-    === "Ruby"
-        <!--codeinclude-->
-        ```ruby
-        
-        ```
-        <!--/codeinclude-->
-
 {{ proto_method_tabs("services.verifiablecredentials.v1.VerifiableCredential.VerifyProof") }}
 
 ???+ info "Validation Results"

--- a/docs/reference/services/provider-service.md
+++ b/docs/reference/services/provider-service.md
@@ -66,7 +66,11 @@ Updates the active ecosystem's `description` or `uri`.
 
 {{proto_sample_start()}}
     === "Trinsic CLI"
-        > CLI support for this endpoint coming soon
+        ```bash
+        trinsic provider update-ecosystem \
+                         --description "New description" \
+                         --uri "https://new-example.com"
+        ```
 
     === "TypeScript"
         <!--codeinclude--> 
@@ -113,7 +117,9 @@ Fetches information about the active ecosystem.
 
 {{ proto_sample_start() }}
     === "Trinsic CLI"
-        > CLI support for this endpoint coming soon
+        ```bash
+        trinsic provider ecosystem-info
+        ```
 
     === "TypeScript"
         <!--codeinclude--> 
@@ -160,7 +166,12 @@ Adds a webhook to an ecosystem.
 
 {{ proto_sample_start() }}
     === "Trinsic CLI"
-        > CLI support for this endpoint coming soon
+        ```bash
+        trinsic provider add-webhook \
+                        --url "https://example.com/webhooks/trinsic" \
+                        --secret "my well-kept secret" \
+                        --events "*"
+        ```
 
     === "TypeScript"
         <!--codeinclude--> 
@@ -215,7 +226,9 @@ Deletes a webhook from an ecosystem.
 
 {{ proto_sample_start() }}
     === "Trinsic CLI"
-        > CLI support for this endpoint coming soon
+        ```bash
+        trinsic provider delete-webhook --webhook-id <WEBHOOK_ID>
+        ```
 
     === "TypeScript"
         <!--codeinclude--> 

--- a/docs/reference/services/wallet-service.md
+++ b/docs/reference/services/wallet-service.md
@@ -124,13 +124,6 @@ If no `query` is specified, this call by default returns the first 100 items in 
         [RegisterIssuer](../../../java/src/test/java/trinsic/WalletsDemo.java) inside_block:searchWalletBasic
         ```
         <!--/codeinclude-->
-
-    === "Ruby"
-        <!--codeinclude-->
-        ```ruby
-        
-        ```
-        <!--/codeinclude-->
     
 {{ proto_method_tabs("services.universalwallet.v1.UniversalWallet.Search") }}
 


### PR DESCRIPTION
- Documents all commands listed in #769 
- Removes Ruby sample tabs (per discussion in #747)
  - Vaccine Walkthrough still has Ruby samples; it'd be senseless to remove this as it's fully-functional and valuable.