### PR TITLE
Configure TrinsicService with DI pipeline. Docs update.

### DIFF
--- a/docs/dotnet/index.md
+++ b/docs/dotnet/index.md
@@ -1,4 +1,4 @@
-# The Trinsic C# / .NET SDK  
+# The Trinsic C# / .NET SDK
 The Trinsic C# / .NET SDK makes it easy to interact with the Trinsic API from your .NET application. The most recent version of the library can be found on NuGet. The Trinsic SDK supports .NET applications written in C#, VB.NET, and F# that utilize any supported version of .NET Core. You can also find the SDKs source on [Github](https://github.com/trinsic-id/sdk/dotnet).
 
 
@@ -6,8 +6,8 @@ The Trinsic C# / .NET SDK makes it easy to interact with the Trinsic API from yo
     .NET targets for iOS, Android, and Blazor are fully supported using the same package dependencies via .NET 6.
 
 ## Installation in a new project
-Add the required dependencies from [Nuget.org <small>:material-open-in-new:</small>](https://www.nuget.org/packages/Trinsic)
 
+Add the required dependencies from [Nuget.org <small>:material-open-in-new:</small>](https://www.nuget.org/packages/Trinsic)
 
 === "Package Manager"
     ```
@@ -21,7 +21,44 @@ Add the required dependencies from [Nuget.org <small>:material-open-in-new:</sma
     ```
     <PackageReference Include="Trinsic" />
     ```
-    
+
+To register the services with dependency injection pipeline:
+
+```cs
+services.AddTrinsic();
+```
+
+To configure additional parameters:
+
+```cs
+services.AddTrinsic(options =>
+{
+    // to configure the service with your auth token
+    options.ServiceOptions.AuthToken = "<auth_token>";
+})
+```
+
+The service can then be injected in your controller as
+
+```cs
+public MyController(TrinsicService trinsicService)
+{
+    // init
+}
+```
+
+Alternatively, you can simply instantiate this service with or without parameters
+
+```cs
+var trinsicService = new TrinsicService();
+
+// or
+
+var trinsicService = new TrinsicService(new ServiceOptions
+{
+    AuthToken = "<auth_token>"
+});
+```
 
 ## Configuration
 

--- a/docs/dotnet/index.md
+++ b/docs/dotnet/index.md
@@ -60,14 +60,6 @@ var trinsicService = new TrinsicService(new ServiceOptions
 });
 ```
 
-## Configuration
-
-<!--codeinclude-->
-```csharp
-[SampleAccountService](../../dotnet/Tests/Tests.cs) inside_block:testSignInAndGetInfo
-```
-<!--/codeinclude-->
-
 ## Next Steps
 
 Once the .NET SDK package is installed and configured, you're ready to start building! We recommend going through the [walkthrough](../walkthroughs/vaccination.md) next. If you're ready to dive into building your ecosystem, check out our [API Reference](../reference/index.md)

--- a/dotnet/Trinsic/Configuration/DefaultTrinsicBuilder.cs
+++ b/dotnet/Trinsic/Configuration/DefaultTrinsicBuilder.cs
@@ -1,0 +1,20 @@
+using Trinsic.Sdk.Options.V1;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public class DefaultTrinsicBuilder : ITrinsicBuilder
+{
+    internal DefaultTrinsicBuilder(IServiceCollection services) {
+        Services = services;
+        ServiceOptions = new();
+    }
+
+    /// <inheritdoc/>
+    public IServiceCollection Services { get; }
+
+    /// <inheritdoc/>
+    public bool TokenPersistenceEnabled { get; set; } = true;
+
+    /// <inheritdoc/>
+    public ServiceOptions ServiceOptions { get; set; }
+}

--- a/dotnet/Trinsic/Configuration/ITrinsicBuilder.cs
+++ b/dotnet/Trinsic/Configuration/ITrinsicBuilder.cs
@@ -1,0 +1,22 @@
+using Trinsic.Sdk.Options.V1;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection;
+
+public interface ITrinsicBuilder
+{
+    /// <summary>
+    /// Service collection
+    /// </summary>
+    IServiceCollection Services { get; }
+
+    /// <summary>
+    /// Enables or disables automatic token persistence
+    /// </summary>
+    bool TokenPersistenceEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the network endpoint service options
+    /// </summary>
+    ServiceOptions ServiceOptions { get; set; }
+}

--- a/dotnet/Trinsic/Extensions/ServiceOptionsExtensions.cs
+++ b/dotnet/Trinsic/Extensions/ServiceOptionsExtensions.cs
@@ -1,9 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
 using Trinsic.Sdk.Options.V1;
 
 namespace Trinsic.Services.Common.V1;
 
 public static class ServiceOptionsExtensions
 {
+    public static ITrinsicBuilder UseInMemoryTokenProvider(this ITrinsicBuilder builder) {
+        builder.Services.AddSingleton<ITokenProvider, MemoryTokenProvider>();
+        return builder;
+    }
     public static string FormatUrl(this ServiceOptions options) {
         return $"{(options.ServerUseTls ? "https" : "http")}://{options.ServerEndpoint}:{options.ServerPort}";
     }

--- a/dotnet/Trinsic/Storage/NoOpTokenProvider.cs
+++ b/dotnet/Trinsic/Storage/NoOpTokenProvider.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Trinsic;
+
+public class NoOpTokenProvider : ITokenProvider
+{
+    public Task<string?> GetAsync(string name = TokenDefaults.Name, CancellationToken cancellationToken = default) {
+        return Task.FromResult(default(string));
+    }
+    public string? Get(string name = TokenDefaults.Name) {
+        return default;
+    }
+    public Task SaveAsync(string authToken, string name = TokenDefaults.Name, CancellationToken cancellationToken = default) {
+        return Task.CompletedTask;
+    }
+    public void Save(string authToken, string name = TokenDefaults.Name) {
+    }
+}

--- a/dotnet/Trinsic/Trinsic.xml
+++ b/dotnet/Trinsic/Trinsic.xml
@@ -5337,7 +5337,7 @@
             Fetch the membership status of an issuer for a given credential schema in a trust registry
             </summary>	
         </member>
-        <member name="M:Trinsic.WalletService.SearchAsync(Trinsic.Services.UniversalWallet.V1.SearchRequest)">
+        <member name="M:Trinsic.WalletService.SearchWalletAsync(Trinsic.Services.UniversalWallet.V1.SearchRequest)">
             <summary>
                 Search the wallet for records matching the specified criteria
             </summary>
@@ -5346,7 +5346,7 @@
             </remarks>
             <returns></returns>
         </member>
-        <member name="M:Trinsic.WalletService.Search(Trinsic.Services.UniversalWallet.V1.SearchRequest)">
+        <member name="M:Trinsic.WalletService.SearchWallet(Trinsic.Services.UniversalWallet.V1.SearchRequest)">
             <summary>
                 Search the wallet for records matching the specified criteria
             </summary>
@@ -5363,6 +5363,16 @@
         <member name="M:Trinsic.WalletService.GetItemAsync(Trinsic.Services.UniversalWallet.V1.GetItemRequest)">
             <summary>
             Retrieve an item from the wallet with a given item identifier
+            </summary>	
+        </member>
+        <member name="M:Trinsic.WalletService.Search(Trinsic.Services.UniversalWallet.V1.SearchRequest)">
+            <summary>
+            Search the wallet using a SQL syntax
+            </summary>	
+        </member>
+        <member name="M:Trinsic.WalletService.SearchAsync(Trinsic.Services.UniversalWallet.V1.SearchRequest)">
+            <summary>
+            Search the wallet using a SQL syntax
             </summary>	
         </member>
         <member name="M:Trinsic.WalletService.InsertItem(Trinsic.Services.UniversalWallet.V1.InsertItemRequest)">
@@ -5438,6 +5448,37 @@
             Authentication token for SDK calls; defaults to empty string (unauthenticated)
             </summary>
         </member>
+        <member name="P:Microsoft.Extensions.DependencyInjection.DefaultTrinsicBuilder.Services">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.Extensions.DependencyInjection.DefaultTrinsicBuilder.TokenPersistenceEnabled">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.Extensions.DependencyInjection.DefaultTrinsicBuilder.ServiceOptions">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.Extensions.DependencyInjection.ITrinsicBuilder.Services">
+            <summary>
+            Service collection
+            </summary>
+        </member>
+        <member name="P:Microsoft.Extensions.DependencyInjection.ITrinsicBuilder.TokenPersistenceEnabled">
+            <summary>
+            Enables or disables automatic token persistence
+            </summary>
+        </member>
+        <member name="P:Microsoft.Extensions.DependencyInjection.ITrinsicBuilder.ServiceOptions">
+            <summary>
+            Gets or sets the network endpoint service options
+            </summary>
+        </member>
+        <member name="M:Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddTrinsic(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            Registers Trinsic SDK services and dependencies
+            </summary>
+            <param name="services"></param>
+            <returns></returns>
+        </member>
         <member name="M:Google.Protobuf.ProtoMessageExtensions.As``1(Google.Protobuf.IMessage)">
             <summary>
             Converts a message from one type into another. The two types must be compatible
@@ -5445,21 +5486,6 @@
             </summary>
             <typeparam name="T"></typeparam>
             <param name="message"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddTrinsic(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Trinsic.Sdk.Options.V1.ServiceOptions})">
-            <summary>
-            Registers Trinsic SDK services and dependencies
-            </summary>
-            <param name="services"></param>
-            <param name="configure"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddTrinsic(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
-            <summary>
-            Registers Trinsic SDK services and dependencies
-            </summary>
-            <param name="services"></param>
             <returns></returns>
         </member>
     </members>

--- a/dotnet/Trinsic/TrinsicService.cs
+++ b/dotnet/Trinsic/TrinsicService.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Threading.Tasks;
-using Google.Protobuf;
 using Microsoft.Extensions.Options;
-using Okapi.Security;
-using Okapi.Security.V1;
 using Trinsic.Sdk.Options.V1;
-using Trinsic.Services.Account.V1;
+using MicrosoftOptions = Microsoft.Extensions.Options.Options;
 
 namespace Trinsic;
 
@@ -32,8 +27,12 @@ public class TrinsicService : ServiceBase
     internal TrinsicService(ITokenProvider tokenProvider) : base(new(), tokenProvider) {
     }
 
-    internal TrinsicService(ITokenProvider tokenProvider, ServiceOptions options)
+    public TrinsicService(ITokenProvider tokenProvider, ServiceOptions options)
         : base(options, tokenProvider) {
+    }
+
+    internal TrinsicService(ITokenProvider tokenProvider, IOptions<ServiceOptions> options)
+        : base(options.Value, tokenProvider) {
     }
 
     /// <summary>
@@ -45,7 +44,7 @@ public class TrinsicService : ServiceBase
         {
             if (_account == null)
             {
-                _account = new AccountService(Options);
+                _account = new AccountService(TokenProvider, MicrosoftOptions.Create(Options));
             }
             return _account;
         }
@@ -60,7 +59,7 @@ public class TrinsicService : ServiceBase
         {
             if (_credential == null)
             {
-                _credential = new CredentialService(Options);
+                _credential = new CredentialService(TokenProvider, MicrosoftOptions.Create(Options));
             }
             return _credential;
         }
@@ -75,7 +74,7 @@ public class TrinsicService : ServiceBase
         {
             if (_template == null)
             {
-                _template = new TemplateService(Options);
+                _template = new TemplateService(TokenProvider, MicrosoftOptions.Create(Options));
             }
             return _template;
         }
@@ -90,7 +89,7 @@ public class TrinsicService : ServiceBase
         {
             if (_provider == null)
             {
-                _provider = new ProviderService(Options);
+                _provider = new ProviderService(TokenProvider, MicrosoftOptions.Create(Options));
             }
             return _provider;
         }
@@ -105,7 +104,7 @@ public class TrinsicService : ServiceBase
         {
             if (_trustRegistry == null)
             {
-                _trustRegistry = new TrustRegistryService(Options);
+                _trustRegistry = new TrustRegistryService(TokenProvider, MicrosoftOptions.Create(Options));
             }
             return _trustRegistry;
         }
@@ -120,7 +119,7 @@ public class TrinsicService : ServiceBase
         {
             if (_wallet == null)
             {
-                _wallet = new WalletService(Options);
+                _wallet = new WalletService(TokenProvider, MicrosoftOptions.Create(Options));
             }
             return _wallet;
         }


### PR DESCRIPTION
- Added the TrinsicService to the DI extensions
- Introduced builder pattern to configure service options and token persistence
- Updated documentation for using the dotnet sdk in common scenarios
  - Removed documentation block for Configuration which causes confusion about using the SDK in server scenario. Code block applied to client-side