### PR TITLE
Release 1.8.0 Fixes

### DIFF
--- a/devops/build_sdks.py
+++ b/devops/build_sdks.py
@@ -8,12 +8,15 @@ import os
 import platform
 import shutil
 import subprocess
-
-import pygit2
-import requests
 from os.path import join, abspath, dirname, isdir, split
 from typing import Dict
-from pygit2 import Repository
+
+try:
+    import requests
+except:
+    os.system("pip install requests")
+    import requests
+
 
 
 def parse_version_tag():

--- a/devops/requirements.txt
+++ b/devops/requirements.txt
@@ -2,4 +2,3 @@ git+https://github.com/danielgtaylor/python-betterproto.git@3ca092a72494f9225bcb
 grpcio-tools
 requests
 markupsafe==2.1.1
-pygit2

--- a/go/services/services.go
+++ b/go/services/services.go
@@ -11,7 +11,7 @@ import (
 
 // GetSdkVersion used to send metadata
 func GetSdkVersion() string {
-	const sdkVersion = "1.0.0"
+    const sdkVersion = "1.8.0"
 	return sdkVersion
 }
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -21,7 +21,7 @@ java {
 def jarDomainId = "id"
 def jarGroupId = "trinsic"
 def jarArtifactId = "services"
-def jarVersion = "1.4.0"
+def jarVersion = "1.8.0"
 
 apply plugin: 'kotlin'
 

--- a/java/src/main/java/trinsic/TrinsicUtilities.java
+++ b/java/src/main/java/trinsic/TrinsicUtilities.java
@@ -92,7 +92,7 @@ public class TrinsicUtilities {
   }
 
   public static String getSdkVersion() {
-    final String sdkVersion = "1.0.0";
+    final String sdkVersion = "1.8.0";
     return sdkVersion;
   }
 }

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = trinsic-sdk
-version = 1.6.0
+version = 1.8.0
 author = Scott Phillips
 author_email = scott.phillips@trinsic.id
 description = Trinsic Services SDK bindings

--- a/python/trinsic/__init__.py
+++ b/python/trinsic/__init__.py
@@ -1,3 +1,3 @@
 def __version__():
-    sdk_version = "1.6.0"
+    sdk_version = "1.8.0"
     return sdk_version

--- a/ruby/lib/version.rb
+++ b/ruby/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Trinsic
-  VERSION = '1.4.0'
+  VERSION = '1.8.0'
 end

--- a/ruby/trinsic.gemspec
+++ b/ruby/trinsic.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency 'rbs', '~> 1.6'
   spec.add_development_dependency 'simplecov', '~> 0.21'
   spec.add_development_dependency 'simplecov-cobertura', '~> 1.4'
-  spec.metadata['rubygems_mfa_required'] = 'true'
+  spec.metadata['rubygems_mfa_required'] = 'false'
 end

--- a/web/src/Version.ts
+++ b/web/src/Version.ts
@@ -1,4 +1,4 @@
 export function getSdkVersion(): string {
-    const sdkVersion = "1.0.0";
+    const sdkVersion = "1.8.0";
     return sdkVersion;
 }


### PR DESCRIPTION
no ruby MFA, don't include unnecessary packages, force update package default versions