### PR TITLE
Update authentication documentation

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,13 +4,63 @@ If you are ready to begin integrating the SDK, make sure you have an SDK install
 
 When using the SDK, you can pass parameters to the default service constructors and use the provided methods to set different active profiles.
 
-## Authorization
+## Authentication
+### Auth Tokens
+Authentication with the Trinsic platform operates off of auth tokens, which are strings that operate similarly to API keys.
 
-See our [security](../learn/platform/security.md) section for more information on how we have implemented wallet authentication and authorization.
-<!-- ### Profile Data Format -->
+Unlike API keys, however, Trinsic utilizes [zero-knowledge proofs](/learn/platform/security) to sign SDK calls using an auth token, without ever transmitting the auth token itself down the wire. This provides increased security compared to API keys, while being more convenient than other public/private key schemes.
 
+### Custom Protection of Auth Tokens
+
+We provide helper methods to [protect](/reference/services/account-service#protect) auth tokens -- enabling you to perform custom security operations. An auth token, once protected with a code, is unusable until unprotected with that same code. Protection and unprotection and performed entirely on-device.
+
+### Using Auth Tokens in the SDK
+
+Whenever you perform an SDK call which returns an auth token (signing in to an account, or creating an ecosystem), our SDKs will automatically store the auth token in memory and use it for subsequent calls.
+
+You can also manually set the auth token used by the SDK (such as when loading an auth token from storage):
+
+=== "Trinsic CLI" 
+    ```bash
+    trinsic config --auth-token {AUTH_TOKEN}
+    ```
+
+=== "TypeScript"
+    <!--codeinclude--> 
+    ```typescript
+    [SetAuthTokenSample](../../web/test/AccountService.test.ts) inside_block:setAuthTokenSample
+    ```
+    <!--/codeinclude-->
+
+=== "C#"
+    <!--codeinclude-->
+    ```csharp
+    [SetAuthTokenSample](../../dotnet/Tests/Tests.cs) inside_block:setAuthTokenSample
+    ```
+    <!--/codeinclude-->
+
+=== "Python"
+    <!--codeinclude-->
+    ```python
+    [SetAuthTokenSample](../../python/samples/account_demo.py) inside_block:setAuthTokenSample
+    ```
+    <!--/codeinclude-->
+
+=== "Go"
+    <!--codeinclude-->
+    ```golang
+    [SetAuthTokenSample](../../go/services/account_service_test.go) inside_block:setAuthTokenSample
+    ```
+    <!--/codeinclude-->
+
+=== "Java"
+    <!--codeinclude-->
+    ```java
+    [SetAuthTokenSample](../../java/src/test/java/trinsic/AccountServiceTest.java) inside_block:setAuthTokenSample
+    ```
+    <!--/codeinclude-->
 ## SDK Services
-Our SDK is broken down into the following services:
+Our SDK is broken down into the following logical services, each of which is accessible through a single `TrinsicService` instance:
 
 - [Account Service](./services/account-service.md)
 - [Credential Service](./services/credential-service.md)

--- a/dotnet/Tests/Tests.cs
+++ b/dotnet/Tests/Tests.cs
@@ -139,7 +139,11 @@ public class Tests
         var trinsic = new TrinsicService(_options.Clone());
         var (ecosystem, authToken) = await trinsic.Provider.CreateEcosystemAsync(new());
 
-        trinsic.SetDefaultEcosystem(ecosystem.Id).SetAuthToken(authToken);
+        trinsic.SetDefaultEcosystem(ecosystem.Id);
+
+        // setAuthTokenSample() {
+        trinsic.SetAuthToken(authToken);
+        // }
 
         // registerGovernanceFramework() {
         var schemaUri = "https://schema.org/Card";

--- a/go/services/account_service_test.go
+++ b/go/services/account_service_test.go
@@ -33,6 +33,10 @@ func TestLogin(t *testing.T) {
 	// There SHOULD be an error -- auth code should be invalid
 	assert2.NotNil(err)
 	assert2.Empty(authToken)
+
+	// setAuthTokenSample() {
+	trinsic.SetToken(authToken)
+	// }
 }
 
 func TestAuthWebhook(t *testing.T) {

--- a/java/src/test/java/trinsic/AccountServiceTest.java
+++ b/java/src/test/java/trinsic/AccountServiceTest.java
@@ -33,6 +33,10 @@ class AccountServiceTest {
           var authToken =
               trinsic.account().loginConfirm(loginResponse.getChallenge(), "12345").get();
           // }
+
+          // setAuthTokenSample() {
+          trinsic.setProfile(authToken);
+          // }
         });
   }
 

--- a/python/samples/account_demo.py
+++ b/python/samples/account_demo.py
@@ -42,6 +42,10 @@ async def account_demo():
         )
         # }
 
+        # setAuthTokenSample() {
+        trinsic.service_options.auth_token = auth_token;
+        # }
+
         assert False  # If we get here, it means login succeeded -- which is an error.
     except:
         pass

--- a/web/test/AccountService.test.ts
+++ b/web/test/AccountService.test.ts
@@ -28,6 +28,10 @@ describe("AccountService Unit Tests", () => {
       // loginConfirm() {
       const authToken = await trinsic.account().loginConfirm(loginResponse.challenge, "12345");
       //}
+
+      // setAuthTokenSample() {
+      trinsic.options.authToken = authToken;
+      //}
     } catch { }
   });
 


### PR DESCRIPTION
This PR:

- Adds documentation surrounding authentication tokens in `Reference -> Overview`
- Adds code samples for each language demonstrating how to set the current auth token

Closes #653 