### PR TITLE
Fix size of Trinsic logo in docs

### DIFF
--- a/docs/_static/extra.css
+++ b/docs/_static/extra.css
@@ -28,7 +28,6 @@ input {
 }
 
 .md-header__button.md-logo {
-    margin-bottom: .4rem;
 }
 
 .md-header__button.md-logo img,
@@ -36,7 +35,7 @@ input {
 .md-nav__title .md-nav__button.md-logo img,
 .md-nav__title .md-nav__button.md-logo svg {
     width: auto;
-    height: 1.8rem;
+    height: 1.6rem !important;
 }
 
 


### PR DESCRIPTION
This PR increases the size of the Trinsic logo in the docs header.

**Old**
![image](https://user-images.githubusercontent.com/1294419/199291235-6cb84ddb-8e96-477c-8c18-6bb43c65443e.png)

**New**
![image](https://user-images.githubusercontent.com/1294419/199291209-775ad58c-8923-46b0-9ced-266dc8cfbe28.png)
