### PR TITLE
Fork `codeinclude` plugin to enable fail-on-not-found functionality

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,7 @@
 mkdocs
 git+https://github.com/squidfunk/mkdocs-material@master#egg=mkdocs-material
-mkdocs-codeinclude-plugin
+git+https://github.com/trinsic-id/mkdocs-codeinclude-plugin@master#egg=mkdocs-codeinclude-plugin
 mkdocs-macros-plugin
-# mkdocs-git-authors-plugin
 git+https://github.com/trinsic-id/mkdocs-git-authors-plugin@sort-order#egg=mkdocs-git-authors-plugin
 mkdocstrings
 mkdocstrings-python-legacy


### PR DESCRIPTION
The `codeinclude` plugin we use has undesirable behavior: when it can't find the injection target, it instead injects the *entire file* as opposed to throwing an error

Additionally, it uses the `better-setuptools-git-version` module, which breaks completely on Python 3.10 -- our fork strips this out as well.


I have forked the plugin to https://github.com/trinsic-id/mkdocs-codeinclude-plugin, and resolved the two above issues in said fork.

This PR changes `docs/requirements.txt` to use the forked version.

**Note**: This PR will intentionally enter our docs into a broken state, wherein they fail to build. This is because we have one or more failed code injection sites. This is desirable; I will create a PR to fix these issues as soon as this one is merged.