### PR TITLE
Add `deprecation` package to `install_requires`

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = trinsic-sdk
-version = 1.8.0
+version = 1.9.1
 author = Scott Phillips
 author_email = scott.phillips@trinsic.id
 description = Trinsic Services SDK bindings
@@ -22,6 +22,7 @@ install_requires =
     grpclib>=0.4.3rc2
     betterproto>=2.0.0b4
     trinsic-okapi>=1.6.0
+    deprecation>=2.1.0
 
 [options.packages.find]
 exclude = tests


### PR DESCRIPTION
This fixes a bug [reported here](https://trinsiccommunity.slack.com/archives/C01L6QK7VJ4/p1675676695974239?thread_ts=1675352568.121159&cid=C01L6QK7VJ4)