### PR TITLE
Remove usage of `signIn` in samples and tests

### DIFF
--- a/dart/example/trustregistry_demo.dart
+++ b/dart/example/trustregistry_demo.dart
@@ -5,7 +5,7 @@ import 'package:uuid/uuid.dart';
 
 Future runTrustRegistryDemo() async {
   var accountService = AccountService(trinsicConfig(), null);
-  var account = await accountService.signIn();
+  var account = await accountService.loginAnonymous("default");
   var trustRegistryService =
       TrustRegistryService(trinsicConfig(authToken: account), null);
 

--- a/dart/example/vaccine_example.dart
+++ b/dart/example/vaccine_example.dart
@@ -35,13 +35,13 @@ Future runVaccineDemo() async {
   // Create 3 different profiles for each participant in the scenario
   var allison = await trinsic
       .account()
-      .signIn(request: SignInRequest(ecosystemId: ecosystemId));
+      .loginAnonymous(ecosystemId);
   var clinic = await trinsic
       .account()
-      .signIn(request: SignInRequest(ecosystemId: ecosystemId));
+      .loginAnonymous(ecosystemId);
   var airline = await trinsic
       .account()
-      .signIn(request: SignInRequest(ecosystemId: ecosystemId));
+      .loginAnonymous(ecosystemId);
   // }
 
   trinsic.serviceOptions.authToken = clinic;

--- a/dart/test/dart_test.dart
+++ b/dart/test/dart_test.dart
@@ -46,8 +46,7 @@ void main() {
       // }
       var myEcosystemId = "default";
       // accountServiceSignIn() {
-      var myProfile = await accountService.signIn(
-          request: SignInRequest(ecosystemId: myEcosystemId));
+      var myProfile = await accountService.loginAnonymous(myEcosystemId);
       // }
       await printGetInfo(accountService, myProfile);
       // protectUnprotectProfile() {

--- a/dotnet/Tests/Tests.cs
+++ b/dotnet/Tests/Tests.cs
@@ -76,11 +76,11 @@ public class Tests
 
         // SETUP ACTORS
         // Create 3 different profiles for each participant in the scenario
-        var allison = await trinsic.Account.SignInAsync(new() { EcosystemId = ecosystemId });
-        var clinic = await trinsic.Account.SignInAsync(new() { EcosystemId = ecosystemId });
-        var airline = await trinsic.Account.SignInAsync(new() { EcosystemId = ecosystemId });
-
-        trinsic.SetAuthToken(clinic);
+        var allison = await trinsic.Account.LoginAnonymousAsync(ecosystemId);
+        var clinic = await trinsic.Account.LoginAnonymousAsync(ecosystemId);
+        var airline = await trinsic.Account.LoginAnonymousAsync(ecosystemId);
+        
+        trinsic.SetAuthToken(clinic!);
 
         var info = await trinsic.Account.GetInfoAsync();
         info.Should().NotBeNull();
@@ -104,7 +104,7 @@ public class Tests
         } catch { } // We expect this to fail
 
         // STORE CREDENTIAL
-        trinsic.SetAuthToken(allison);
+        trinsic.SetAuthToken(allison!);
 
         var insertItemResponse = await trinsic.Wallet.InsertItemAsync(new() { ItemJson = credential.SignedDocumentJson });
         var itemId = insertItemResponse.ItemId;
@@ -141,7 +141,7 @@ public class Tests
 
 
         // VERIFY CREDENTIAL
-        trinsic.SetAuthToken(airline);
+        trinsic.SetAuthToken(airline!);
 
         var valid = await trinsic.Credential.VerifyProofAsync(new() {
             ProofDocumentJson = credentialProof.ProofDocumentJson
@@ -151,7 +151,7 @@ public class Tests
         Assert.True(valid.ValidationResults["SignatureVerification"].IsValid);
         
         // DELETE CREDENTIAL
-        trinsic.SetAuthToken(allison);
+        trinsic.SetAuthToken(allison!);
         // deleteItem() {
         await trinsic.Wallet.DeleteItemAsync(new DeleteItemRequest()
         {

--- a/java/src/test/java/trinsic/AccountServiceTest.java
+++ b/java/src/test/java/trinsic/AccountServiceTest.java
@@ -55,7 +55,7 @@ class AccountServiceTest {
     var trinsic = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
     // }
     // accountServiceSignIn() {
-    var myProfile = trinsic.account().signIn(myEcosystemIdOrName).get();
+    var myProfile = trinsic.account().loginAnonymous(myEcosystemIdOrName).get();
     // }
 
     // protectUnprotectProfile() {

--- a/java/src/test/java/trinsic/TemplatesDemo.java
+++ b/java/src/test/java/trinsic/TemplatesDemo.java
@@ -23,7 +23,7 @@ public class TemplatesDemo {
   public static void run()
       throws IOException, DidException, ExecutionException, InterruptedException {
     var trinsic = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
-    var account = trinsic.account().signIn(myEcosystemIdOrName).get();
+    var account = trinsic.account().loginAnonymous(myEcosystemIdOrName).get();
     trinsic.setAuthToken(account);
 
     // create example template

--- a/java/src/test/java/trinsic/TrustRegistryDemo.java
+++ b/java/src/test/java/trinsic/TrustRegistryDemo.java
@@ -19,7 +19,7 @@ public class TrustRegistryDemo {
   public static void run()
       throws IOException, DidException, ExecutionException, InterruptedException {
     var trinsic = new TrinsicService(TrinsicUtilities.getTrinsicServiceOptions());
-    var account = trinsic.account().signIn(myEcosystemIdOrName).get();
+    var account = trinsic.account().loginAnonymous(myEcosystemIdOrName).get();
     trinsic.setAuthToken(account);
 
     var didUri = "did:example:test";

--- a/java/src/test/java/trinsic/TrustRegistryDemoKt.kt
+++ b/java/src/test/java/trinsic/TrustRegistryDemoKt.kt
@@ -18,7 +18,7 @@ suspend fun main() {
     IOException::class, DidException::class, ExecutionException::class, InterruptedException::class)
 suspend fun runTrustRegistryDemo() {
   val trinsic = TrinsicServiceKt(TrinsicUtilities.getTrinsicServiceOptions())
-  val account = trinsic.account().signIn()
+  val account = trinsic.account().loginAnonymous("default")
   trinsic.setAuthToken(account)
 
   val didUri = "did:example:test"


### PR DESCRIPTION
The `signIn` flow is deprecated in favor of `login`/`loginConfirm`/`loginAnonymous` -- this PR removes all references to it in our samples and test.