### PR TITLE
Target the main branch for `sdk-swift`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "swift"]
 	path = swift
 	url = https://github.com/trinsic-id/sdk-swift
+	branch = main


### PR DESCRIPTION
This ensures that we only submodule in the `main` branch, which is what we would expect. (As opposed to `HEAD`)