### PR TITLE
New docs navigation style

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,8 @@ theme:
     - navigation.tracking
     - announce.dismiss
     - navigation.tabs
+    - navigation.tabs.sticky
+    - toc.integrate
     # - navigation.expand
     # - navigation.sections
   icon:


### PR DESCRIPTION
This PR enables the following `mkdocs-material` features:

- `navigation.tabs.sticky`
  - The top-level tabs no longer disappear as you scroll down the page
- `toc.integrate`
  - The Table of Contents for an article is now integrated into the left-hand nav bar, as opposed to being a separate element on the right side of the page. 