### PR TITLE
build: Cache NPM dependencies for performance

### DIFF
--- a/.github/workflows/test-infrastructure.yml
+++ b/.github/workflows/test-infrastructure.yml
@@ -49,6 +49,8 @@ jobs:
         name: Setup Node v18
         with:
           node-version: 18
+          cache: 'npm'
+          cache-dependency-path: ./sdk/samples/grpc-web/package-lock.json
       - run: |
           npm ci
           npm run test:browser -- --trinsic_environment="${{ inputs.environment }}"

--- a/.github/workflows/test-infrastructure.yml
+++ b/.github/workflows/test-infrastructure.yml
@@ -45,15 +45,23 @@ jobs:
         with:
           repository: trinsic-id/sdk
           path: ./sdk
+      - uses: actions/cache@v2
+        id: npm-cache
+        with:
+          path: './sdk/samples/grpc-web/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('./sdk/samples/grpc-web/package.lock') }}
       - uses: actions/setup-node@v3
         name: Setup Node v18
         with:
           node-version: 18
           cache: 'npm'
           cache-dependency-path: ./sdk/samples/grpc-web/package-lock.json
-      - run: |
-          npm ci
-          npm run test:browser -- --trinsic_environment="${{ inputs.environment }}"
+      - run: npm ci
+        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
+        name: "Install packages"
+        shell: pwsh
+        working-directory: ./sdk/samples/grpc-web
+      - run: npm run test:browser -- --trinsic_environment="${{ inputs.environment }}"
         name: "Run grpc-web tests"
         shell: pwsh
         working-directory: ./sdk/samples/grpc-web

--- a/.github/workflows/test-infrastructure.yml
+++ b/.github/workflows/test-infrastructure.yml
@@ -45,11 +45,12 @@ jobs:
         with:
           repository: trinsic-id/sdk
           path: ./sdk
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: npm-cache
         with:
           path: './sdk/samples/grpc-web/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('./sdk/samples/grpc-web/package.lock') }}
+          restore-keys: ${{ runner.os }}-modules-
       - uses: actions/setup-node@v3
         name: Setup Node v18
         with:


### PR DESCRIPTION
Speed up the playwright UI tests by cutting the 55 seconds of `npm install` to [ ]

- [x] Time it to ensure it's faster