### PR TITLE
fix: Specify Browser and Node module types (fixes #940)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,16 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    "*": {
+        "browser": [
+            "./lib/browser/index.d.ts"
+        ],
+        "node": [
+            "./lib/node/index.d.ts"
+        ]
+    }
+  },
   "files": [
     "lib/**/*"
   ],


### PR DESCRIPTION
For more information, [see Publishing documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).

Follow up question is how to handle the default export, as code editors will now hint and suggest you can do `import {AccountService} from "@trinsic/trinsic"`