### PR TITLE
Remove usage of invalid `--name` parameter in tutorial

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ Immediately following `proto_sample_start()` should be a set of tabs, **indented
 {{ proto_sample_start() }}
     === "Trinsic CLI" 
         ```bash
-        trinsic account login --email <PROFILE_EMAIL> --name <PROFILE_NAME>
+        trinsic account login --email <PROFILE_EMAIL>
         ```
 
     === "TypeScript"

--- a/docs/walkthroughs/vaccination.md
+++ b/docs/walkthroughs/vaccination.md
@@ -137,13 +137,13 @@ The clinic's account will **issue** the credential, Allison's account will **hol
     When using the CLI, the authentication token of the most recently used account is saved in `~/.trinsic`. In a real-world scenario, you should back this token up securely.
 
     ```bash
-    trinsic account login --ecosystem {ECOSYSTEM_ID} --name "Allison"
+    trinsic account login --ecosystem {ECOSYSTEM_ID}
     # Save auth token in `allison.txt` before continuing
 
-    trinsic account login --ecosystem {ECOSYSTEM_ID} --name "Airline"
+    trinsic account login --ecosystem {ECOSYSTEM_ID}
     # Save auth token in `airline.txt` before continuing
 
-    trinsic account login --ecosystem {ECOSYSTEM_ID} --name "Vaccination Clinic"
+    trinsic account login --ecosystem {ECOSYSTEM_ID}
     # Save auth token in `clinic.txt` before continuing
     ```
 


### PR DESCRIPTION
The `--name` parameter was removed from the `trinsic account login` command, so the docs should not reference it.

Closes #925 (unless we want to further resolve by re-adding the feature)