### PR TITLE
Update proto/README.md to direct to single source of truth

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -2,6 +2,8 @@
 
 These files are synched with Buf repo at https://buf.build/trinsic/services.
 
+***Do not edit/add files directly here. Any work on protobuf files must be performed on [trinsic-id/server](https://github.com/trinsic-id/server/tree/main/proto)** Any work there will be reflected here.
+
 ## Working with Buf repo
 
 Requires Buf CLI. See intallation instructions - https://docs.buf.build/installation

--- a/proto/README.md
+++ b/proto/README.md
@@ -2,7 +2,7 @@
 
 These files are synched with Buf repo at https://buf.build/trinsic/services.
 
-***Do not edit/add files directly here. Any work on protobuf files must be performed on [trinsic-id/server](https://github.com/trinsic-id/server/tree/main/proto)** Any work there will be reflected here.
+***Do not edit/add files directly here. Any work on protobuf files must be performed on [trinsic-id/server](https://github.com/trinsic-id/server/tree/main/proto)*** Any work there will be reflected here.
 
 ## Working with Buf repo
 


### PR DESCRIPTION
Add the line, `***Do not edit/add files directly here. Any work on protobuf files must be performed on [trinsic-id/server](https://github.com/trinsic-id/server/tree/main/proto)*** Any work there will be reflected here.`, to the [proto/README.md](./proto/README.md) file.

I spend some time trying to update some protobuf descriptions in the documentation simply because I didn't new I should be editing the original files in the server repository.