### PR TITLE
update okapi-python to 1.6.1

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/danielgtaylor/python-betterproto.git@3ca092a72494f9225bcb124aab2d0675f9e8c125#egg=betterproto
 grpclib==0.4.3
 grpcio-tools
-trinsic-okapi==1.6.0
+trinsic-okapi==1.6.1
 deprecation==2.1.0


### PR DESCRIPTION
* Fixes a customer reported bug where the native libraries aren't found
* Closes https://github.com/trinsic-id/server/issues/1659