### PR TITLE
Docs `navigation.sections` feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,7 +69,7 @@ theme:
     - navigation.tabs.sticky
     - toc.integrate
     # - navigation.expand
-    # - navigation.sections
+    - navigation.sections
   icon:
     repo: fontawesome/brands/github-alt
   font:


### PR DESCRIPTION
This PR enables the `navigation.sections` feature of `mkdocs-material`.


**Before**

![image](https://user-images.githubusercontent.com/1294419/176747981-26eda847-bc40-4897-b488-1e33d7cbb385.png)

**After**
![image](https://user-images.githubusercontent.com/1294419/176748061-6ab99cd3-1d0c-4baf-895c-466775e02ecb.png)
