### PR TITLE
Fix documentation PR automation breaking with emojis in branch names

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -41,7 +41,7 @@ jobs:
       - run: mkdocs build
       - name: Determine Branch Name
         run: |
-          DOCS_BRANCH_VAR="$(echo "trinsic-docs-pr-${{ github.head_ref }}" | tr / - | tr '[:upper:]' '[:lower:]')"
+          DOCS_BRANCH_VAR="$(echo "trinsic-docs-pr-${{ github.sha }}" | tr / - | tr '[:upper:]' '[:lower:]')"
           echo "DOCS_BRANCH_NAME=$DOCS_BRANCH_VAR" >> $GITHUB_ENV
           echo "Branch name: $DOCS_BRANCH_VAR"
       - name: Create new Netlify site

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,6 @@ hide:
 ## Issue and verify universally-accepted digital credentials.
 Trinsic is the proof of anything platform. We make it easy for people and organizations to prove things about themselves with technology instead of paper documents. Our software is based on Decentralized Identifiers (DIDs) and Verifiable Credentials (VCs), a new digital identity standard. 
 
-A test change to trigger docs PR.
-
 Using Trinsic, organizations and their customers share data between each other in a trustworthy, standardized, and privacy-preserving way without requiring a centralized server or database. 
 
 We make all of this possible by signing, sharing and storing verifiable data within identity wallets owned by individuals. People can easily share them with others to prove things about themselves anywhere.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,8 @@ hide:
 ## Issue and verify universally-accepted digital credentials.
 Trinsic is the proof of anything platform. We make it easy for people and organizations to prove things about themselves with technology instead of paper documents. Our software is based on Decentralized Identifiers (DIDs) and Verifiable Credentials (VCs), a new digital identity standard. 
 
+A test change to trigger docs PR.
+
 Using Trinsic, organizations and their customers share data between each other in a trustworthy, standardized, and privacy-preserving way without requiring a centralized server or database. 
 
 We make all of this possible by signing, sharing and storing verifiable data within identity wallets owned by individuals. People can easily share them with others to prove things about themselves anywhere.


### PR DESCRIPTION
- Changes the GitHub Action which auto-hosts a preview of the docs site to use the commit hash in the generated URL, as opposed to the branch name.
  - Ensures that branch names can have any characters, including emojis, without breaking anything
  - Subsequent pushes to a PR won't overwrite previous previews

Fixes #928 