### PR TITLE
fix: Correct proto generation file paths

### DIFF
--- a/.github/workflows/build-proto.yml
+++ b/.github/workflows/build-proto.yml
@@ -52,12 +52,12 @@ jobs:
         id: buildsdkwrappers
         with:
           protoPath: ${{ github.workspace }}/proto
-          dartPath: ${{ github.workspace }}/dart
-          dotnetPath: ${{ github.workspace }}/dotnet
-          golangPath: ${{ github.workspace }}/go
-          javaKotlinPath: ${{ github.workspace }}/java
-          pythonPath: ${{ github.workspace }}/python
-          typescriptPath: ${{ github.workspace }}/web
+          dartPath: ${{ github.workspace }}/dart/lib/src
+          dotnetPath: ${{ github.workspace }}/dotnet/Trinsic
+          golangPath: ${{ github.workspace }}/go/services
+          javaKotlinPath: ${{ github.workspace }}/java/src/main/java/trinsic/services
+          pythonPath: ${{ github.workspace }}/python/trinsic
+          typescriptPath: ${{ github.workspace }}/web/src
       - name: Install protobuf plugins
         run: |
           pip install -r ./devops/requirements.txt


### PR DESCRIPTION
* Target the correct subfolders inside each language
* This fixes the missing webhook deprecation code issue as well @janpieterz
* Running `protoc-gen-sdk` locally with the `build_test.ps1` script works because it had the correct paths already.
* I need to figure out a way to cause the action to fail when it can't find an output file. That's a PR coming in the `protoc-gen-sdk` repository, which will automatically deal with the issue here in the future.
* Closes https://github.com/trinsic-id/server/issues/1834