### PR TITLE
Remove duplicated authors footer

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,17 +1,5 @@
 {% extends "base.html" %}
 
-{% block content %}
-  {{ super() }}
-
-  {% if git_page_authors %}
-    <div class="md-source-date">
-      <small>
-          Authors: {{ git_page_authors | default('enable mkdocs-git-authors-plugin') }}
-      </small>
-    </div>
-  {% endif %}
-{% endblock %}
-
 {% block announce %}
 <p>Join <a href="https://trinsic.typeform.com/to/EIO26xym">Trinsic Ecosystems Beta!</a></p>
 {% endblock %}


### PR DESCRIPTION
`mkdocs-material` recently added support for `mkdocs-git-authors-plugin`, and automatically appends it to the footer of each page.

This caused our authorship to become duplicated because we are *also* adding it to the footer of each page.