### PR TITLE
`docs-v2` -> `docs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,22 +41,22 @@ Learn how to issue and verify universally-accepted digital credentials so that a
 
 ## Getting Started
 
-Check our our [documentation](https://docs-v2.trinsic.id) to learn about Trinsic, work through a basic implementation, plan a full integration, and learn about our tools you can use.
+Check our our [documentation](https://docs.trinsic.id) to learn about Trinsic, work through a basic implementation, plan a full integration, and learn about our tools you can use.
 
 ## Example Implementations
 
 Check out our [dedicated repository with various examples](https://github.com/trinsic-id/sdk-examples/) and use cases for different platforms and languages.
 
 ## Available SDKs
-- [.NET](https://docs-v2.trinsic.id/dotnet)
-- [Java / Android](https://docs-v2.trinsic.id/java)
-- [Swift](https://docs-v2.trinsic.id/python)
-- [TypeScript / Node](https://docs-v2.trinsic.id/node)
-- [TypeScript / Browser](https://docs-v2.trinsic.id/node)
-- [Python](https://docs-v2.trinsic.id/python)
-- [Go](https://docs-v2.trinsic.id/go)
-- [Ruby](https://docs-v2.trinsic.id/ruby)
-- [Command Line](https://docs-v2.trinsic.id/cli)
+- [.NET](https://docs.trinsic.id/dotnet)
+- [Java / Android](https://docs.trinsic.id/java)
+- [Swift](https://docs.trinsic.id/python)
+- [TypeScript / Node](https://docs.trinsic.id/node)
+- [TypeScript / Browser](https://docs.trinsic.id/node)
+- [Python](https://docs.trinsic.id/python)
+- [Go](https://docs.trinsic.id/go)
+- [Ruby](https://docs.trinsic.id/ruby)
+- [Command Line](https://docs.trinsic.id/cli)
 
 ## Updating Proto-Generated Files
 

--- a/dart/README.md
+++ b/dart/README.md
@@ -1,4 +1,4 @@
-Dart bindings for Trinsic SDK https://docs-v2.trinsic.id/
+Dart bindings for Trinsic SDK https://docs.trinsic.id/
 
 
 ## Usage
@@ -11,4 +11,4 @@ var trinsic = TrinsicService(trinsicConfig(), null);
 
 ## Additional information
 
-General documentation here: https://docs-v2.trinsic.id/
+General documentation here: https://docs.trinsic.id/

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-docs-v2.trinsic.id
+docs.trinsic.id

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -16,4 +16,4 @@ dotnet add package Trinsic.Web
 
 ## Usage
 
-See [documentation here](https://docs-v2.trinsic.id/)
+See [documentation here](https://docs.trinsic.id/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_dir: docs-site
 repo_url: "https://github.com/trinsic-id/sdk"
 edit_uri: edit/main/docs/
 repo_name: trinsic-id/sdk
-site_url: https://docs-v2.trinsic.id
+site_url: https://docs.trinsic.id
 nav:
   - Home:
     - Introduction: index.md

--- a/python/README.md
+++ b/python/README.md
@@ -13,4 +13,4 @@ the encoded `AccountProfile`. For more information, see the documentation link b
 
 ## Documentation
 
-See [documentation here](https://docs-v2.trinsic.id/)
+See [documentation here](https://docs.trinsic.id/)

--- a/ruby/trinsic.gemspec
+++ b/ruby/trinsic.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['polygonguru@gmail.com']
 
   spec.summary       = 'Trinsic Services Ruby SDK'
-  spec.description   = 'Ruby language wrapper for the Trinsic services. Documentation site is here: https://docs-v2.trinsic.id/'
+  spec.description   = 'Ruby language wrapper for the Trinsic services. Documentation site is here: https://docs.trinsic.id/'
   spec.homepage      = 'https://github.com/trinsic-id/sdk'
   spec.license       = 'MIT'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')

--- a/web/README.md
+++ b/web/README.md
@@ -18,7 +18,7 @@ import { AccountService } from "@trinsic/sdk/browser";
 
 ## Documentation
 
-See [documentation here](https://docs-v2.trinsic.id/)
+See [documentation here](https://docs.trinsic.id/)
 
 ## Maintainers
 


### PR DESCRIPTION
This PR changes all links to `docs-v2.trinsic.id` to `docs.trinsic.id`

**NOTE: We still need to actually switch the subdomain over. This PR does not change anything about the GitHub page or DNS configuration**.