### PR TITLE
Mark Deprecated endpoints in the docs

### DIFF
--- a/docs/learn/concepts/wallets.md
+++ b/docs/learn/concepts/wallets.md
@@ -1,16 +1,16 @@
 # Wallets
 
-In Trinsic’s platform, identity wallets are secure, partitioned data stores scoped to a single holder, capable of storing and sharing credentials and proofs. Endless configurations of wallets exist (custodial, non-custodial, etc.) each with different trade-offs; Trinsic has designed a hybrid-cloud wallet system intended to strike the ideal balance between security and usability: 
+In Trinsic’s platform, identity wallets are secure, partitioned data stores scoped to a single holder, capable of storing and sharing credentials and proofs. Endless configurations of wallets exist (custodial, non-custodial, etc.) each with different trade-offs; Trinsic has designed a hybrid-cloud wallet system intended to strike the ideal balance between security and usability:
 
 - Cloud-based data store
 - Edge-based authentication keys
 
-For a deeper-dive into how hybrid-cloud wallets work, see our [security overview](/learn/platform/security). 
+For a deeper-dive into how hybrid-cloud wallets work, see our [security overview](/learn/platform/security).
 
 ### How to use wallets in your app
 
-When a user creates an account in your product, you will create a wallet for them. This wallet is tied to the user’s identity using either their email or phone number (for now) - after the user enters the code to prove control of their identifier and claim their wallet, you’ll be off to the races. 
+When a user creates an account in your product, you will create a wallet for them. This wallet is tied to the user’s identity using either their email or phone number (for now) - after the user enters the code to prove control of their identifier and claim their wallet, you’ll be off to the races.
 
 The user will interact with and control their wallet through your application. From your application’s perspective, wallet storage should be treated in parallel with the database you use to manage user data. When users obtain credentials from inside or outside your ecosystem, those credentials will be inserted in the wallet. When users want to share credentials with verifiers, your product will need to obtain user consent before the data is shared.
 
-All the participants in an ecosystem, not just holders, will technically have wallets behind them. Therefore any participant can issue, verify, and hold credentials to establish trust.
+All the participants in an ecosystem, not just holders, will technically have wallets behind them. Therefore, any participant can issue from a template, verify, and hold credentials to establish trust.

--- a/docs/reference/services/credential-service.md
+++ b/docs/reference/services/credential-service.md
@@ -12,6 +12,9 @@ The Credential Service exposes functionality for issuance, proof generation, ver
 
 ## Issue Credential
 
+!!! warning "Deprecation Notice"
+    This endpoint is deprecated, and will be removed on May 1, 2023. Please call [Issue Credential From Template](./credential-service.md#issue-credential-from-template).
+
 Issues a credential from a valid JSON-LD document. Issued credentials are not automatically stored in any wallet.
 
 {{ proto_sample_start() }}
@@ -57,7 +60,7 @@ Issues a credential from a valid JSON-LD document. Issued credentials are not au
 
 {{ proto_method_tabs("services.verifiablecredentials.v1.VerifiableCredential.Issue") }}
 
-!!! warning
+!!! warning "`Issue` vs `IssueFromTemplate`"
     **`IssueCredential` requires a valid JSON-LD document to be provided**. Do not confuse this operation with [Issue Credential From Template](./credential-service.md#issue-credential-from-template).
 
     When provided a valid credential, this endpoint creates and appends the `proof` object, using a key pair tied to the issuing Trinsic account.

--- a/docs/reference/services/provider-service.md
+++ b/docs/reference/services/provider-service.md
@@ -65,6 +65,9 @@ If `name` is left empty, an anonymous ecosystem will be created.
 
 ## Update Ecosystem
 
+!!! warning "Deprecation Notice"
+    This endpoint is deprecated, and will be removed May 1, 2023. Please use the [dashboard to update](https://dashboard.trinsic.id/).
+
 Updates the active ecosystem's `description` or `uri`.
 
 {{proto_sample_start()}}


### PR DESCRIPTION
* I looked for discussion of `Issue` endpoint, and everything seems to talk about issuing from templates.
* Added a warning header about deprecation