### PR TITLE
Fix usage of invalid `:` character in template names

### DIFF
--- a/dart/example/templates_demo.dart
+++ b/dart/example/templates_demo.dart
@@ -14,14 +14,16 @@ Future runTemplatesDemo() async {
   var uuid = Uuid();
   // createTemplate() {
   var template = await trinsic.template().create(
-          CreateCredentialTemplateRequest(
-              name: "An Example Credential: ${uuid.v4()}",
-              allowAdditionalFields: false,
-              fields: {
-            "firstName": TemplateField(description: "Given name"),
-            "lastName": TemplateField(),
-            "age": TemplateField(optional: true, type: FieldType.NUMBER)
-          }));
+    CreateCredentialTemplateRequest(
+      name: "An Example Credential ${uuid.v4()}",
+      allowAdditionalFields: false,
+      fields: {
+        "firstName": TemplateField(description: "Given name"),
+        "lastName": TemplateField(),
+        "age": TemplateField(optional: true, type: FieldType.NUMBER)
+      }
+    )
+  );
   // }
   assert(template.data.id != "");
   assert(template.data.schemaUri != "");

--- a/python/samples/templates_demo.py
+++ b/python/samples/templates_demo.py
@@ -25,7 +25,7 @@ async def templates_demo():
     # createTemplate() {
     template = await trinsic_service.template.create(
         request=CreateCredentialTemplateRequest(
-            name=f"An Example Credential: {uuid.uuid4()}",
+            name=f"An Example Credential {uuid.uuid4()}",
             allow_additional_fields=False,
             fields={
                 "firstName": TemplateField(description="Given name"),


### PR DESCRIPTION
- Removes usage of `:` character when constructing templates in dart and python samples