### PR TITLE
.NET: Always send metadata; don't fail if auth token not present

### DIFF
--- a/dotnet/Trinsic/AccountService.cs
+++ b/dotnet/Trinsic/AccountService.cs
@@ -47,7 +47,7 @@ public class AccountService : ServiceBase
     /// <returns></returns>
     public async Task<string> SignInAsync(SignInRequest request) {
         if (string.IsNullOrWhiteSpace(request.EcosystemId)) request.EcosystemId = Options.DefaultEcosystem;
-        var response = await Client.SignInAsync(request);
+        var response = await Client.SignInAsync(request, await BuildMetadataAsync(request));
 
         var authToken = Base64Url.Encode(response.Profile.ToByteArray());
 
@@ -65,7 +65,7 @@ public class AccountService : ServiceBase
     /// <returns></returns>
     public string SignIn(SignInRequest request) {
         if (string.IsNullOrWhiteSpace(request.EcosystemId)) request.EcosystemId = Options.DefaultEcosystem;
-        var response = Client.SignIn(request);
+        var response = Client.SignIn(request, BuildMetadata(request));
 
         var authToken = Base64Url.Encode(response.Profile.ToByteArray());
 
@@ -127,7 +127,7 @@ public class AccountService : ServiceBase
         if (string.IsNullOrWhiteSpace(request.EcosystemId))
             request.EcosystemId = Options.DefaultEcosystem;
 
-        var response = await Client.LoginAsync(request);
+        var response = await Client.LoginAsync(request, await BuildMetadataAsync(request));
 
         if (response.ResponseCase == LoginResponse.ResponseOneofCase.Profile)
         {
@@ -146,7 +146,7 @@ public class AccountService : ServiceBase
         if (string.IsNullOrWhiteSpace(request.EcosystemId))
             request.EcosystemId = Options.DefaultEcosystem;
 
-        var response = Client.Login(request);
+        var response = Client.Login(request, BuildMetadata(request));
 
         return response;
     }
@@ -169,7 +169,7 @@ public class AccountService : ServiceBase
             ConfirmationCodeHashed = hashed.Digest
         };
 
-        var response = await Client.LoginConfirmAsync(request);
+        var response = await Client.LoginConfirmAsync(request, await BuildMetadataAsync(request));
 
         if (response?.Profile == null)
             return null;
@@ -202,7 +202,7 @@ public class AccountService : ServiceBase
             ConfirmationCodeHashed = hashed.Digest
         };
 
-        var response = Client.LoginConfirm(request);
+        var response = Client.LoginConfirm(request, BuildMetadata(request));
 
         if (response?.Profile == null)
             return null;

--- a/dotnet/Trinsic/ProviderService.cs
+++ b/dotnet/Trinsic/ProviderService.cs
@@ -37,10 +37,7 @@ public class ProviderService : ServiceBase
     public async Task<(Ecosystem ecosystem, string authToken)> CreateEcosystemAsync(CreateEcosystemRequest request) {
         request.Details ??= new();
 
-        var response = !string.IsNullOrWhiteSpace(request.Name) || !string.IsNullOrWhiteSpace(request.Details?.Email)
-            ? await Client.CreateEcosystemAsync(request, await BuildMetadataAsync(request))
-            : await Client.CreateEcosystemAsync(request);
-
+        var response = await Client.CreateEcosystemAsync(request, await BuildMetadataAsync(request));
         var authToken = Base64Url.Encode(response.Profile.ToByteArray());
 
         if (!response.Profile.Protection?.Enabled ?? true)
@@ -59,9 +56,7 @@ public class ProviderService : ServiceBase
     public (Ecosystem ecosystem, string authToken) CreateEcosystem(CreateEcosystemRequest request) {
         request.Details ??= new();
 
-        var response = !string.IsNullOrWhiteSpace(request.Name) || !string.IsNullOrWhiteSpace(request.Details?.Email)
-            ? Client.CreateEcosystem(request, BuildMetadata(request))
-            : Client.CreateEcosystem(request);
+        var response = Client.CreateEcosystem(request, BuildMetadata(request));
         var authToken = Base64Url.Encode(response.Profile.ToByteArray());
 
         if (!response.Profile.Protection?.Enabled ?? true)

--- a/dotnet/Trinsic/ServiceBase.cs
+++ b/dotnet/Trinsic/ServiceBase.cs
@@ -79,12 +79,17 @@ public abstract class ServiceBase
         var authToken = string.IsNullOrWhiteSpace(Options.AuthToken)
             ? await TokenProvider.GetAsync()
             : Options.AuthToken;
-        if (authToken is null) throw new("Cannot call authenticated endpoint before signing in");
+
+        // Return empty metadata if no auth token
+        if (authToken is null)
+        {
+            return new();
+        }
 
         var profile = AccountProfile.Parser.ParseFrom(Base64Url.DecodeBytes(authToken));
 
         return new() {
-            {"Authorization", await _securityProvider.GetAuthHeaderAsync(profile, request)}
+            { "Authorization", await _securityProvider.GetAuthHeaderAsync(profile, request) }
         };
     }
 
@@ -93,19 +98,20 @@ public abstract class ServiceBase
     /// </summary>
     /// <returns></returns>
     protected Metadata BuildMetadata(IMessage request) {
-        var authToken = string.IsNullOrWhiteSpace(Options.AuthToken) 
-            ? TokenProvider.Get() 
+        var authToken = string.IsNullOrWhiteSpace(Options.AuthToken)
+            ? TokenProvider.Get()
             : Options.AuthToken;
 
-        string authHeader = "";
-        if (authToken is not null)
+        // Return empty metadata if no auth token
+        if (authToken is null)
         {
-            var profile = AccountProfile.Parser.ParseFrom(Base64Url.DecodeBytes(authToken));
-            authHeader = _securityProvider.GetAuthHeader(profile, request);
+            return new();
         }
 
+        var profile = AccountProfile.Parser.ParseFrom(Base64Url.DecodeBytes(authToken));
+
         return new() {
-            {"Authorization", authHeader}
+            { "Authorization", _securityProvider.GetAuthHeader(profile, request) }
         };
     }
 }

--- a/dotnet/Trinsic/ServiceBase.cs
+++ b/dotnet/Trinsic/ServiceBase.cs
@@ -96,12 +96,16 @@ public abstract class ServiceBase
         var authToken = string.IsNullOrWhiteSpace(Options.AuthToken) 
             ? TokenProvider.Get() 
             : Options.AuthToken;
-        if (authToken is null) throw new("Cannot call authenticated endpoint before signing in");
 
-        var profile = AccountProfile.Parser.ParseFrom(Base64Url.DecodeBytes(authToken));
+        string authHeader = "";
+        if (authToken is not null)
+        {
+            var profile = AccountProfile.Parser.ParseFrom(Base64Url.DecodeBytes(authToken));
+            authHeader = _securityProvider.GetAuthHeader(profile, request);
+        }
 
         return new() {
-            {"Authorization", _securityProvider.GetAuthHeader(profile, request)}
+            {"Authorization", authHeader}
         };
     }
 }

--- a/dotnet/Trinsic/Trinsic.xml
+++ b/dotnet/Trinsic/Trinsic.xml
@@ -326,6 +326,43 @@
             blake3256 hash of the request body
             </summary>
         </member>
+        <member name="P:Trinsic.Services.Common.V1.Common.Descriptor">
+            <summary>Service descriptor</summary>
+        </member>
+        <member name="T:Trinsic.Services.Common.V1.Common.CommonBase">
+            <summary>Base class for server-side implementations of Common</summary>
+        </member>
+        <member name="T:Trinsic.Services.Common.V1.Common.CommonClient">
+            <summary>Client for Common</summary>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.CommonClient.#ctor(Grpc.Core.ChannelBase)">
+            <summary>Creates a new client for Common</summary>
+            <param name="channel">The channel to use to make remote calls.</param>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.CommonClient.#ctor(Grpc.Core.CallInvoker)">
+            <summary>Creates a new client for Common that uses a custom <c>CallInvoker</c>.</summary>
+            <param name="callInvoker">The callInvoker to use to make remote calls.</param>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.CommonClient.#ctor">
+            <summary>Protected parameterless constructor to allow creation of test doubles.</summary>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.CommonClient.#ctor(Grpc.Core.ClientBase.ClientBaseConfiguration)">
+            <summary>Protected constructor to allow creation of configured clients.</summary>
+            <param name="configuration">The client configuration.</param>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.CommonClient.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)">
+            <summary>Creates a new instance of client from given <c>ClientBaseConfiguration</c>.</summary>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.BindService(Trinsic.Services.Common.V1.Common.CommonBase)">
+            <summary>Creates service definition that can be registered with a server</summary>
+            <param name="serviceImpl">An object implementing the server-side handling logic.</param>
+        </member>
+        <member name="M:Trinsic.Services.Common.V1.Common.BindService(Grpc.Core.ServiceBinderBase,Trinsic.Services.Common.V1.Common.CommonBase)">
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
+            Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
+            <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
+            <param name="serviceImpl">An object implementing the server-side handling logic.</param>
+        </member>
         <member name="T:Trinsic.Services.Account.V1.AccountReflection">
             <summary>Holder for reflection information generated from services/account/v1/account.proto</summary>
         </member>


### PR DESCRIPTION
This PR changes .NET to always send message metadata in every call (even if unnecessary). Additionally, `BuildMetadata[Async]` no longer throws if `authToken` is not present; instead, it simply sends an empty auth header.

All in accordance with #822 