### PR TITLE
Update name of `TrinsicService` in samples

### DIFF
--- a/dotnet/Tests/Samples/VaccineWalkthroughTests.cs
+++ b/dotnet/Tests/Samples/VaccineWalkthroughTests.cs
@@ -40,21 +40,21 @@ public class VaccineWalkthroughTests
     [Fact(DisplayName = "Vaccine Walkthrough")]
     public async Task TestWalkthrough() {
         // createEcosystem() {
-        var trinsicService = new TrinsicService(_options);
+        var trinsic = new TrinsicService(_options);
 
-        var (ecosystem, _authToken) = await trinsicService.Provider.CreateEcosystemAsync(new());
+        var (ecosystem, _authToken) = await trinsic.Provider.CreateEcosystemAsync(new());
         var ecosystemId = ecosystem?.Id;
         // }
 
         ecosystemId.Should().NotBeNullOrEmpty();
 
         // Set default ecosystem
-        trinsicService.Options.DefaultEcosystem = ecosystemId;
+        trinsic.Options.DefaultEcosystem = ecosystemId;
 
         // setupActors() {
-        var allison = await trinsicService.Account.SignInAsync(new() { EcosystemId = ecosystemId });
-        var clinic = await trinsicService.Account.SignInAsync(new() { EcosystemId = ecosystemId });
-        var airline = await trinsicService.Account.SignInAsync(new() { EcosystemId = ecosystemId });
+        var allison = await trinsic.Account.SignInAsync(new() { EcosystemId = ecosystemId });
+        var clinic = await trinsic.Account.SignInAsync(new() { EcosystemId = ecosystemId });
+        var airline = await trinsic.Account.SignInAsync(new() { EcosystemId = ecosystemId });
         // }
 
         allison.Should().NotBeNullOrEmpty();
@@ -74,7 +74,7 @@ public class VaccineWalkthroughTests
         templateRequest.Fields.Add("countryOfVaccination", new() { Description = "Country in which the subject was vaccinated" });
 
         // Create template
-        var template = await trinsicService.Template.CreateAsync(templateRequest);
+        var template = await trinsic.Template.CreateAsync(templateRequest);
         var templateId = template?.Data?.Id;
         // }
 
@@ -83,7 +83,7 @@ public class VaccineWalkthroughTests
         // issueCredential() {
         // Set active profile to 'clinic' so we can issue credential signed
         // with the clinic's signing keys
-        trinsicService.Options.AuthToken = clinic;
+        trinsic.Options.AuthToken = clinic;
 
         // Prepare credential values
         var credentialValues = new Dictionary<string, string>() {
@@ -94,8 +94,8 @@ public class VaccineWalkthroughTests
         };
 
         // Issue credential
-        trinsicService.SetAuthToken(_authToken);
-        var issueResponse = await trinsicService.Credential.IssueFromTemplateAsync(new() {
+        trinsic.SetAuthToken(_authToken);
+        var issueResponse = await trinsic.Credential.IssueFromTemplateAsync(new() {
             TemplateId = templateId,
             ValuesJson = JsonSerializer.Serialize(credentialValues)
         });
@@ -107,10 +107,10 @@ public class VaccineWalkthroughTests
 
         // storeCredential() {
         // Set active profile to 'allison' so we can manage her cloud wallet
-        trinsicService.Options.AuthToken = allison;
+        trinsic.Options.AuthToken = allison;
 
         // Insert credential into Allison's wallet
-        var insertItemResponse = await trinsicService.Wallet.InsertItemAsync(new() {
+        var insertItemResponse = await trinsic.Wallet.InsertItemAsync(new() {
             ItemJson = signedCredential
         });
 
@@ -122,10 +122,10 @@ public class VaccineWalkthroughTests
 
         // shareCredential() {
         // Set active profile to 'allison' so we can create a proof using her key
-        trinsicService.Options.AuthToken = allison;
+        trinsic.Options.AuthToken = allison;
 
         // Build a proof for the signed credential
-        var proofResponse = await trinsicService.Credential.CreateProofAsync(new() {
+        var proofResponse = await trinsic.Credential.CreateProofAsync(new() {
             ItemId = itemId
         });
 
@@ -136,7 +136,7 @@ public class VaccineWalkthroughTests
 
         // verifyCredential() {
         // Verify that Allison has provided a valid proof
-        var verifyResponse = await trinsicService.Credential.VerifyProofAsync(new() {
+        var verifyResponse = await trinsic.Credential.VerifyProofAsync(new() {
             ProofDocumentJson = proofJSON
         });
 

--- a/dotnet/Tests/Tests.cs
+++ b/dotnet/Tests/Tests.cs
@@ -55,23 +55,23 @@ public class Tests
     [Fact(DisplayName = "Demo: wallet and credential sample")]
     public async Task TestWalletService() {
         // createService() {
-        var trinsicService = new TrinsicService(_options.Clone());
+        var trinsic = new TrinsicService(_options.Clone());
         // }
         // createAccountService() {
-        var (ecosystem, _) = trinsicService.Provider.CreateEcosystem(new());
+        var (ecosystem, _) = trinsic.Provider.CreateEcosystem(new());
         var ecosystemId = ecosystem.Id;
         // }
 
         // SETUP ACTORS
         // Create 3 different profiles for each participant in the scenario
         // setupActors() {
-        var allison = await trinsicService.Account.SignInAsync(new() {EcosystemId = ecosystemId});
-        var clinic = await trinsicService.Account.SignInAsync(new() {EcosystemId = ecosystemId});
-        var airline = await trinsicService.Account.SignInAsync(new() {EcosystemId = ecosystemId});
+        var allison = await trinsic.Account.SignInAsync(new() {EcosystemId = ecosystemId});
+        var clinic = await trinsic.Account.SignInAsync(new() {EcosystemId = ecosystemId});
+        var airline = await trinsic.Account.SignInAsync(new() {EcosystemId = ecosystemId});
         // }
 
-        trinsicService.Options.AuthToken = clinic;
-        var info = await trinsicService.Account.GetInfoAsync();
+        trinsic.Options.AuthToken = clinic;
+        var info = await trinsic.Account.GetInfoAsync();
         info.Should().NotBeNull();
 
         // ISSUE CREDENTIAL
@@ -79,13 +79,13 @@ public class Tests
         // issueCredential() {
         // Set active profile to 'clinic' so we can issue credential signed
         // with the clinic's signing keys
-        trinsicService.Options.AuthToken = clinic;
+        trinsic.Options.AuthToken = clinic;
 
         // Read the JSON credential data
         var credentialJson = await File.ReadAllTextAsync(VaccinationCertificateUnsigned);
         // Sign the credential using BBS+ signature scheme
         // issueCredentialSample() {
-        var credential = await trinsicService.Credential.IssueCredentialAsync(new() {DocumentJson = credentialJson});
+        var credential = await trinsic.Credential.IssueCredentialAsync(new() {DocumentJson = credentialJson});
         _testOutputHelper.WriteLine($"Credential:\n{credential.SignedDocumentJson}");
         // }
         // }
@@ -99,7 +99,7 @@ public class Tests
 
         try {
             // sendCredential() {
-            await trinsicService.Credential.SendAsync(new() {Email = "example@trinsic.id"});
+            await trinsic.Credential.SendAsync(new() {Email = "example@trinsic.id"});
             // }
         } catch { } // We expect this to fail
 
@@ -108,18 +108,18 @@ public class Tests
 
         // storeCredential() {
         // Set active profile to 'allison' so we can manage her cloud wallet
-        trinsicService.Options.AuthToken = allison;
+        trinsic.Options.AuthToken = allison;
 
-        var insertItemResponse = await trinsicService.Wallet.InsertItemAsync(new() {ItemJson = credential.SignedDocumentJson});
+        var insertItemResponse = await trinsic.Wallet.InsertItemAsync(new() {ItemJson = credential.SignedDocumentJson});
         var itemId = insertItemResponse.ItemId;
         // }
         // searchWalletBasic() {
-        var walletItems = await trinsicService.Wallet.SearchAsync(new());
+        var walletItems = await trinsic.Wallet.SearchAsync(new());
         // }
         _testOutputHelper.WriteLine($"Last wallet item:\n{walletItems.Items.Last()}");
 
         // searchWalletSQL() { 
-        var walletItems2 = await trinsicService.Wallet.SearchAsync(new() {Query = "SELECT c.id, c.type, c.data FROM c WHERE c.type = 'VerifiableCredential'"});
+        var walletItems2 = await trinsic.Wallet.SearchAsync(new() {Query = "SELECT c.id, c.type, c.data FROM c WHERE c.type = 'VerifiableCredential'"});
         // }
 
         // SHARE CREDENTIAL
@@ -128,13 +128,13 @@ public class Tests
         // that they require expressed as a JSON-LD frame.
         // shareCredential() {
         // We'll read the request frame from a file and communicate this with Allison
-        trinsicService.Options.AuthToken = allison;
+        trinsic.Options.AuthToken = allison;
 
         var proofRequestJson = await File.ReadAllTextAsync(VaccinationCertificateFrame);
 
         // Build a proof for the given request and the `itemId` we previously received
         // which points to the stored credential
-        var credentialProof = await trinsicService.Credential.CreateProofAsync(new() {
+        var credentialProof = await trinsic.Credential.CreateProofAsync(new() {
             ItemId = itemId,
             RevealDocumentJson = proofRequestJson
         });
@@ -146,10 +146,10 @@ public class Tests
         // VERIFY CREDENTIAL
         // verifyCredential() {
         // The airline verifies the credential
-        trinsicService.Options.AuthToken = airline;
+        trinsic.Options.AuthToken = airline;
 
         // Check for valid signature
-        var valid = await trinsicService.Credential.VerifyProofAsync(new() {
+        var valid = await trinsic.Credential.VerifyProofAsync(new() {
             ProofDocumentJson = credentialProof.ProofDocumentJson
         });
         _testOutputHelper.WriteLine($"Verification result: {valid.IsValid}");
@@ -162,8 +162,8 @@ public class Tests
         var governanceUri = $"https://example.com/{Guid.NewGuid():N}";
 
         // setup
-        var trinsicService = new TrinsicService(_options.Clone());
-        var (_, authToken) = await trinsicService.Provider.CreateEcosystemAsync(new());
+        var trinsic = new TrinsicService(_options.Clone());
+        var (_, authToken) = await trinsic.Provider.CreateEcosystemAsync(new());
         var service = new TrustRegistryService(_options.CloneWithAuthToken(authToken));
 
         // registerGovernanceFramework() {
@@ -215,12 +215,12 @@ public class Tests
     [Fact(DisplayName = "Demo: ecosystem creation and listing")]
     public async Task EcosystemTests() {
         // setup
-        var trinsicService = new TrinsicService(_options.Clone());
-        var account = await trinsicService.Account.SignInAsync(new());
+        var trinsic = new TrinsicService(_options.Clone());
+        var account = await trinsic.Account.SignInAsync(new());
 
         // test create ecosystem
         // createEcosystem() {
-        var (actualCreate, _) = await trinsicService.Provider.CreateEcosystemAsync(new() {
+        var (actualCreate, _) = await trinsic.Provider.CreateEcosystemAsync(new() {
             Description = "My ecosystem",
             Uri = "https://example.com"
         });
@@ -232,7 +232,7 @@ public class Tests
 
         try {
             // inviteParticipant() {
-            var inviteResponse = await trinsicService.Provider.InviteParticipantAsync(new() {
+            var inviteResponse = await trinsic.Provider.InviteParticipantAsync(new() {
                 Participant = ParticipantType.Individual,
                 Description = "Doc sample",
                 Details = new() {
@@ -245,7 +245,7 @@ public class Tests
         var invitationId = "N/A";
         try {
             // invitationStatus() {
-            var inviteStatus = await trinsicService.Provider.InvitationStatusAsync(new() {InvitationId = invitationId});
+            var inviteStatus = await trinsic.Provider.InvitationStatusAsync(new() {InvitationId = invitationId});
             // }
         } catch(Exception) { } // This is expected as a doc sample
     }
@@ -254,14 +254,14 @@ public class Tests
     public async Task TestProtectUnprotectProfile() {
         // testSignInAndGetInfo() {
         // accountServiceConstructor() {
-        var trinsicService = new TrinsicService(_options.Clone());
+        var trinsic = new TrinsicService(_options.Clone());
         // }
         // accountServiceSignIn() {
-        var myProfile = await trinsicService.Account.SignInAsync(new());
+        var myProfile = await trinsic.Account.SignInAsync(new());
         // }
-        trinsicService.Account.Options.AuthToken = myProfile;
+        trinsic.Account.Options.AuthToken = myProfile;
         // accountServiceGetInfo() {
-        var output = await trinsicService.Account.GetInfoAsync();
+        var output = await trinsic.Account.GetInfoAsync();
         // }
         Assert.NotNull(output);
         // }
@@ -271,43 +271,43 @@ public class Tests
         var myProtectedProfile = AccountService.Protect(myProfile, securityCode);
         var myUnprotectedProfile = AccountService.Unprotect(myProtectedProfile, securityCode);
         // }
-        trinsicService.Account.Options.AuthToken = myProtectedProfile;
-        await Assert.ThrowsAsync<Exception>(trinsicService.Account.GetInfoAsync);
-        trinsicService.Account.Options.AuthToken = myUnprotectedProfile;
-        Assert.NotNull(await trinsicService.Account.GetInfoAsync());
-        Assert.NotNull(trinsicService.Account.GetInfo());
+        trinsic.Account.Options.AuthToken = myProtectedProfile;
+        await Assert.ThrowsAsync<Exception>(trinsic.Account.GetInfoAsync);
+        trinsic.Account.Options.AuthToken = myUnprotectedProfile;
+        Assert.NotNull(await trinsic.Account.GetInfoAsync());
+        Assert.NotNull(trinsic.Account.GetInfo());
     }
 
     [Fact]
     public async Task TestInvitationIdSet() {
-        var trinsicService = new TrinsicService(_options.Clone());
-        _ = await trinsicService.Provider.CreateEcosystemAsync(new());
+        var trinsic = new TrinsicService(_options.Clone());
+        _ = await trinsic.Provider.CreateEcosystemAsync(new());
 
-        var invitationResponse = await trinsicService.Provider.InviteParticipantAsync(new());
+        var invitationResponse = await trinsic.Provider.InviteParticipantAsync(new());
 
         invitationResponse.Should().NotBeNull();
         invitationResponse.InvitationCode.Should().NotBeEmpty();
 
-        await Assert.ThrowsAsync<Exception>(async () => await trinsicService.Provider.InvitationStatusAsync(new()));
+        await Assert.ThrowsAsync<Exception>(async () => await trinsic.Provider.InvitationStatusAsync(new()));
     }
 
     [Fact(Skip = "Ecosystem support not complete yet")]
     public async Task TestInviteParticipant() {
-        var trinsicService = new TrinsicService(_options.Clone());
-        var myProfile = await trinsicService.Account.SignInAsync(new());
+        var trinsic = new TrinsicService(_options.Clone());
+        var myProfile = await trinsic.Account.SignInAsync(new());
         var invite = new InviteRequest {Description = "Test invitation"};
-        var response = await trinsicService.Provider.InviteParticipantAsync(invite);
+        var response = await trinsic.Provider.InviteParticipantAsync(invite);
         Assert.NotNull(response);
 
-        var statusResponse = await trinsicService.Provider.InvitationStatusAsync(new() {InvitationId = response.InvitationId});
+        var statusResponse = await trinsic.Provider.InvitationStatusAsync(new() {InvitationId = response.InvitationId});
         Assert.NotNull(statusResponse);
     }
 
     [Fact]
     public async Task TestGovernanceFrameworkUriParse() {
-        var trinsicService = new TrinsicService(_options.Clone());
-        var myProfile = await trinsicService.Account.SignInAsync(new());
-        await Assert.ThrowsAsync<Exception>(async () => await trinsicService.TrustRegistry.AddFrameworkAsync(new() {
+        var trinsic = new TrinsicService(_options.Clone());
+        var myProfile = await trinsic.Account.SignInAsync(new());
+        await Assert.ThrowsAsync<Exception>(async () => await trinsic.TrustRegistry.AddFrameworkAsync(new() {
             Description = "invalid uri",
             GovernanceFrameworkUri = ""
         }));
@@ -315,8 +315,8 @@ public class Tests
 
     [Fact(DisplayName = "Demo: template management and credential issuance from template")]
     public async Task DemoTemplatesWithIssuance() {
-        var trinsicService = new TrinsicService(_options.Clone());
-        var (_, authToken) = await trinsicService.Provider.CreateEcosystemAsync(new());
+        var trinsic = new TrinsicService(_options.Clone());
+        var (_, authToken) = await trinsic.Provider.CreateEcosystemAsync(new());
 
         // create example template
         // createTemplate() {
@@ -328,7 +328,7 @@ public class Tests
         templateRequest.Fields.Add("lastName", new());
         templateRequest.Fields.Add("age", new() {Optional = true}); // TODO - use FieldType.NUMBER once schema validation is fixed.
 
-        var template = await trinsicService.Template.CreateAsync(templateRequest);
+        var template = await trinsic.Template.CreateAsync(templateRequest);
         // }
 
         template.Should().NotBeNull();
@@ -344,7 +344,7 @@ public class Tests
         });
 
         // issueFromTemplate() {
-        var credentialJson = await trinsicService.Credential.IssueFromTemplateAsync(new() {
+        var credentialJson = await trinsic.Credential.IssueFromTemplateAsync(new() {
             TemplateId = template.Data.Id,
             ValuesJson = values
         });
@@ -358,7 +358,7 @@ public class Tests
         jsonDocument.Should().Contain(x => x.Name == "credentialSubject");
 
         // insertItemWallet() {
-        var insertItemResponse = await trinsicService.Wallet.InsertItemAsync(new() {ItemJson = credentialJson.DocumentJson});
+        var insertItemResponse = await trinsic.Wallet.InsertItemAsync(new() {ItemJson = credentialJson.DocumentJson});
         // }
         var itemId = insertItemResponse.ItemId;
 
@@ -369,46 +369,46 @@ public class Tests
 
         // Create proof from input document
         // createProof() {
-        var proof = await trinsicService.Credential.CreateProofAsync(new() {
+        var proof = await trinsic.Credential.CreateProofAsync(new() {
             DocumentJson = credentialJson.DocumentJson,
             RevealDocumentJson = frame.ToString(Formatting.None)
         });
         // }
         // verifyProof() {
-        var valid = await trinsicService.Credential.VerifyProofAsync(new() {ProofDocumentJson = proof.ProofDocumentJson});
+        var valid = await trinsic.Credential.VerifyProofAsync(new() {ProofDocumentJson = proof.ProofDocumentJson});
         // }
         valid.IsValid.Should().BeTrue();
 
         // Create proof from item id
-        var proof2 = await trinsicService.Credential.CreateProofAsync(new() {
+        var proof2 = await trinsic.Credential.CreateProofAsync(new() {
             ItemId = itemId,
             RevealDocumentJson = frame.ToString(Formatting.None)
         });
 
-        var valid2 = await trinsicService.Credential.VerifyProofAsync(new() {ProofDocumentJson = proof2.ProofDocumentJson});
+        var valid2 = await trinsic.Credential.VerifyProofAsync(new() {ProofDocumentJson = proof2.ProofDocumentJson});
 
         valid2.IsValid.Should().BeTrue();
 
         try {
             // checkCredentialStatus() {
-            var checkResponse = await trinsicService.Credential.CheckStatusAsync(new() {CredentialStatusId = ""});
+            var checkResponse = await trinsic.Credential.CheckStatusAsync(new() {CredentialStatusId = ""});
             // }
         } catch { } // We expect this to fail
 
         try {
             // updateCredentialStatus() {
-            await trinsicService.Credential.UpdateStatusAsync(new() {CredentialStatusId = "", Revoked = true});
+            await trinsic.Credential.UpdateStatusAsync(new() {CredentialStatusId = "", Revoked = true});
             // }
         } catch { } // We expect this to fail
 
         // getCredentialTemplate() {
-        var getTemplateResponse = await trinsicService.Template.GetAsync(new() {Id = template.Data.Id});
+        var getTemplateResponse = await trinsic.Template.GetAsync(new() {Id = template.Data.Id});
         // }
         // searchCredentialTemplate() {
-        var searchTemplateResponse = await trinsicService.Template.SearchAsync(new() {Query = "SELECT * FROM c"});
+        var searchTemplateResponse = await trinsic.Template.SearchAsync(new() {Query = "SELECT * FROM c"});
         // }
         // deleteCredentialTemplate() {
-        var deleteTemplateResponse = await trinsicService.Template.DeleteAsync(new() {Id = template.Data.Id});
+        var deleteTemplateResponse = await trinsic.Template.DeleteAsync(new() {Id = template.Data.Id});
         // }
     }
 

--- a/go/services/account_service_test.go
+++ b/go/services/account_service_test.go
@@ -12,13 +12,13 @@ func TestProtectUnprotectProfile(t *testing.T) {
 	assert2 := assert.New(t)
 
 	// accountServiceConstructor() {
-	trinsicService, err := NewTrinsic(WithTestEnv())
+	trinsic, err := NewTrinsic(WithTestEnv())
 	if !assert2.Nil(err) {
 		return
 	}
 	// }
 	// accountServiceSignIn() {
-	profile, _, err := trinsicService.Account().SignIn(context.Background(), &account.SignInRequest{})
+	profile, _, err := trinsic.Account().SignIn(context.Background(), &account.SignInRequest{})
 	if !assert2.Nil(err) {
 		return
 	}
@@ -27,19 +27,19 @@ func TestProtectUnprotectProfile(t *testing.T) {
 	// accountService
 	// protectUnprotectProfile() {
 	securityCode := "1234"
-	protectedProfile, err := trinsicService.Account().Protect(profile, securityCode)
+	protectedProfile, err := trinsic.Account().Protect(profile, securityCode)
 	if !assert2.Nil(err) {
 		return
 	}
-	unprotectedProfile, err := trinsicService.Account().Unprotect(protectedProfile, securityCode)
+	unprotectedProfile, err := trinsic.Account().Unprotect(protectedProfile, securityCode)
 	if !assert2.Nil(err) {
 		return
 	}
 	// }
 
 	t.Run("Protected profile should fail", func(t *testing.T) {
-		trinsicService.Account().SetToken(protectedProfile)
-		info2, err2 := trinsicService.Account().GetInfo(context.Background())
+		trinsic.Account().SetToken(protectedProfile)
+		info2, err2 := trinsic.Account().GetInfo(context.Background())
 		if !assert2.NotNil(err2) {
 			t.FailNow()
 		}
@@ -49,9 +49,9 @@ func TestProtectUnprotectProfile(t *testing.T) {
 	})
 
 	t.Run("Unprotected profile should work", func(t *testing.T) {
-		trinsicService.Account().SetToken(unprotectedProfile)
+		trinsic.Account().SetToken(unprotectedProfile)
 		// getInfo() {
-		info2, err2 := trinsicService.Account().GetInfo(context.Background())
+		info2, err2 := trinsic.Account().GetInfo(context.Background())
 		// }
 		if !assert2.Nil(err2) {
 			t.FailNow()

--- a/go/services/credentialtemplate_service_test.go
+++ b/go/services/credentialtemplate_service_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTemplatesDemo(t *testing.T) {
-	assert2, service, err := createAccountAndSignIn(t)
+	assert2, trinsic, err := createAccountAndSignIn(t)
 	if !assert2.Nil(err) {
 		return
 	}
@@ -25,7 +25,7 @@ func TestTemplatesDemo(t *testing.T) {
 	templateRequest.Fields["lastName"] = &template.TemplateField{}
 	templateRequest.Fields["age"] = &template.TemplateField{Type: template.FieldType_NUMBER, Optional: true}
 
-	templateResponse, err := service.Template().Create(context.Background(), templateRequest)
+	templateResponse, err := trinsic.Template().Create(context.Background(), templateRequest)
 	// }
 	if !assert2.Nil(err) && !assert2.NotNil(templateResponse) {
 		return
@@ -50,7 +50,7 @@ func TestTemplatesDemo(t *testing.T) {
 	}
 
 	// issueFromTemplate() {
-	credentialJSON, err := service.Credential().IssueFromTemplate(context.Background(), &credential.IssueFromTemplateRequest{
+	credentialJSON, err := trinsic.Credential().IssueFromTemplate(context.Background(), &credential.IssueFromTemplateRequest{
 		TemplateId: templateResponse.Data.Id,
 		ValuesJson: string(valuesString),
 	})
@@ -68,31 +68,31 @@ func TestTemplatesDemo(t *testing.T) {
 	assert2.NotNil(jsonDocument["credentialSubject"])
 
 	// getCredentialTemplate() {
-	getResponse, err := service.Template().Get(context.Background(), &template.GetCredentialTemplateRequest{Id: templateResponse.Data.Id})
+	getResponse, err := trinsic.Template().Get(context.Background(), &template.GetCredentialTemplateRequest{Id: templateResponse.Data.Id})
 	// }
 	if getResponse != nil {
 	}
 
 	// searchCredentialTemplate() {
-	searchResponse, err := service.Template().Search(context.Background(), &template.SearchCredentialTemplatesRequest{Query: "SELECT * FROM c"})
+	searchResponse, err := trinsic.Template().Search(context.Background(), &template.SearchCredentialTemplatesRequest{Query: "SELECT * FROM c"})
 	// }
 	if searchResponse != nil {
 	}
 
 	// deleteCredentialTemplate() {
-	deleteResponse, err := service.Template().Delete(context.Background(), &template.DeleteCredentialTemplateRequest{Id: templateResponse.Data.Id})
+	deleteResponse, err := trinsic.Template().Delete(context.Background(), &template.DeleteCredentialTemplateRequest{Id: templateResponse.Data.Id})
 	// }
 	if deleteResponse != nil {
 	}
 
 	// checkCredentialStatus() {
-	status, err := service.Credential().CheckStatus(context.Background(), &credential.CheckStatusRequest{CredentialStatusId: ""})
+	status, err := trinsic.Credential().CheckStatus(context.Background(), &credential.CheckStatusRequest{CredentialStatusId: ""})
 	// }
 	if status != nil {
 	}
 
 	// updateCredentialStatus() {
-	updateResponse, err := service.Credential().UpdateStatus(context.Background(), &credential.UpdateStatusRequest{CredentialStatusId: "", Revoked: true})
+	updateResponse, err := trinsic.Credential().UpdateStatus(context.Background(), &credential.UpdateStatusRequest{CredentialStatusId: "", Revoked: true})
 	// }
 	if updateResponse != nil {
 	}

--- a/go/services/services_test.go
+++ b/go/services/services_test.go
@@ -62,7 +62,7 @@ func TestServiceOptions(t *testing.T) {
 }
 
 func TestTrustRegistryDemo(t *testing.T) {
-	assert2, service, err := createAccountAndSignIn(t)
+	assert2, trinsic, err := createAccountAndSignIn(t)
 	if !assert2.Nil(err) {
 		return
 	}
@@ -73,7 +73,7 @@ func TestTrustRegistryDemo(t *testing.T) {
 	frameworkURI := fmt.Sprintf("https://example.com/%s", uuid.New())
 
 	// registerGovernanceFramework() {
-	newFramework, err := service.TrustRegistry().AddFramework(context.Background(), &trustregistry.AddFrameworkRequest{
+	newFramework, err := trinsic.TrustRegistry().AddFramework(context.Background(), &trustregistry.AddFrameworkRequest{
 		GovernanceFrameworkUri: frameworkURI,
 		Name:                   fmt.Sprintf("Example Framework - %s", uuid.New()),
 	})
@@ -83,7 +83,7 @@ func TestTrustRegistryDemo(t *testing.T) {
 	}
 
 	// registerMemberSample() {
-	registerMemberResponse, err := service.TrustRegistry().RegisterMember(context.Background(), &trustregistry.RegisterMemberRequest{
+	registerMemberResponse, err := trinsic.TrustRegistry().RegisterMember(context.Background(), &trustregistry.RegisterMemberRequest{
 		FrameworkId: newFramework.Id,
 		SchemaUri:   schemaURI,
 		Member:      &trustregistry.RegisterMemberRequest_DidUri{DidUri: didURI},
@@ -94,7 +94,7 @@ func TestTrustRegistryDemo(t *testing.T) {
 	}
 
 	// getMembershipStatus() {
-	getMembershipStatusResponse, err := service.TrustRegistry().GetMembershipStatus(context.Background(), &trustregistry.GetMembershipStatusRequest{
+	getMembershipStatusResponse, err := trinsic.TrustRegistry().GetMembershipStatus(context.Background(), &trustregistry.GetMembershipStatusRequest{
 		GovernanceFrameworkUri: frameworkURI,
 		Member:                 &trustregistry.GetMembershipStatusRequest_DidUri{DidUri: didURI},
 		SchemaUri:              schemaURI,
@@ -106,7 +106,7 @@ func TestTrustRegistryDemo(t *testing.T) {
 	assert2.Equal(trustregistry.RegistrationStatus_CURRENT, getMembershipStatusResponse.Status, "Member status should be current")
 
 	// searchTrustRegistry() {
-	ecosystemList, err := service.TrustRegistry().SearchRegistry(context.Background(), nil)
+	ecosystemList, err := trinsic.TrustRegistry().SearchRegistry(context.Background(), nil)
 	// }
 	if !assert2.Nil(err) {
 		return
@@ -115,7 +115,7 @@ func TestTrustRegistryDemo(t *testing.T) {
 	assert2.NotEmpty(ecosystemList)
 
 	// unregisterIssuer() {
-	unregisterMemberResponse, err := service.TrustRegistry().UnregisterMember(context.Background(), &trustregistry.UnregisterMemberRequest{
+	unregisterMemberResponse, err := trinsic.TrustRegistry().UnregisterMember(context.Background(), &trustregistry.UnregisterMemberRequest{
 		SchemaUri:   schemaURI,
 		FrameworkId: newFramework.Id,
 	})
@@ -130,27 +130,27 @@ func TestTrustRegistryDemo(t *testing.T) {
 func createAccountAndSignIn(t *testing.T) (*assert.Assertions, *Trinsic, error) {
 	assert2 := assert.New(t)
 
-	service, err := NewTrinsic(WithTestEnv())
+	trinsic, err := NewTrinsic(WithTestEnv())
 	if !assert2.Nil(err) {
 		fmt.Println(err)
 		return assert2, nil, err
 	}
-	_, _, err = service.Account().SignIn(context.Background(), &account.SignInRequest{})
+	_, _, err = trinsic.Account().SignIn(context.Background(), &account.SignInRequest{})
 	if !assert2.Nil(err) {
 		fmt.Println(err)
 		return assert2, nil, err
 	}
-	return assert2, service, nil
+	return assert2, trinsic, nil
 }
 
 func TestEcosystemDemo(t *testing.T) {
-	assert2, service, err := createAccountAndSignIn(t)
+	assert2, trinsic, err := createAccountAndSignIn(t)
 	if !assert2.Nil(err) {
 		return
 	}
 
 	// createEcosystem() {
-	actualCreate, err := service.Provider().CreateEcosystem(context.Background(), &provider.CreateEcosystemRequest{
+	actualCreate, err := trinsic.Provider().CreateEcosystem(context.Background(), &provider.CreateEcosystemRequest{
 		Description: "My ecosystem",
 		Uri:         "https://example.com",
 	})
@@ -163,7 +163,7 @@ func TestEcosystemDemo(t *testing.T) {
 	// assert2.True(strings.HasPrefix(actualCreate.Id, "urn:trinsic:ecosystems:"))
 
 	// inviteParticipant() {
-	inviteResponse, err := service.Provider().InviteParticipant(context.Background(),
+	inviteResponse, err := trinsic.Provider().InviteParticipant(context.Background(),
 		&provider.InviteRequest{Participant: provider.ParticipantType_participant_type_individual,
 			Details: &account.AccountDetails{Email: "example@trinsic.id"}})
 	// }
@@ -171,7 +171,7 @@ func TestEcosystemDemo(t *testing.T) {
 		inviteResponse = &provider.InviteResponse{InvitationId: "NA"}
 	}
 	// invitationStatus() {
-	inviteStatus, err := service.Provider().InvitationStatus(context.Background(), &provider.InvitationStatusRequest{InvitationId: inviteResponse.InvitationId})
+	inviteStatus, err := trinsic.Provider().InvitationStatus(context.Background(), &provider.InvitationStatusRequest{InvitationId: inviteResponse.InvitationId})
 	// }
 	if inviteStatus != nil {
 	}

--- a/java/src/test/java/trinsic/AccountServiceTest.java
+++ b/java/src/test/java/trinsic/AccountServiceTest.java
@@ -15,10 +15,10 @@ class AccountServiceTest {
       throws ExecutionException, InterruptedException, InvalidProtocolBufferException,
           DidException {
     // accountServiceConstructor() {
-    var trinsicService = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
+    var trinsic = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
     // }
     // accountServiceSignIn() {
-    var myProfile = trinsicService.account().signIn().get();
+    var myProfile = trinsic.account().signIn().get();
     // }
 
     // protectUnprotectProfile() {
@@ -30,17 +30,17 @@ class AccountServiceTest {
     Assertions.assertThrows(
         Exception.class,
         () -> {
-          trinsicService.setProfile(myProtectedProfile);
+          trinsic.setProfile(myProtectedProfile);
           Assertions.assertEquals(
-              myProtectedProfile, trinsicService.account().getOptionsBuilder().getAuthToken());
-          trinsicService.account().getInfo().get();
+              myProtectedProfile, trinsic.account().getOptionsBuilder().getAuthToken());
+          trinsic.account().getInfo().get();
         });
 
     Assertions.assertDoesNotThrow(
         () -> {
-          trinsicService.setProfile(myUnprotectedProfile);
+          trinsic.setProfile(myUnprotectedProfile);
           // getInfo() {
-          var info = trinsicService.account().getInfo().get();
+          var info = trinsic.account().getInfo().get();
           // }
         });
   }

--- a/java/src/test/java/trinsic/CredentialsDemo.java
+++ b/java/src/test/java/trinsic/CredentialsDemo.java
@@ -24,9 +24,9 @@ public class CredentialsDemo {
 
     var serverConfig = TrinsicUtilities.getTrinsicServiceOptions();
 
-    var trinsicService = new TrinsicService(serverConfig);
+    var trinsic = new TrinsicService(serverConfig);
     var ecosystemId =
-        trinsicService
+        trinsic
             .provider()
             .createEcosystem(ProviderOuterClass.CreateEcosystemRequest.getDefaultInstance())
             .get()
@@ -37,14 +37,14 @@ public class CredentialsDemo {
 
     //    trinsicService.setOptionsBuilder(serverConfig);
 
-    var issuerVerifier = trinsicService.account().signIn().get(); // Both issues and verifies
-    var holder = trinsicService.account().signIn().get();
+    var issuerVerifier = trinsic.account().signIn().get(); // Both issues and verifies
+    var holder = trinsic.account().signIn().get();
 
-    trinsicService.setProfile(issuerVerifier);
+    trinsic.setProfile(issuerVerifier);
 
     // issueCredentialSample() {
     var issueResult =
-        trinsicService
+        trinsic
             .credential()
             .issueCredential(
                 VerifiableCredentials.IssueRequest.newBuilder()
@@ -57,10 +57,10 @@ public class CredentialsDemo {
 
     System.out.println("Credential: " + signedCredentialJson);
 
-    trinsicService.setProfile(holder);
+    trinsic.setProfile(holder);
     // createProof() {
     var createProofResponse =
-        trinsicService
+        trinsic
             .credential()
             .createProof(
                 VerifiableCredentials.CreateProofRequest.newBuilder()
@@ -76,7 +76,7 @@ public class CredentialsDemo {
 
     try {
       // sendCredential() {
-      trinsicService
+      trinsic
           .credential()
           .send(
               VerifiableCredentials.SendRequest.newBuilder()
@@ -88,10 +88,10 @@ public class CredentialsDemo {
       // This is okay, we don't expect that account to exist.
     }
 
-    trinsicService.setProfile(issuerVerifier);
+    trinsic.setProfile(issuerVerifier);
     // verifyProof() {
     var verifyProofResponse =
-        trinsicService
+        trinsic
             .credential()
             .verifyProof(
                 VerifiableCredentials.VerifyProofRequest.newBuilder()

--- a/java/src/test/java/trinsic/EcosystemsDemo.java
+++ b/java/src/test/java/trinsic/EcosystemsDemo.java
@@ -16,11 +16,11 @@ public class EcosystemsDemo {
 
   public static void run()
       throws IOException, DidException, ExecutionException, InterruptedException {
-    var trinsicService = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
-    var account = trinsicService.account().signIn().get();
+    var trinsic = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
+    var account = trinsic.account().signIn().get();
     // createEcosystem() {
     var response =
-        trinsicService
+        trinsic
             .provider()
             .createEcosystem(
                 ProviderOuterClass.CreateEcosystemRequest.newBuilder()
@@ -45,7 +45,7 @@ public class EcosystemsDemo {
     try {
       // inviteParticipant() {
       inviteResponse =
-          trinsicService
+          trinsic
               .provider()
               .invite(
                   ProviderOuterClass.InviteRequest.newBuilder()
@@ -65,7 +65,7 @@ public class EcosystemsDemo {
     try {
       // invitationStatus() {
       var invitationStatus =
-          trinsicService
+          trinsic
               .provider()
               .invitationStatus(
                   ProviderOuterClass.InvitationStatusRequest.newBuilder()

--- a/java/src/test/java/trinsic/TemplatesDemo.java
+++ b/java/src/test/java/trinsic/TemplatesDemo.java
@@ -19,9 +19,9 @@ public class TemplatesDemo {
 
   public static void run()
       throws IOException, DidException, ExecutionException, InterruptedException {
-    var trinsicService = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
-    var account = trinsicService.account().signIn().get();
-    trinsicService.setProfile(account);
+    var trinsic = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
+    var account = trinsic.account().signIn().get();
+    trinsic.setProfile(account);
 
     // create example template
     // createTemplate() {
@@ -41,7 +41,7 @@ public class TemplatesDemo {
             .setAllowAdditionalFields(false)
             .putAllFields(fields)
             .build();
-    var template = trinsicService.template().create(templateRequest).get();
+    var template = trinsic.template().create(templateRequest).get();
     // }
 
     assert template != null;
@@ -57,7 +57,7 @@ public class TemplatesDemo {
     valuesMap.put("age", 42);
     var valuesJson = new Gson().toJson(valuesMap);
     var issueResponse =
-        trinsicService
+        trinsic
             .credential()
             .issueCredentialFromTemplate(
                 VerifiableCredentials.IssueFromTemplateRequest.newBuilder()
@@ -77,7 +77,7 @@ public class TemplatesDemo {
 
     // getCredentialTemplate() {
     var getResponse =
-        trinsicService
+        trinsic
             .template()
             .get(Templates.GetCredentialTemplateRequest.newBuilder().setId(id).build())
             .get();
@@ -85,7 +85,7 @@ public class TemplatesDemo {
 
     // searchCredentialTemplate() {
     var searchResponse =
-        trinsicService
+        trinsic
             .template()
             .search(
                 Templates.SearchCredentialTemplatesRequest.newBuilder()
@@ -97,7 +97,7 @@ public class TemplatesDemo {
     try {
       // checkCredentialStatus() {
       var checkStatusResponse =
-          trinsicService
+          trinsic
               .credential()
               .checkStatus(VerifiableCredentials.CheckStatusRequest.newBuilder().build())
               .get();
@@ -107,7 +107,7 @@ public class TemplatesDemo {
 
     try {
       // updateCredentialStatus() {
-      trinsicService
+      trinsic
           .credential()
           .updateStatus(VerifiableCredentials.UpdateStatusRequest.newBuilder().build());
       // }
@@ -117,7 +117,7 @@ public class TemplatesDemo {
     try {
         // deleteCredentialTemplate() {
         var deleteResponse =
-                trinsicService
+                trinsic
                         .template()
                         .delete(Templates.DeleteCredentialTemplateRequest.newBuilder().setId(id).build())
                         .get();

--- a/java/src/test/java/trinsic/TrustRegistryDemo.java
+++ b/java/src/test/java/trinsic/TrustRegistryDemo.java
@@ -16,9 +16,9 @@ public class TrustRegistryDemo {
 
   public static void run()
       throws IOException, DidException, ExecutionException, InterruptedException {
-    var trinsicService = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
-    var account = trinsicService.account().signIn().get();
-    trinsicService.setProfile(account);
+    var trinsic = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
+    var account = trinsic.account().signIn().get();
+    trinsic.setProfile(account);
 
     final String didUri = "did:example:test";
     final String frameworkUri = "https://example.com/" + UUID.randomUUID();
@@ -26,7 +26,7 @@ public class TrustRegistryDemo {
 
     // addFramework() {
     var frameworkResponse =
-        trinsicService
+        trinsic
             .trustRegistry()
             .addFramework(
                 TrustRegistryOuterClass.AddFrameworkRequest.newBuilder()
@@ -37,7 +37,7 @@ public class TrustRegistryDemo {
     // }
 
     // registerIssuerSample() {
-    trinsicService
+    trinsic
         .trustRegistry()
         .registerMember(
             TrustRegistryOuterClass.RegisterMemberRequest.newBuilder()
@@ -48,7 +48,7 @@ public class TrustRegistryDemo {
     // }
     // checkIssuerStatus() {
     var issuerStatus =
-        trinsicService
+        trinsic
             .trustRegistry()
             .checkIssuerStatus(
                 TrustRegistryOuterClass.GetMembershipStatusRequest.newBuilder()
@@ -62,14 +62,14 @@ public class TrustRegistryDemo {
         TrustRegistryOuterClass.RegistrationStatus.CURRENT, issuerStatus.getStatus());
 
     // searchTrustRegistry() {
-    var searchResult = trinsicService.trustRegistry().searchRegistry().get();
+    var searchResult = trinsic.trustRegistry().searchRegistry().get();
     // }
     Assertions.assertNotNull(searchResult);
     Assertions.assertNotNull(searchResult.getItemsJson());
     Assertions.assertTrue(searchResult.getItemsJson().length() > 0);
 
     // unregisterIssuer() {
-    trinsicService
+    trinsic
         .trustRegistry()
         .unregisterIssuer(
             TrustRegistryOuterClass.UnregisterMemberRequest.newBuilder()

--- a/java/src/test/java/trinsic/VaccineDemo.java
+++ b/java/src/test/java/trinsic/VaccineDemo.java
@@ -24,11 +24,11 @@ public class VaccineDemo {
       throws IOException, DidException, ExecutionException, InterruptedException {
     var serverConfig = TrinsicUtilities.getTrinsicServiceOptions();
 
-    var trinsicService = new TrinsicService(serverConfig);
+    var trinsic = new TrinsicService(serverConfig);
 
     // createEcosystem() {
     var ecosystemResponse =
-        trinsicService
+        trinsic
             .provider()
             .createEcosystem(ProviderOuterClass.CreateEcosystemRequest.getDefaultInstance())
             .get();
@@ -38,30 +38,30 @@ public class VaccineDemo {
 
     // Set default ecosystem on config
     serverConfig.setDefaultEcosystem(ecosystemId);
-    trinsicService.setDefaultEcosystem(ecosystemId);
+    trinsic.setDefaultEcosystem(ecosystemId);
 
     // setupActors() {
     // Create an account for each participant in the scenario
-    var allison = trinsicService.account().signIn().get();
-    var clinic = trinsicService.account().signIn().get();
-    var airline = trinsicService.account().signIn().get();
+    var allison = trinsic.account().signIn().get();
+    var clinic = trinsic.account().signIn().get();
+    var airline = trinsic.account().signIn().get();
     // }
 
     // Create template
-    var templateId = DefineTemplate(trinsicService.template(), clinic);
+    var templateId = DefineTemplate(trinsic.template(), clinic);
 
     // Issue credential
-    var credential = IssueCredential(trinsicService, templateId, clinic);
+    var credential = IssueCredential(trinsic, templateId, clinic);
 
     System.out.println("Credential: " + credential);
 
     // storeCredential() {
     // Set active profile to 'allison' so we can manage her cloud wallet
-    trinsicService.setProfile(allison);
+    trinsic.setProfile(allison);
 
     // Allison stores the credential in her cloud wallet.
     var insertItemResponse =
-        trinsicService
+        trinsic
             .wallet()
             .insertItem(
                 UniversalWalletOuterClass.InsertItemRequest.newBuilder()
@@ -76,11 +76,11 @@ public class VaccineDemo {
 
     // shareCredential() {
     // Set active profile to 'allison' so we can create a proof using her key
-    trinsicService.setProfile(allison);
+    trinsic.setProfile(allison);
 
     // Allison shares the credential with the venue
     var createProofResponse =
-        trinsicService
+        trinsic
             .credential()
             .createProof(
                 VerifiableCredentials.CreateProofRequest.newBuilder().setItemId(itemId).build())
@@ -92,11 +92,11 @@ public class VaccineDemo {
     System.out.println("Proof: " + credentialProof);
 
     // verifyCredential() {
-    trinsicService.setProfile(airline);
+    trinsic.setProfile(airline);
 
     // Verify that Allison has provided a valid proof
     var verifyProofResponse =
-        trinsicService
+        trinsic
             .credential()
             .verifyProof(
                 VerifiableCredentials.VerifyProofRequest.newBuilder()

--- a/java/src/test/java/trinsic/WalletsDemo.java
+++ b/java/src/test/java/trinsic/WalletsDemo.java
@@ -17,28 +17,28 @@ public class WalletsDemo {
   public static void run()
       throws IOException, DidException, ExecutionException, InterruptedException {
     // Create ecosystem
-    var trinsicService = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
+    var trinsic = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
     var ecosystemResponse =
-        trinsicService
+        trinsic
             .provider()
             .createEcosystem(ProviderOuterClass.CreateEcosystemRequest.getDefaultInstance())
             .get();
     var ecosystemId = ecosystemResponse.getEcosystem().getId();
 
     // Create account
-    trinsicService.setDefaultEcosystem(ecosystemId);
+    trinsic.setDefaultEcosystem(ecosystemId);
 
-    var account = trinsicService.account().signIn().get();
+    var account = trinsic.account().signIn().get();
 
     // Insert wallet item into wallet
-    trinsicService.setProfile(account);
+    trinsic.setProfile(account);
 
     var credentialJson =
         "{\"foo\":\"bar\"}"; // Doesn't need to actually be a credential for this test
 
     // insertItemWallet() {
     var insertResponse =
-        trinsicService
+        trinsic
             .wallet()
             .insertItem(
                 UniversalWalletOuterClass.InsertItemRequest.newBuilder()
@@ -53,7 +53,7 @@ public class WalletsDemo {
     // Abuse scope to allow redeclaration of walletItems for docs injection niceness
     {
       // searchWalletBasic() {
-      var walletItems = trinsicService.wallet().search().get();
+      var walletItems = trinsic.wallet().search().get();
       // }
 
       Assertions.assertNotNull(walletItems);
@@ -62,7 +62,7 @@ public class WalletsDemo {
 
     // Delete item in-between searches
     var deleteResponse =
-        trinsicService
+        trinsic
             .wallet()
             .deleteItem(
                 UniversalWalletOuterClass.DeleteItemRequest.newBuilder().setItemId(itemId).build())
@@ -73,7 +73,7 @@ public class WalletsDemo {
     {
       // searchWalletSQL() {
       var walletItems =
-          trinsicService
+          trinsic
               .wallet()
               .search(
                   UniversalWalletOuterClass.SearchRequest.newBuilder()

--- a/ruby/test/credential_template_demo.rb
+++ b/ruby/test/credential_template_demo.rb
@@ -9,10 +9,10 @@ require 'securerandom'
 
 # rubocop:disable Metrics/MethodLength Metrics/AbcSize Metrics/CyclomaticComplexity
 def credential_template_demo_run
-  account_service = Trinsic::AccountService.new(Trinsic.trinsic_server)
-  account = account_service.sign_in
-  credential_service = Trinsic::CredentialService.new(Trinsic.trinsic_server(account))
-  template_service = Trinsic::TemplateService.new(Trinsic.trinsic_server(account))
+  trinsic = Trinsic::TrinsicService.new(Trinsic.trinsic_server)
+  account = trinsic.account_service.login_anonymous
+
+  trinsic.auth_token = account
 
   # create example template
   template_request = Trinsic::Template::CreateCredentialTemplateRequest.new(
@@ -22,7 +22,7 @@ def credential_template_demo_run
   template_request.fields['lastName'] = Trinsic::Template::TemplateField.new
   template_request.fields['age'] =
     Trinsic::Template::TemplateField.new(type: Trinsic::Template::FieldType::NUMBER, optional: true)
-  template = template_service.create(template_request)
+  template = trinsic.template_service.create(template_request)
 
   raise 'template should not be nil' if template.nil?
   raise 'template data should not be nil' if template.data.nil?
@@ -31,7 +31,7 @@ def credential_template_demo_run
 
   # issue credential from this template
   values = JSON.generate({ firstName: 'Jane', lastName: 'Doe', age: 42 })
-  credential_json = credential_service.issue_from_template(Trinsic::Credentials::IssueFromTemplateRequest.new(
+  credential_json = trinsic.credential_service.issue_from_template(Trinsic::Credentials::IssueFromTemplateRequest.new(
                                                              template_id: template.data.id, values_json: values
                                                            ))
   raise 'credential json document should not be nil' if credential_json.document_json.nil?

--- a/ruby/test/ecosystem_demo.rb
+++ b/ruby/test/ecosystem_demo.rb
@@ -5,12 +5,13 @@ require 'services/account_service'
 require 'services/provider_service'
 
 def ecosystem_demo_run
-  account_service = Trinsic::AccountService.new(Trinsic.trinsic_server)
-  account = account_service.sign_in(nil)
-  service = Trinsic::ProviderService.new(Trinsic.trinsic_server(account))
+  trinsic = Trinsic::TrinsicService.new(Trinsic.trinsic_server)
+  account = trinsic.account_service.login_anonymous
+
+  trinsic.auth_token = account
 
   # test create ecosystem
-  actual_create = service.create_ecosystem(Trinsic::Provider::CreateEcosystemRequest.new(
+  actual_create = trinsic.provider_service.create_ecosystem(Trinsic::Provider::CreateEcosystemRequest.new(
                                              description: 'My ecosystem', uri: 'https://example.com'
                                            ))
   raise 'ecosystem should be created' if actual_create.ecosystem.nil?

--- a/ruby/test/trust_registry_demo.rb
+++ b/ruby/test/trust_registry_demo.rb
@@ -7,30 +7,31 @@ require 'securerandom'
 
 # rubocop:disable Metrics/MethodLength
 def trust_registry_demo_run
-  account_service = Trinsic::AccountService.new(Trinsic.trinsic_server)
-  account = account_service.sign_in(nil)
-  service = Trinsic::TrustRegistryService.new(Trinsic.trinsic_server(account))
+  trinsic = Trinsic::TrinsicService.new(Trinsic.trinsic_server)
+  account = account_service.login_anonymous
+
+  trinsic.auth_token = account
 
   # New governance framework
   framework_uri = "urn:egf:#{SecureRandom.uuid}"
-  governance_framework_response = service.add_framework(Trinsic::TrustRegistry::AddFrameworkRequest.new(
+  governance_framework_response = trinsic.provider_service.add_framework(Trinsic::TrustRegistry::AddFrameworkRequest.new(
                                                           governance_framework_uri: framework_uri, name: "Test Governance Framework - #{SecureRandom.uuid}"
                                                         ))
 
   # register issuer
   did_uri = 'did:example:test'
   type_uri = 'https://schema.org/Card'
-  service.register_member(Trinsic::TrustRegistry::RegisterMemberRequest.new(did_uri: did_uri,
+  trinsic.provider_service.register_member(Trinsic::TrustRegistry::RegisterMemberRequest.new(did_uri: did_uri,
                                                                                framework_id: governance_framework_response.id, schema_uri: type_uri))
 
   # check issuer status
-  issuer_status = service.get_membership_status(Trinsic::TrustRegistry::GetMembershipStatusRequest.new(
+  issuer_status = trinsic.provider_service.get_membership_status(Trinsic::TrustRegistry::GetMembershipStatusRequest.new(
                                                   did_uri: did_uri, governance_framework_uri: framework_uri, schema_uri: type_uri
                                                 ))
   raise "Issuer status #{issuer_status.status} should be current" unless issuer_status.status == :CURRENT
 
   # search registry
-  search_result = service.search_registry
+  search_result = trinsic.provider_service.search_registry
   raise 'Search result should exist' if search_result.nil?
   raise 'Search result should not be empty' unless JSON.parse(search_result.items_json).length.positive?
 end

--- a/web/test/AccountService.test.ts
+++ b/web/test/AccountService.test.ts
@@ -12,14 +12,14 @@ async function printGetInfo(service: TrinsicService, profile: string) {
 describe("AccountService Unit Tests", () => {
   setTestTimeout();
   it("protect/unprotect account profile", async () => {
-    let service = new TrinsicService(options);
-    let myProfile = await service.account().signIn();
-    await printGetInfo(service, myProfile);
+    let trinsic = new TrinsicService(options);
+    let myProfile = await trinsic.account().signIn();
+    await printGetInfo(trinsic, myProfile);
 
     const code = "1234";
     const myProtectedProfile = await AccountService.protect(myProfile, code);
     try {
-      await printGetInfo(service, myProtectedProfile);
+      await printGetInfo(trinsic, myProtectedProfile);
       fail("previous line should have thrown.");
     } catch {}
 
@@ -27,6 +27,6 @@ describe("AccountService Unit Tests", () => {
       myProtectedProfile,
       code
     );
-    await printGetInfo(service, myUnprotectedProfile);
+    await printGetInfo(trinsic, myUnprotectedProfile);
   });
 });

--- a/web/test/CredentialService.spec.ts
+++ b/web/test/CredentialService.spec.ts
@@ -10,18 +10,18 @@ import vaccineCertUnsigned from "./data/vaccination-certificate-unsigned.json";
 import { getTestServerOptions, setTestTimeout } from "./env";
 
 let options: ServiceOptions = getTestServerOptions();
-let service: TrinsicService;
+let trinsic: TrinsicService;
 
 describe("CredentialService Unit Tests", () => {
   setTestTimeout();
   beforeAll(async () => {
-    service = new TrinsicService(options);
-    options.authToken = await service.account().signIn();
+    trinsic = new TrinsicService(options);
+    options.authToken = await trinsic.account().signIn();
   });
 
   it("Issue Credential From Template", async () => {
     //Get account info so we can compare issued DID etc.
-    let info = await service.account().info();
+    let info = await trinsic.account().info();
 
     //Set issuer DID of credential
     let vaccineCert = Object.assign({}, vaccineCertUnsigned, {
@@ -30,7 +30,7 @@ describe("CredentialService Unit Tests", () => {
     let credentialJSON = JSON.stringify(vaccineCert);
 
     // issueCredential() {
-    const issueResponse = await service.credential().issueCredential(
+    const issueResponse = await trinsic.credential().issueCredential(
       IssueRequest.fromPartial({ documentJson: credentialJSON })
     );
     // }

--- a/web/test/CredentialTemplateShared.ts
+++ b/web/test/CredentialTemplateShared.ts
@@ -56,30 +56,30 @@ export async function verifyCredential(
   options: ServiceOptions,
   templateCertFrame: string
 ): Promise<boolean> {
-    const service = new TrinsicService(options);
+  const trinsic = new TrinsicService(options);
 
-  const allison = await service.account().signIn();
-  const airline = await service.account().signIn();
+  const allison = await trinsic.account().signIn();
+  const airline = await trinsic.account().signIn();
 
   const credential = await issueCredentialFromTemplate(options);
 
-  service.wallet().options.authToken = allison;
-  const insertItemResponse = await service.wallet().insertItem(
+  trinsic.wallet().options.authToken = allison;
+  const insertItemResponse = await trinsic.wallet().insertItem(
     InsertItemRequest.fromPartial({ itemJson: credential.documentJson })
   );
 
-  service.credential().options.authToken = allison;
+  trinsic.credential().options.authToken = allison;
   const proofRequest = CreateProofRequest.fromPartial({
     itemId: insertItemResponse.itemId,
     revealDocumentJson: templateCertFrame,
   });
-  const proof = await service.credential().createProof(proofRequest);
+  const proof = await trinsic.credential().createProof(proofRequest);
 
-  service.credential().options.authToken = airline;
+  trinsic.credential().options.authToken = airline;
   const verifyProofRequest = VerifyProofRequest.fromPartial({
     proofDocumentJson: proof.proofDocumentJson,
   });
-  const verifyProofResponse = await service.credential().verifyProof(
+  const verifyProofResponse = await trinsic.credential().verifyProof(
     verifyProofRequest
   );
 
@@ -97,7 +97,7 @@ export async function createCredentialTemplateTest(
     isVaccinated,
   } = createRequiredTestObjects();
   // createTemplate() {
-  const trinsicService = new TrinsicService(options);
+  const trinsic = new TrinsicService(options);
 
   let request = CreateCredentialTemplateRequest.fromPartial({
     name: credentialTemplateName,
@@ -109,7 +109,7 @@ export async function createCredentialTemplateTest(
     },
   });
 
-  let response = await trinsicService.template().createCredentialTemplate(request);
+  let response = await trinsic.template().createCredentialTemplate(request);
   // }
 
   return response;
@@ -120,7 +120,7 @@ export async function issueCredentialFromTemplate(
 ): Promise<IssueFromTemplateResponse> {
   let templateResponse = await createCredentialTemplateTest(options);
 
-  let service = new TrinsicService(options);
+  let trinsic = new TrinsicService(options);
   // issueFromTemplate() {
   let request = IssueFromTemplateRequest.fromPartial({
     templateId: templateResponse?.data?.id ?? "",
@@ -132,7 +132,7 @@ export async function issueCredentialFromTemplate(
     }),
   });
 
-  let response = await service.credential().issueFromTemplate(request);
+  let response = await trinsic.credential().issueFromTemplate(request);
   // }
 
   return response;

--- a/web/test/CredentialTemplates.spec.ts
+++ b/web/test/CredentialTemplates.spec.ts
@@ -17,13 +17,13 @@ const {
 } = createRequiredTestObjects();
 
 let options: ServiceOptions = getTestServerOptions();
-let service: TrinsicService;
+let trinsic: TrinsicService;
 
 describe("Demo: Credential Templates", () => {
   setTestTimeout();
   beforeAll(async () => {
-    service = new TrinsicService(options);
-    options.authToken = await service.account().signIn();
+    trinsic = new TrinsicService(options);
+    options.authToken = await trinsic.account().signIn();
   });
 
   it("should run create credential templates", async () => {

--- a/web/test/ProviderService.test.ts
+++ b/web/test/ProviderService.test.ts
@@ -7,14 +7,14 @@ const options = getTestServerOptions();
 describe("ProviderService Unit Tests", () => {
   setTestTimeout();
   beforeAll(async () => {
-    let service = new TrinsicService(options);
-      options.authToken = await service.account().signIn();
+    let trinsic = new TrinsicService(options);
+      options.authToken = await trinsic.account().signIn();
   });
 
   it("Demo: Ecosystem Tests", async () => {
-    let trinsicService = new TrinsicService(options);
+    let trinsic = new TrinsicService(options);
     // createEcosystem() {
-    let actualCreate = await trinsicService.provider().createEcosystem(
+    let actualCreate = await trinsic.provider().createEcosystem(
       CreateEcosystemRequest.fromPartial({
         description: "Test ecosystem from Node",
         uri: "https://example.com",

--- a/web/test/TrustRegistry.test.ts
+++ b/web/test/TrustRegistry.test.ts
@@ -11,16 +11,16 @@ import { getTestServerOptions } from "./env";
 import { GetMembershipStatusRequest } from "../lib";
 
 const options = getTestServerOptions();
-let service: TrinsicService;
+let trinsic: TrinsicService;
 
 describe("TrustRegistryService Unit Tests", () => {
   beforeAll(async () => {
-    service = new TrinsicService(options);
-      options.authToken = await service.account().signIn(SignInRequest.fromPartial({}));
+    trinsic = new TrinsicService(options);
+      options.authToken = await trinsic.account().signIn(SignInRequest.fromPartial({}));
   });
 
   it("add governance framework", async () => {
-    let response = await service.trustRegistry().addFramework(
+    let response = await trinsic.trustRegistry().addFramework(
       AddFrameworkRequest.fromPartial({
         governanceFrameworkUri: `urn:egf:${uuid()}`,
         name: `Test Governance Framework - ${uuid()}`,
@@ -31,7 +31,7 @@ describe("TrustRegistryService Unit Tests", () => {
 
   it("add governance framework - invalid uri", async () => {
     try {
-      await service.trustRegistry().addFramework(
+      await trinsic.trustRegistry().addFramework(
         AddFrameworkRequest.fromPartial({})
       );
       // This is a failure case since jest doesn't have expect().toThrow()
@@ -46,14 +46,14 @@ describe("TrustRegistryService Unit Tests", () => {
     const frameworkUri = `urn:egf:${uuid()}`;
     const schemaUri = "https://schema.org/Card";
 
-    let frameworkResponse = await service.trustRegistry().addFramework(
+    let frameworkResponse = await trinsic.trustRegistry().addFramework(
       AddFrameworkRequest.fromPartial({
         governanceFrameworkUri: frameworkUri,
         name: `Test Governance Framework - ${uuid()}`,
       })
     );
 
-    let response = await service.trustRegistry().registerMember(
+    let response = await trinsic.trustRegistry().registerMember(
       RegisterMemberRequest.fromPartial({
         didUri: didUri,
         frameworkId: frameworkResponse.id,
@@ -62,7 +62,7 @@ describe("TrustRegistryService Unit Tests", () => {
     );
     expect(response).not.toBeNull();
 
-    let response2 = await service.trustRegistry().registerMember(
+    let response2 = await trinsic.trustRegistry().registerMember(
       RegisterMemberRequest.fromPartial({
         didUri: didUri,
         frameworkId: frameworkResponse.id,
@@ -71,7 +71,7 @@ describe("TrustRegistryService Unit Tests", () => {
     );
     expect(response2).not.toBeNull();
 
-    let issuerStatus = await service.trustRegistry().getMembershipStatus(
+    let issuerStatus = await trinsic.trustRegistry().getMembershipStatus(
       GetMembershipStatusRequest.fromPartial({
         didUri: didUri,
         governanceFrameworkUri: frameworkUri,
@@ -81,7 +81,7 @@ describe("TrustRegistryService Unit Tests", () => {
     expect(issuerStatus).not.toBeNull();
     expect(issuerStatus.status).toBe(RegistrationStatus.CURRENT);
 
-    let verifierStatus = await service.trustRegistry().getMembershipStatus(
+    let verifierStatus = await trinsic.trustRegistry().getMembershipStatus(
       GetMembershipStatusRequest.fromPartial({
         didUri: didUri,
         governanceFrameworkUri: frameworkUri,
@@ -91,7 +91,7 @@ describe("TrustRegistryService Unit Tests", () => {
     expect(verifierStatus).not.toBeNull();
     expect(verifierStatus.status).toBe(RegistrationStatus.CURRENT);
 
-    let searchResult = await service.trustRegistry().searchRegistry();
+    let searchResult = await trinsic.trustRegistry().searchRegistry();
     expect(searchResult).not.toBeNull();
     expect(searchResult.itemsJson).not.toBeNull();
     expect(searchResult.itemsJson.length > 0).toBeTruthy();

--- a/web/test/VaccineDemoShared.ts
+++ b/web/test/VaccineDemoShared.ts
@@ -23,32 +23,32 @@ const options = getTestServerOptions();
 
 export async function vaccineDemo() {
   // createService() {
-  const trinsicService = new TrinsicService(options);
+  const trinsic = new TrinsicService(options);
   // }
 
   // createEcosystem() {
-  const ecosystem = await trinsicService
+  const ecosystem = await trinsic
     .provider()
     .createEcosystem(CreateEcosystemRequest.fromPartial({}));
   const ecosystemId = ecosystem.ecosystem!.id;
   // }
 
   options.defaultEcosystem =
-    trinsicService.provider().options.defaultEcosystem = ecosystemId;
+    trinsic.provider().options.defaultEcosystem = ecosystemId;
 
   // setupActors() {
   // Create 3 different profiles for each participant in the scenario
-  const allison = await trinsicService.account().signIn();
-  const clinic = await trinsicService.account().signIn();
-  const airline = await trinsicService.account().signIn();
+  const allison = await trinsic.account().signIn();
+  const clinic = await trinsic.account().signIn();
+  const airline = await trinsic.account().signIn();
   // }
 
-  trinsicService.options.authToken = clinic;
-  const info = await trinsicService.account().info();
+  trinsic.options.authToken = clinic;
+  const info = await trinsic.account().info();
 
   // Create template
-  trinsicService.options.authToken = clinic;
-  const template = await doTemplate(trinsicService);
+  trinsic.options.authToken = clinic;
+  const template = await doTemplate(trinsic);
 
   // issueCredential() {
   // Prepare the credential values JSON document
@@ -60,8 +60,8 @@ export async function vaccineDemo() {
   });
 
   // Sign a credential as the clinic and send it to Allison
-  trinsicService.options.authToken = clinic;
-  const issueResponse = await trinsicService.credential().issueFromTemplate(
+  trinsic.options.authToken = clinic;
+  const issueResponse = await trinsic.credential().issueFromTemplate(
     IssueFromTemplateRequest.fromPartial({
       templateId: template.id,
       valuesJson: credentialValues,
@@ -71,8 +71,8 @@ export async function vaccineDemo() {
 
   // storeCredential() {
   // Alice stores the credential in her cloud wallet.
-  trinsicService.options.authToken = allison;
-  const insertResponse = await trinsicService.wallet().insertItem(
+  trinsic.options.authToken = allison;
+  const insertResponse = await trinsic.wallet().insertItem(
     InsertItemRequest.fromPartial({
       itemJson: issueResponse.documentJson,
     })
@@ -81,8 +81,8 @@ export async function vaccineDemo() {
 
   // shareCredential() {
   // Allison shares the credential with the venue.
-  trinsicService.options.authToken = allison;
-  const proofResponse = await trinsicService.credential().createProof(
+  trinsic.options.authToken = allison;
+  const proofResponse = await trinsic.credential().createProof(
     CreateProofRequest.fromPartial({
       itemId: insertResponse.itemId,
     })
@@ -91,8 +91,8 @@ export async function vaccineDemo() {
 
   // verifyCredential() {
   // The airline verifies the credential
-  trinsicService.options.authToken = airline;
-  const verifyResponse = await trinsicService.credential().verifyProof(
+  trinsic.options.authToken = airline;
+  const verifyResponse = await trinsic.credential().verifyProof(
     VerifyProofRequest.fromPartial({
       proofDocumentJson: proofResponse.proofDocumentJson,
     })

--- a/web/test/WalletService.spec.ts
+++ b/web/test/WalletService.spec.ts
@@ -13,22 +13,22 @@ import {v4 as uuid} from "uuid";
 
 let options = getTestServerOptions();
 
-let service: TrinsicService;
+let trinsic: TrinsicService;
 
 describe("wallet service tests", () => {
     setTestTimeout();
     beforeAll(async () => {
-        service = new TrinsicService(options);
-        options.authToken = await service.account().signIn();
+        trinsic = new TrinsicService(options);
+        options.authToken = await trinsic.account().signIn();
     });
 
     it("can retrieve account info", async () => {
-        const info = await service.account().info();
+        const info = await trinsic.account().info();
         expect(info).not.toBeNull();
     });
 
     it("can create new ecosystem", async () => {
-        const response = await service.provider().createEcosystem(
+        const response = await trinsic.provider().createEcosystem(
             CreateEcosystemRequest.fromPartial({})
         );
 
@@ -42,12 +42,12 @@ describe("wallet service tests", () => {
             id: "https://issuer.oidp.uscis.gov/credentials/83627465",
         };
 
-        let issueResponse = await service.credential().issueCredential({
+        let issueResponse = await trinsic.credential().issueCredential({
             documentJson: JSON.stringify(unsignedDocument),
         });
         expect(issueResponse).not.toBeNull();
 
-        let insertResponse = await service.wallet().insertItem(
+        let insertResponse = await trinsic.wallet().insertItem(
             InsertItemRequest.fromPartial({
                 itemJson: issueResponse.signedDocumentJson,
             })
@@ -55,11 +55,11 @@ describe("wallet service tests", () => {
         expect(insertResponse).not.toBeNull();
         expect(insertResponse.itemId).not.toBe("");
 
-        let searchResponse = await service.wallet().search();
+        let searchResponse = await trinsic.wallet().search();
         expect(searchResponse).not.toBeNull();
         expect(searchResponse.items.length).toBeGreaterThan(0);
 
-        let proof = await service.credential().createProof(
+        let proof = await trinsic.credential().createProof(
             CreateProofRequest.fromPartial({
                 itemId: insertResponse.itemId,
                 revealDocumentJson: JSON.stringify({
@@ -69,7 +69,7 @@ describe("wallet service tests", () => {
         );
         expect(proof).not.toBeNull();
 
-        let verifyResponse = await service.credential().verifyProof({
+        let verifyResponse = await trinsic.credential().verifyProof({
             proofDocumentJson: proof.proofDocumentJson,
         });
         expect(verifyResponse).not.toBeNull();
@@ -91,7 +91,7 @@ describe("wallet service tests", () => {
             },
         });
 
-        let template = await service.template().createCredentialTemplate(
+        let template = await trinsic.template().createCredentialTemplate(
             templateRequest
         );
 
@@ -107,7 +107,7 @@ describe("wallet service tests", () => {
             age: 42,
         });
 
-        let issueResponse = await service.credential().issueFromTemplate(
+        let issueResponse = await trinsic.credential().issueFromTemplate(
             IssueFromTemplateRequest.fromPartial({
                 templateId: template!.data!.id,
                 valuesJson: values,

--- a/web/test/WalletService.test.ts
+++ b/web/test/WalletService.test.ts
@@ -24,36 +24,36 @@ const options = getTestServerOptions();
 const allison = getTestServerOptions();
 const clinic = getTestServerOptions();
 const airline = getTestServerOptions();
-let service = new TrinsicService(options);
+let trinsic = new TrinsicService(options);
 
 describe("WalletService Unit Tests", () => {
   setTestTimeout();
   beforeAll(async () => {
-    allison.authToken = await service.account().signIn();
-    clinic.authToken = await service.account().signIn();
-    airline.authToken = await service.account().signIn();
+    allison.authToken = await trinsic.account().signIn();
+    clinic.authToken = await trinsic.account().signIn();
+    airline.authToken = await trinsic.account().signIn();
   });
 
   it("get account info", async () => {
-    let info = await service.account().info();
+    let info = await trinsic.account().info();
 
     expect(info).not.toBeNull();
   });
 
   it("create new account", async () => {
-    let response = await service.account().signIn();
+    let response = await trinsic.account().signIn();
 
     expect(response).not.toBeNull();
     expect(response).not.toBe("");
   });
 
   it("Demo: create wallet, set profile, search records, issue credential", async () => {
-    let issueResponse = await service.credential().issueCredential({
+    let issueResponse = await trinsic.credential().issueCredential({
       documentJson: getVaccineCertUnsignedJSON(),
     });
 
     // insertItemWallet() {
-    let insertItemResponse = await service.wallet().insertItem(
+    let insertItemResponse = await trinsic.wallet().insertItem(
       InsertItemRequest.fromPartial({
         itemJson: issueResponse.signedDocumentJson,
       })
@@ -68,10 +68,10 @@ describe("WalletService Unit Tests", () => {
     await new Promise((res) => setTimeout(res, 1000));
 
     // searchWalletBasic() {
-    let items = await service.wallet().search();
+    let items = await trinsic.wallet().search();
     // }
     // searchWalletSQL() {
-    let items2 = await service.wallet().search(
+    let items2 = await trinsic.wallet().search(
       SearchRequest.fromPartial({
         query:
           "SELECT c.id, c.type, c.data FROM c WHERE c.type = 'VerifiableCredential'",
@@ -79,9 +79,9 @@ describe("WalletService Unit Tests", () => {
     );
     // }
 
-    service.options = allison;
+    trinsic.options = allison;
     // createProof() {
-    let proof = await service.credential().createProof(
+    let proof = await trinsic.credential().createProof(
       CreateProofRequest.fromPartial({
         itemId: insertItemResponse.itemId,
         revealDocumentJson: getVaccineCertFrameJSON(),
@@ -89,9 +89,9 @@ describe("WalletService Unit Tests", () => {
     );
     // }
 
-    service.options = airline;
+    trinsic.options = airline;
     // verifyProof() {
-    let verifyResponse = await service.credential().verifyProof({
+    let verifyResponse = await trinsic.credential().verifyProof({
       proofDocumentJson: proof.proofDocumentJson,
     });
     // }
@@ -114,7 +114,7 @@ describe("WalletService Unit Tests", () => {
       },
     });
 
-    let template = await service
+    let template = await trinsic
       .template()
       .createCredentialTemplate(templateRequest);
 
@@ -130,7 +130,7 @@ describe("WalletService Unit Tests", () => {
       age: 42,
     });
 
-    let issueResponse = await service.credential().issueFromTemplate(
+    let issueResponse = await trinsic.credential().issueFromTemplate(
       IssueFromTemplateRequest.fromPartial({
         templateId: template.data!.id,
         valuesJson: values,


### PR DESCRIPTION
This PR updates the name of the `TrinsicService` variable used in tests to always be `trinsic`.

This way, our samples can always be in the form of `trinsic.{x}Service.Method()`.


- Python is untouched as `trinsic` would collide with the SDK namespace
- Dart and Swift untouched due to prioritization