### PR TITLE
Remove all obsolete/deprecated CLI commands

### DIFF
--- a/cli/src/cli.yaml
+++ b/cli/src/cli.yaml
@@ -105,19 +105,6 @@ subcommands:
   - vc:
       about: Verifiable Credentials Service
       subcommands:
-        - issue:
-            about: Issue a credential
-            args:
-              - document:
-                  long: document
-                  value_name: FILE
-                  help: Json document to sign
-                  takes_value: true
-              - out:
-                  long: out
-                  value_name: FILE
-                  help: output location for issue response
-                  takes_value: true
         - issue-from-template:
             about: Issue a credential from template
             args:
@@ -232,78 +219,6 @@ subcommands:
                   help: Alias to use with this authentication profile
                   takes_value: true
                   required: false
-        - update-ecosystem:
-            about: Updates ecosystem description or URI
-            args:
-              - description:
-                  long: description
-                  help: New description for the ecosystem
-                  takes_value: true
-                  required: false
-              - uri:
-                  long: uri
-                  help: New URI for the ecosystem
-                  takes_value: true
-                  required: false
-        - ecosystem-info:
-            about: Fetches information about the current ecosystem
-        - add-webhook:
-            about: Adds a webhook to the ecosystem
-            args:
-              - url:
-                  long: url
-                  help: Destination URL of webhook
-                  takes_value: true
-                  required: true
-              - secret:
-                  long: secret
-                  help: Secret phrase used to sign and verify webhook payloads
-                  takes_value: true
-                  required: true
-              - events:
-                  long: events
-                  help: Comma-separated list of events webhook should receive, or "*" for all (default "*")
-                  takes_value: true
-                  required: false
-        - delete-webhook:
-            about: Deletes a webhook from the ecosystem
-            args:
-              - webhook-id:
-                  long: webhook-id
-                  help: ID of webhook to delete
-                  takes_value: true
-                  required: true
-        - invite:
-            about: Send an invitation
-            args:
-              - description:
-                  long: description
-                  value_name: STRING
-                  help: Description
-                  takes_value: true
-                  required: false
-              - method-email:
-                  long: method-email
-                  value_name: EMAIL
-                  help: send invitation via email
-                  takes_value: true
-                  required: false
-              - method-sms:
-                  long: method-sms
-                  value_name: PHONE
-                  help: send invitation via sms
-                  takes_value: true
-                  required: false
-              - individual:
-                  long: individual
-                  help: (Default) Invite participant as individual
-                  required: false
-              - organization:
-                  long: organization
-                  help: Invite participant as organization
-                  required: false
-        - invitation_status:
-            about: Check invitation status
         - upgrade-did:
             about: Upgrade a public DID to a different method
             args:
@@ -327,8 +242,6 @@ subcommands:
                   help: "DID method options (ex: 'mainnet', 'testnet')"
                   takes_value: true
                   required: false
-
-
 args:
   - json:
       long: json

--- a/cli/src/parser/provider.rs
+++ b/cli/src/parser/provider.rs
@@ -5,16 +5,6 @@ use std::fmt::{self, Display, Formatter};
 pub(crate) fn parse(args: &ArgMatches) -> Result<Command, Error> {
     if args.subcommand_matches("create-ecosystem").is_some() {
         create_ecosystem(args.subcommand_matches("create-ecosystem").ok_or(Error::MissingArguments)?)
-    } else if args.subcommand_matches("update-ecosystem").is_some() {
-        update_ecosystem(args.subcommand_matches("update-ecosystem").ok_or(Error::MissingArguments)?)
-    } else if args.subcommand_matches("ecosystem-info").is_some() {
-        ecosystem_info()
-    } else if args.subcommand_matches("invite").is_some() {
-        invite(args.subcommand_matches("invite").ok_or(Error::MissingArguments)?)
-    } else if args.subcommand_matches("add-webhook").is_some() {
-        add_webhook(args.subcommand_matches("add-webhook").ok_or(Error::MissingArguments)?)
-    } else if args.subcommand_matches("delete-webhook").is_some() {
-        delete_webhook(args.subcommand_matches("delete-webhook").ok_or(Error::MissingArguments)?)
     } else if args.subcommand_matches("upgrade-did").is_some() {
         upgrade_did(args.subcommand_matches("upgrade-did").ok_or(Error::MissingArguments)?)
     } else {
@@ -32,65 +22,6 @@ fn create_ecosystem(args: &ArgMatches) -> Result<Command, Error> {
     Ok(Command::CreateEcosystem(ecosystem))
 }
 
-fn update_ecosystem(args: &ArgMatches) -> Result<Command, Error> {
-    if !args.is_present("description") && !args.is_present("uri") {
-        return Err(Error::MissingArguments);
-    }
-
-    let args = UpdateEcosystemArgs {
-        description: args.value_of("description").map(|x| x.into()),
-        uri: args.value_of("uri").map(|x| x.into()),
-    };
-
-    Ok(Command::UpdateEcosystem(args))
-}
-
-fn ecosystem_info<'a>() -> Result<Command<'a>, Error> {
-    Ok(Command::EcosystemInfo)
-}
-
-fn add_webhook<'a>(args: &'a ArgMatches) -> Result<Command<'a>, Error> {
-    // Get the events arg
-    let events_val: &'a str = args.value_of("events").unwrap_or("*");
-
-    // Split on comma
-    let split = events_val.split(",");
-
-    // Fill a Vec<String> with the split contents
-    let mut events = vec![];
-    events.extend(split.into_iter().map(|x| x.into()));
-
-    Ok(Command::AddWebhook(AddWebhookArgs {
-        url: args.value_of("url").map(|x| x.into()).unwrap(),
-        secret: args.value_of("secret").map(|x| x.into()).unwrap(),
-        events,
-    }))
-}
-
-fn delete_webhook(args: &ArgMatches) -> Result<Command, Error> {
-    Ok(Command::DeleteWebhook(DeleteWebhookArgs {
-        webhook_id: args.value_of("webhook-id").map(|x| x.into()).unwrap(),
-    }))
-}
-
-fn invite(args: &ArgMatches) -> Result<Command, Error> {
-    Ok(Command::Invite(InviteArgs {
-        participant_type: if args.is_present("organization") {
-            ParticipantType::Organization
-        } else {
-            ParticipantType::Individual
-        },
-        invitation_method: if args.is_present("method-email") {
-            InvitationMethod::Email(args.value_of("method-email").expect("Unable to parse").to_string())
-        } else if args.is_present("method-email") {
-            InvitationMethod::Sms(args.value_of("method-sms").expect("Unable to parse").to_string())
-        } else {
-            InvitationMethod::None
-        },
-        description: args.value_of("description"),
-    }))
-}
-
 fn upgrade_did(args: &ArgMatches) -> Result<Command, Error> {
     let ecosystem = UpgradeDidArgs {
         method: args.value_of("method").ok_or_else(|| Error::MissingArguments)?.into(),
@@ -103,15 +34,9 @@ fn upgrade_did(args: &ArgMatches) -> Result<Command, Error> {
 }
 
 #[derive(Debug, PartialEq)]
-pub enum Command<'a> {
+pub enum Command {
     CreateEcosystem(CreateEcosystemArgs),
-    UpdateEcosystem(UpdateEcosystemArgs),
-    EcosystemInfo,
-    AddWebhook(AddWebhookArgs),
-    DeleteWebhook(DeleteWebhookArgs),
-    Invite(InviteArgs<'a>),
     UpgradeDid(UpgradeDidArgs),
-    InvitationStatus,
 }
 
 #[derive(Debug, PartialEq)]
@@ -127,44 +52,6 @@ pub struct UpgradeDidArgs {
     pub method_options: Option<String>,
     pub email: Option<String>,
     pub wallet_id: Option<String>,
-}
-
-#[derive(Debug, PartialEq)]
-pub struct UpdateEcosystemArgs {
-    pub description: Option<String>,
-    pub uri: Option<String>,
-}
-
-#[derive(Debug, PartialEq)]
-pub struct AddWebhookArgs {
-    pub url: String,
-    pub secret: String,
-    pub events: Vec<String>,
-}
-
-#[derive(Debug, PartialEq)]
-pub struct DeleteWebhookArgs {
-    pub webhook_id: String,
-}
-
-#[derive(Debug, PartialEq)]
-pub struct InviteArgs<'a> {
-    pub participant_type: ParticipantType,
-    pub invitation_method: InvitationMethod,
-    pub description: Option<&'a str>,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum ParticipantType {
-    Individual,
-    Organization,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum InvitationMethod {
-    Email(String),
-    Sms(String),
-    None,
 }
 
 #[derive(Debug, PartialEq)]

--- a/cli/src/parser/trustregistry.rs
+++ b/cli/src/parser/trustregistry.rs
@@ -7,8 +7,6 @@ pub enum TrustRegistryCommand {
     Search(SearchArgs),
     RegisterMember(RegisterMemberArgs),
     UnregisterMember(UnregisterMemberArgs),
-    AddFramework(AddFrameworkArgs),
-    RemoveFramework(RemoveFrameworkArgs),
     GetMembershipStatus(GetMembershipStatusArgs),
     FetchData(FetchDataArgs),
 }
@@ -56,18 +54,6 @@ pub struct GovernanceFrameworkArgs {
 }
 
 #[derive(Debug, PartialEq, Default)]
-pub struct AddFrameworkArgs {
-    pub governance_framework_uri: String,
-    pub description: Option<String>,
-    pub name: String,
-}
-
-#[derive(Debug, PartialEq, Default)]
-pub struct RemoveFrameworkArgs {
-    pub framework_id: String,
-}
-
-#[derive(Debug, PartialEq, Default)]
 pub struct GetMembershipStatusArgs {
     pub did_uri: String,
     pub schema_uri: String,
@@ -86,10 +72,6 @@ pub(crate) fn parse(args: &ArgMatches) -> Result<TrustRegistryCommand, Error> {
         unregister_member(&args.subcommand_matches("unregister-member").expect("Error parsing request"))
     } else if args.subcommand_matches("get-membership-status").is_some() {
         get_status(&args.subcommand_matches("get-membership-status").expect("Error parsing request"))
-    } else if args.subcommand_matches("add-framework").is_some() {
-        add_framework(&args.subcommand_matches("add-framework").expect("Error parsing request"))
-    } else if args.subcommand_matches("remove-framework").is_some() {
-        remove_framework(&args.subcommand_matches("remove-framework").expect("Error parsing request"))
     } else {
         Err(Error::MissingArguments)
     }
@@ -155,40 +137,10 @@ fn get_status(args: &ArgMatches) -> Result<TrustRegistryCommand, Error> {
     }))
 }
 
-fn add_framework(args: &ArgMatches) -> Result<TrustRegistryCommand, Error> {
-    Ok(TrustRegistryCommand::AddFramework(AddFrameworkArgs {
-        name: args.value_of("name").map(|x| x.into()).ok_or(Error::MissingArguments)?,
-        governance_framework_uri: args.value_of("uri").map(|q| q.into()).ok_or(Error::MissingArguments)?,
-        description: args.value_of("description").map(|x| x.into()),
-    }))
-}
-
-fn remove_framework(args: &ArgMatches) -> Result<TrustRegistryCommand, Error> {
-    Ok(TrustRegistryCommand::RemoveFramework(RemoveFrameworkArgs {
-        framework_id: args.value_of("framework-id").map(|x| x.into()).ok_or(Error::MissingArguments)?,
-    }))
-}
-
 pub(crate) fn subcommand<'a, 'b>() -> App<'a> {
     SubCommand::with_name("trust-registry")
         .about("Manage Trust Registry membership and governance")
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(
-            SubCommand::with_name("add-framework")
-            .setting(AppSettings::ArgRequiredElseHelp)
-            .about("Add new Ecosystem Governenace Framework (EGF)")
-            .after_help("EXAMPLES:\r\n\ttrinsic trust-registry add-framework --name 'Example EGF' --uri 'https://example.com/governance'")
-            .arg(Arg::from_usage("-n --name <NAME> 'Name of the ecosystem governance framework'").required(true))
-            .arg(Arg::from_usage("-u --uri <URI> 'Governance framework URI'").required(true))
-            .arg(Arg::from_usage("-d --description <DESCRIPTION> 'Description of the governance framework'").required(false)),
-        )
-        .subcommand(
-            SubCommand::with_name("remove-framework")
-            .setting(AppSettings::ArgRequiredElseHelp)
-            .about("Remove an Ecosystem Governenace Framework (EGF)")
-            .after_help("EXAMPLES:\r\n\ttrinsic trust-registry remove-framework --framework-id 'urn:egf:example'")
-            .arg(Arg::from_usage("-f --framework-id <URI> 'Governance framework URI'").required(true)),
-        )
         .subcommand(
             SubCommand::with_name("register-member")
             .setting(AppSettings::ArgRequiredElseHelp)

--- a/cli/src/parser/vc.rs
+++ b/cli/src/parser/vc.rs
@@ -2,9 +2,7 @@ use crate::error::Error;
 use clap::ArgMatches;
 
 pub(crate) fn parse(args: &ArgMatches) -> Result<Command, Error> {
-    if args.subcommand_matches("issue").is_some() {
-        issue(&args.subcommand_matches("issue").expect("Error parsing request"))
-    } else if args.subcommand_matches("issue-from-template").is_some() {
+    if args.subcommand_matches("issue-from-template").is_some() {
         issue_from_template(&args.subcommand_matches("issue-from-template").expect("Error parsing request"))
     } else if args.subcommand_matches("get-status").is_some() {
         get_status(&args.subcommand_matches("get-status").expect("Error parsing request"))
@@ -17,13 +15,6 @@ pub(crate) fn parse(args: &ArgMatches) -> Result<Command, Error> {
     } else {
         Err(Error::MissingArguments)
     }
-}
-
-fn issue(args: &ArgMatches) -> Result<Command, Error> {
-    Ok(Command::Issue(IssueArgs {
-        document: args.value_of("document").map(|x| x.into()),
-        out: args.value_of("out").map(|x| x.into()),
-    }))
 }
 
 fn issue_from_template(args: &ArgMatches) -> Result<Command, Error> {
@@ -66,18 +57,11 @@ fn verify_proof(args: &ArgMatches) -> Result<Command, Error> {
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum Command<'a> {
-    Issue(IssueArgs),
     IssueFromTemplate(IssueFromTemplateArgs),
     GetStatus(GetStatusArgs),
     UpdateStatus(UpdateStatusArgs),
     CreateProof(CreateProofArgs),
     VerifyProof(VerifyProofArgs<'a>),
-}
-
-#[derive(Debug, PartialEq)]
-pub struct IssueArgs {
-    pub document: Option<String>,
-    pub out: Option<String>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/cli/src/proto/google/protobuf/mod.rs
+++ b/cli/src/proto/google/protobuf/mod.rs
@@ -1,150 +1,157 @@
 /// The protocol compiler can output a FileDescriptorSet containing the .proto
 /// files it parses.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorSet {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub file: ::prost::alloc::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     /// e.g. "foo", "foo.bar", etc.
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub package: ::core::option::Option<::prost::alloc::string::String>,
     /// Names of files imported by this file.
-    #[prost(string, repeated, tag="3")]
+    #[prost(string, repeated, tag = "3")]
     pub dependency: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Indexes of the public imported files in the dependency list above.
-    #[prost(int32, repeated, packed="false", tag="10")]
+    #[prost(int32, repeated, packed = "false", tag = "10")]
     pub public_dependency: ::prost::alloc::vec::Vec<i32>,
     /// Indexes of the weak imported files in the dependency list.
     /// For Google-internal migration only. Do not use.
-    #[prost(int32, repeated, packed="false", tag="11")]
+    #[prost(int32, repeated, packed = "false", tag = "11")]
     pub weak_dependency: ::prost::alloc::vec::Vec<i32>,
     /// All top-level definitions in this file.
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub message_type: ::prost::alloc::vec::Vec<DescriptorProto>,
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub enum_type: ::prost::alloc::vec::Vec<EnumDescriptorProto>,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub service: ::prost::alloc::vec::Vec<ServiceDescriptorProto>,
-    #[prost(message, repeated, tag="7")]
+    #[prost(message, repeated, tag = "7")]
     pub extension: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
-    #[prost(message, optional, tag="8")]
+    #[prost(message, optional, tag = "8")]
     pub options: ::core::option::Option<FileOptions>,
     /// This field contains optional information about the original source code.
     /// You may safely remove this entire field without harming runtime
     /// functionality of the descriptors -- the information is needed only by
     /// development tools.
-    #[prost(message, optional, tag="9")]
+    #[prost(message, optional, tag = "9")]
     pub source_code_info: ::core::option::Option<SourceCodeInfo>,
     /// The syntax of the proto file.
     /// The supported values are "proto2" and "proto3".
-    #[prost(string, optional, tag="12")]
+    #[prost(string, optional, tag = "12")]
     pub syntax: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Describes a message type.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DescriptorProto {
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub field: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub extension: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub nested_type: ::prost::alloc::vec::Vec<DescriptorProto>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub enum_type: ::prost::alloc::vec::Vec<EnumDescriptorProto>,
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub extension_range: ::prost::alloc::vec::Vec<descriptor_proto::ExtensionRange>,
-    #[prost(message, repeated, tag="8")]
+    #[prost(message, repeated, tag = "8")]
     pub oneof_decl: ::prost::alloc::vec::Vec<OneofDescriptorProto>,
-    #[prost(message, optional, tag="7")]
+    #[prost(message, optional, tag = "7")]
     pub options: ::core::option::Option<MessageOptions>,
-    #[prost(message, repeated, tag="9")]
+    #[prost(message, repeated, tag = "9")]
     pub reserved_range: ::prost::alloc::vec::Vec<descriptor_proto::ReservedRange>,
     /// Reserved field names, which may not be used by fields in the same message.
     /// A given name may only be reserved once.
-    #[prost(string, repeated, tag="10")]
+    #[prost(string, repeated, tag = "10")]
     pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `DescriptorProto`.
 pub mod descriptor_proto {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ExtensionRange {
         /// Inclusive.
-        #[prost(int32, optional, tag="1")]
+        #[prost(int32, optional, tag = "1")]
         pub start: ::core::option::Option<i32>,
         /// Exclusive.
-        #[prost(int32, optional, tag="2")]
+        #[prost(int32, optional, tag = "2")]
         pub end: ::core::option::Option<i32>,
-        #[prost(message, optional, tag="3")]
+        #[prost(message, optional, tag = "3")]
         pub options: ::core::option::Option<super::ExtensionRangeOptions>,
     }
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
     /// not overlap.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ReservedRange {
         /// Inclusive.
-        #[prost(int32, optional, tag="1")]
+        #[prost(int32, optional, tag = "1")]
         pub start: ::core::option::Option<i32>,
         /// Exclusive.
-        #[prost(int32, optional, tag="2")]
+        #[prost(int32, optional, tag = "2")]
         pub end: ::core::option::Option<i32>,
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
-    #[prost(message, repeated, tag="999")]
+    #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 /// Describes a field within a message.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldDescriptorProto {
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(int32, optional, tag="3")]
+    #[prost(int32, optional, tag = "3")]
     pub number: ::core::option::Option<i32>,
-    #[prost(enumeration="field_descriptor_proto::Label", optional, tag="4")]
+    #[prost(enumeration = "field_descriptor_proto::Label", optional, tag = "4")]
     pub label: ::core::option::Option<i32>,
     /// If type_name is set, this need not be set.  If both this and type_name
     /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
-    #[prost(enumeration="field_descriptor_proto::Type", optional, tag="5")]
+    #[prost(enumeration = "field_descriptor_proto::Type", optional, tag = "5")]
     pub r#type: ::core::option::Option<i32>,
     /// For message and enum types, this is the name of the type.  If the name
     /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
     /// rules are used to find the type (i.e. first the nested types within this
     /// message are searched, then within the parent, on up to the root
     /// namespace).
-    #[prost(string, optional, tag="6")]
+    #[prost(string, optional, tag = "6")]
     pub type_name: ::core::option::Option<::prost::alloc::string::String>,
     /// For extensions, this is the name of the type being extended.  It is
     /// resolved in the same manner as type_name.
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub extendee: ::core::option::Option<::prost::alloc::string::String>,
     /// For numeric types, contains the original text representation of the value.
     /// For booleans, "true" or "false".
     /// For strings, contains the default text contents (not escaped in any way).
     /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-    #[prost(string, optional, tag="7")]
+    #[prost(string, optional, tag = "7")]
     pub default_value: ::core::option::Option<::prost::alloc::string::String>,
     /// If set, gives the index of a oneof in the containing type's oneof_decl
     /// list.  This field is a member of that oneof.
-    #[prost(int32, optional, tag="9")]
+    #[prost(int32, optional, tag = "9")]
     pub oneof_index: ::core::option::Option<i32>,
     /// JSON name of this field. The value is set by protocol compiler. If the
     /// user has set a "json_name" option on this field, that option's value
     /// will be used. Otherwise, it's deduced from the field's name by converting
     /// it to camelCase.
-    #[prost(string, optional, tag="10")]
+    #[prost(string, optional, tag = "10")]
     pub json_name: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(message, optional, tag="8")]
+    #[prost(message, optional, tag = "8")]
     pub options: ::core::option::Option<FieldOptions>,
     /// If true, this is a proto3 "optional". When a proto3 field is optional, it
     /// tracks presence regardless of field type.
@@ -167,12 +174,22 @@ pub struct FieldDescriptorProto {
     ///
     /// Proto2 optional fields do not set this flag, because they already indicate
     /// optional with `LABEL_OPTIONAL`.
-    #[prost(bool, optional, tag="17")]
+    #[prost(bool, optional, tag = "17")]
     pub proto3_optional: ::core::option::Option<bool>,
 }
 /// Nested message and enum types in `FieldDescriptorProto`.
 pub mod field_descriptor_proto {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Type {
         /// 0 is reserved for errors.
@@ -235,8 +252,42 @@ pub mod field_descriptor_proto {
                 Type::Sint64 => "TYPE_SINT64",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "TYPE_DOUBLE" => Some(Self::Double),
+                "TYPE_FLOAT" => Some(Self::Float),
+                "TYPE_INT64" => Some(Self::Int64),
+                "TYPE_UINT64" => Some(Self::Uint64),
+                "TYPE_INT32" => Some(Self::Int32),
+                "TYPE_FIXED64" => Some(Self::Fixed64),
+                "TYPE_FIXED32" => Some(Self::Fixed32),
+                "TYPE_BOOL" => Some(Self::Bool),
+                "TYPE_STRING" => Some(Self::String),
+                "TYPE_GROUP" => Some(Self::Group),
+                "TYPE_MESSAGE" => Some(Self::Message),
+                "TYPE_BYTES" => Some(Self::Bytes),
+                "TYPE_UINT32" => Some(Self::Uint32),
+                "TYPE_ENUM" => Some(Self::Enum),
+                "TYPE_SFIXED32" => Some(Self::Sfixed32),
+                "TYPE_SFIXED64" => Some(Self::Sfixed64),
+                "TYPE_SINT32" => Some(Self::Sint32),
+                "TYPE_SINT64" => Some(Self::Sint64),
+                _ => None,
+            }
+        }
     }
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Label {
         /// 0 is reserved for errors
@@ -256,33 +307,46 @@ pub mod field_descriptor_proto {
                 Label::Repeated => "LABEL_REPEATED",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "LABEL_OPTIONAL" => Some(Self::Optional),
+                "LABEL_REQUIRED" => Some(Self::Required),
+                "LABEL_REPEATED" => Some(Self::Repeated),
+                _ => None,
+            }
+        }
     }
 }
 /// Describes a oneof.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofDescriptorProto {
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub options: ::core::option::Option<OneofOptions>,
 }
 /// Describes an enum type.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumDescriptorProto {
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub value: ::prost::alloc::vec::Vec<EnumValueDescriptorProto>,
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub options: ::core::option::Option<EnumOptions>,
     /// Range of reserved numeric values. Reserved numeric values may not be used
     /// by enum values in the same enum declaration. Reserved ranges may not
     /// overlap.
-    #[prost(message, repeated, tag="4")]
-    pub reserved_range: ::prost::alloc::vec::Vec<enum_descriptor_proto::EnumReservedRange>,
+    #[prost(message, repeated, tag = "4")]
+    pub reserved_range: ::prost::alloc::vec::Vec<
+        enum_descriptor_proto::EnumReservedRange,
+    >,
     /// Reserved enum value names, which may not be reused. A given name may only
     /// be reserved once.
-    #[prost(string, repeated, tag="5")]
+    #[prost(string, repeated, tag = "5")]
     pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `EnumDescriptorProto`.
@@ -293,102 +357,75 @@ pub mod enum_descriptor_proto {
     /// Note that this is distinct from DescriptorProto.ReservedRange in that it
     /// is inclusive such that it can appropriately represent the entire int32
     /// domain.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct EnumReservedRange {
         /// Inclusive.
-        #[prost(int32, optional, tag="1")]
+        #[prost(int32, optional, tag = "1")]
         pub start: ::core::option::Option<i32>,
         /// Inclusive.
-        #[prost(int32, optional, tag="2")]
+        #[prost(int32, optional, tag = "2")]
         pub end: ::core::option::Option<i32>,
     }
 }
 /// Describes a value within an enum.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueDescriptorProto {
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(int32, optional, tag="2")]
+    #[prost(int32, optional, tag = "2")]
     pub number: ::core::option::Option<i32>,
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub options: ::core::option::Option<EnumValueOptions>,
 }
 /// Describes a service.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceDescriptorProto {
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub method: ::prost::alloc::vec::Vec<MethodDescriptorProto>,
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub options: ::core::option::Option<ServiceOptions>,
 }
 /// Describes a method of a service.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodDescriptorProto {
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     /// Input and output type names.  These are resolved in the same way as
     /// FieldDescriptorProto.type_name, but must refer to a message type.
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub input_type: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, optional, tag="3")]
+    #[prost(string, optional, tag = "3")]
     pub output_type: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub options: ::core::option::Option<MethodOptions>,
     /// Identifies if client streams multiple client messages
-    #[prost(bool, optional, tag="5", default="false")]
+    #[prost(bool, optional, tag = "5", default = "false")]
     pub client_streaming: ::core::option::Option<bool>,
     /// Identifies if server streams multiple server messages
-    #[prost(bool, optional, tag="6", default="false")]
+    #[prost(bool, optional, tag = "6", default = "false")]
     pub server_streaming: ::core::option::Option<bool>,
 }
-// ===================================================================
-// Options
-
-// Each of the definitions above may have "options" attached.  These are
-// just annotations which may cause code to be generated slightly differently
-// or may contain hints for code that manipulates protocol messages.
-//
-// Clients may define custom options as extensions of the *Options messages.
-// These extensions may not yet be known at parsing time, so the parser cannot
-// store the values in them.  Instead it stores them in a field in the *Options
-// message called uninterpreted_option. This field must have the same name
-// across all *Options messages. We then use this field to populate the
-// extensions when we build a descriptor, at which point all protos have been
-// parsed and so all extensions are known.
-//
-// Extension numbers for custom options may be chosen as follows:
-// * For options which will only be used within a single application or
-//    organization, or for experimental options, use field numbers 50000
-//    through 99999.  It is up to you to ensure that you do not use the
-//    same number for multiple options.
-// * For options which will be published and used publicly by multiple
-//    independent entities, e-mail protobuf-global-extension-registry@google.com
-//    to reserve extension numbers. Simply provide your project name (e.g.
-//    Objective-C plugin) and your project website (if available) -- there's no
-//    need to explain how you intend to use them. Usually you only need one
-//    extension number. You can declare multiple options with only one extension
-//    number by putting them in a sub-message. See the Custom Options section of
-//    the docs for examples:
-//    <https://developers.google.com/protocol-buffers/docs/proto#options>
-//    If this turns out to be popular, a web service will be set up
-//    to automatically assign option numbers.
-
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileOptions {
     /// Sets the Java package where classes generated from this .proto will be
     /// placed.  By default, the proto package is used, but this is often
     /// inappropriate because proto packages do not normally start with backwards
     /// domain names.
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub java_package: ::core::option::Option<::prost::alloc::string::String>,
     /// Controls the name of the wrapper Java class generated for the .proto file.
     /// That class will always contain the .proto file's getDescriptor() method as
     /// well as any top-level extensions defined in the .proto file.
     /// If java_multiple_files is disabled, then all the other classes from the
     /// .proto file will be nested inside the single wrapper outer class.
-    #[prost(string, optional, tag="8")]
+    #[prost(string, optional, tag = "8")]
     pub java_outer_classname: ::core::option::Option<::prost::alloc::string::String>,
     /// If enabled, then the Java code generator will generate a separate .java
     /// file for each top-level message, enum, and service defined in the .proto
@@ -396,11 +433,11 @@ pub struct FileOptions {
     /// named by java_outer_classname.  However, the wrapper class will still be
     /// generated to contain the file's getDescriptor() method as well as any
     /// top-level extensions defined in the file.
-    #[prost(bool, optional, tag="10", default="false")]
+    #[prost(bool, optional, tag = "10", default = "false")]
     pub java_multiple_files: ::core::option::Option<bool>,
     /// This option does nothing.
     #[deprecated]
-    #[prost(bool, optional, tag="20")]
+    #[prost(bool, optional, tag = "20")]
     pub java_generate_equals_and_hash: ::core::option::Option<bool>,
     /// If set true, then the Java2 code generator will generate code that
     /// throws an exception whenever an attempt is made to assign a non-UTF-8
@@ -408,16 +445,21 @@ pub struct FileOptions {
     /// Message reflection will do the same.
     /// However, an extension field still accepts non-UTF-8 byte sequences.
     /// This option has no effect on when used with the lite runtime.
-    #[prost(bool, optional, tag="27", default="false")]
+    #[prost(bool, optional, tag = "27", default = "false")]
     pub java_string_check_utf8: ::core::option::Option<bool>,
-    #[prost(enumeration="file_options::OptimizeMode", optional, tag="9", default="Speed")]
+    #[prost(
+        enumeration = "file_options::OptimizeMode",
+        optional,
+        tag = "9",
+        default = "Speed"
+    )]
     pub optimize_for: ::core::option::Option<i32>,
     /// Sets the Go package where structs generated from this .proto will be
     /// placed. If omitted, the Go package will be derived from the following:
     ///    - The basename of the package import path, if provided.
     ///    - Otherwise, the package statement in the .proto file, if present.
     ///    - Otherwise, the basename of the .proto file, without extension.
-    #[prost(string, optional, tag="11")]
+    #[prost(string, optional, tag = "11")]
     pub go_package: ::core::option::Option<::prost::alloc::string::String>,
     /// Should generic services be generated in each language?  "Generic" services
     /// are not specific to any particular RPC system.  They are generated by the
@@ -429,65 +471,75 @@ pub struct FileOptions {
     /// that generate code specific to your particular RPC system.  Therefore,
     /// these default to false.  Old code which depends on generic services should
     /// explicitly set them to true.
-    #[prost(bool, optional, tag="16", default="false")]
+    #[prost(bool, optional, tag = "16", default = "false")]
     pub cc_generic_services: ::core::option::Option<bool>,
-    #[prost(bool, optional, tag="17", default="false")]
+    #[prost(bool, optional, tag = "17", default = "false")]
     pub java_generic_services: ::core::option::Option<bool>,
-    #[prost(bool, optional, tag="18", default="false")]
+    #[prost(bool, optional, tag = "18", default = "false")]
     pub py_generic_services: ::core::option::Option<bool>,
-    #[prost(bool, optional, tag="42", default="false")]
+    #[prost(bool, optional, tag = "42", default = "false")]
     pub php_generic_services: ::core::option::Option<bool>,
     /// Is this file deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for everything in the file, or it will be completely ignored; in the very
     /// least, this is a formalization for deprecating files.
-    #[prost(bool, optional, tag="23", default="false")]
+    #[prost(bool, optional, tag = "23", default = "false")]
     pub deprecated: ::core::option::Option<bool>,
     /// Enables the use of arenas for the proto messages in this file. This applies
     /// only to generated classes for C++.
-    #[prost(bool, optional, tag="31", default="true")]
+    #[prost(bool, optional, tag = "31", default = "true")]
     pub cc_enable_arenas: ::core::option::Option<bool>,
     /// Sets the objective c class prefix which is prepended to all objective c
     /// generated classes from this .proto. There is no default.
-    #[prost(string, optional, tag="36")]
+    #[prost(string, optional, tag = "36")]
     pub objc_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Namespace for generated classes; defaults to the package.
-    #[prost(string, optional, tag="37")]
+    #[prost(string, optional, tag = "37")]
     pub csharp_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// By default Swift generators will take the proto package and CamelCase it
     /// replacing '.' with underscore and use that to prefix the types/symbols
     /// defined. When this options is provided, they will use this value instead
     /// to prefix the types/symbols defined.
-    #[prost(string, optional, tag="39")]
+    #[prost(string, optional, tag = "39")]
     pub swift_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Sets the php class prefix which is prepended to all php generated classes
     /// from this .proto. Default is empty.
-    #[prost(string, optional, tag="40")]
+    #[prost(string, optional, tag = "40")]
     pub php_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the namespace of php generated classes. Default
     /// is empty. When this option is empty, the package name will be used for
     /// determining the namespace.
-    #[prost(string, optional, tag="41")]
+    #[prost(string, optional, tag = "41")]
     pub php_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the namespace of php generated metadata classes.
     /// Default is empty. When this option is empty, the proto file name will be
     /// used for determining the namespace.
-    #[prost(string, optional, tag="44")]
+    #[prost(string, optional, tag = "44")]
     pub php_metadata_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the package of ruby generated classes. Default
     /// is empty. When this option is not set, the package name will be used for
     /// determining the ruby package.
-    #[prost(string, optional, tag="45")]
+    #[prost(string, optional, tag = "45")]
     pub ruby_package: ::core::option::Option<::prost::alloc::string::String>,
     /// The parser stores options it doesn't recognize here.
     /// See the documentation for the "Options" section above.
-    #[prost(message, repeated, tag="999")]
+    #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 /// Nested message and enum types in `FileOptions`.
 pub mod file_options {
     /// Generated classes can be optimized for speed or code size.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum OptimizeMode {
         /// Generate complete code for parsing, serialization,
@@ -511,8 +563,18 @@ pub mod file_options {
                 OptimizeMode::LiteRuntime => "LITE_RUNTIME",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "SPEED" => Some(Self::Speed),
+                "CODE_SIZE" => Some(Self::CodeSize),
+                "LITE_RUNTIME" => Some(Self::LiteRuntime),
+                _ => None,
+            }
+        }
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MessageOptions {
     /// Set true to use the old proto1 MessageSet wire format for extensions.
@@ -533,18 +595,18 @@ pub struct MessageOptions {
     ///
     /// Because this is an option, the above two restrictions are not enforced by
     /// the protocol compiler.
-    #[prost(bool, optional, tag="1", default="false")]
+    #[prost(bool, optional, tag = "1", default = "false")]
     pub message_set_wire_format: ::core::option::Option<bool>,
     /// Disables the generation of the standard "descriptor()" accessor, which can
     /// conflict with a field of the same name.  This is meant to make migration
     /// from proto1 easier; new code should avoid fields named "descriptor".
-    #[prost(bool, optional, tag="2", default="false")]
+    #[prost(bool, optional, tag = "2", default = "false")]
     pub no_standard_descriptor_accessor: ::core::option::Option<bool>,
     /// Is this message deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for the message, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating messages.
-    #[prost(bool, optional, tag="3", default="false")]
+    #[prost(bool, optional, tag = "3", default = "false")]
     pub deprecated: ::core::option::Option<bool>,
     /// Whether the message is an automatically generated map entry type for the
     /// maps field.
@@ -567,26 +629,32 @@ pub struct MessageOptions {
     /// NOTE: Do not set the option in .proto files. Always use the maps syntax
     /// instead. The option should only be implicitly set by the proto compiler
     /// parser.
-    #[prost(bool, optional, tag="7")]
+    #[prost(bool, optional, tag = "7")]
     pub map_entry: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
-    #[prost(message, repeated, tag="999")]
+    #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldOptions {
     /// The ctype option instructs the C++ code generator to use a different
     /// representation of the field than it normally would.  See the specific
     /// options below.  This option is not yet implemented in the open source
     /// release -- sorry, we'll try to include it in a future version!
-    #[prost(enumeration="field_options::CType", optional, tag="1", default="String")]
+    #[prost(
+        enumeration = "field_options::CType",
+        optional,
+        tag = "1",
+        default = "String"
+    )]
     pub ctype: ::core::option::Option<i32>,
     /// The packed option can be enabled for repeated primitive fields to enable
     /// a more efficient representation on the wire. Rather than repeatedly
     /// writing the tag and type for each element, the entire array is encoded as
     /// a single length-delimited blob. In proto3, only explicit setting it to
     /// false will avoid using packed encoding.
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub packed: ::core::option::Option<bool>,
     /// The jstype option determines the JavaScript type used for values of the
     /// field.  The option is permitted only for 64 bit integral and fixed types
@@ -599,7 +667,12 @@ pub struct FieldOptions {
     ///
     /// This option is an enum to permit additional types to be added, e.g.
     /// goog.math.Integer.
-    #[prost(enumeration="field_options::JsType", optional, tag="6", default="JsNormal")]
+    #[prost(
+        enumeration = "field_options::JsType",
+        optional,
+        tag = "6",
+        default = "JsNormal"
+    )]
     pub jstype: ::core::option::Option<i32>,
     /// Should this field be parsed lazily?  Lazy applies only to message-type
     /// fields.  It means that when the outer message is initially parsed, the
@@ -635,29 +708,39 @@ pub struct FieldOptions {
     /// finally parsed upon access.
     ///
     /// TODO(b/211906113):  Enable validation on lazy fields.
-    #[prost(bool, optional, tag="5", default="false")]
+    #[prost(bool, optional, tag = "5", default = "false")]
     pub lazy: ::core::option::Option<bool>,
     /// unverified_lazy does no correctness checks on the byte stream. This should
     /// only be used where lazy with verification is prohibitive for performance
     /// reasons.
-    #[prost(bool, optional, tag="15", default="false")]
+    #[prost(bool, optional, tag = "15", default = "false")]
     pub unverified_lazy: ::core::option::Option<bool>,
     /// Is this field deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for accessors, or it will be completely ignored; in the very least, this
     /// is a formalization for deprecating fields.
-    #[prost(bool, optional, tag="3", default="false")]
+    #[prost(bool, optional, tag = "3", default = "false")]
     pub deprecated: ::core::option::Option<bool>,
     /// For Google-internal migration only. Do not use.
-    #[prost(bool, optional, tag="10", default="false")]
+    #[prost(bool, optional, tag = "10", default = "false")]
     pub weak: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
-    #[prost(message, repeated, tag="999")]
+    #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 /// Nested message and enum types in `FieldOptions`.
 pub mod field_options {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum CType {
         /// Default mode.
@@ -677,8 +760,27 @@ pub mod field_options {
                 CType::StringPiece => "STRING_PIECE",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "STRING" => Some(Self::String),
+                "CORD" => Some(Self::Cord),
+                "STRING_PIECE" => Some(Self::StringPiece),
+                _ => None,
+            }
+        }
     }
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum JsType {
         /// Use the default type.
@@ -700,76 +802,85 @@ pub mod field_options {
                 JsType::JsNumber => "JS_NUMBER",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "JS_NORMAL" => Some(Self::JsNormal),
+                "JS_STRING" => Some(Self::JsString),
+                "JS_NUMBER" => Some(Self::JsNumber),
+                _ => None,
+            }
+        }
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
-    #[prost(message, repeated, tag="999")]
+    #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
     /// value.
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub allow_alias: ::core::option::Option<bool>,
     /// Is this enum deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for the enum, or it will be completely ignored; in the very least, this
     /// is a formalization for deprecating enums.
-    #[prost(bool, optional, tag="3", default="false")]
+    #[prost(bool, optional, tag = "3", default = "false")]
     pub deprecated: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
-    #[prost(message, repeated, tag="999")]
+    #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueOptions {
     /// Is this enum value deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for the enum value, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating enum values.
-    #[prost(bool, optional, tag="1", default="false")]
+    #[prost(bool, optional, tag = "1", default = "false")]
     pub deprecated: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
-    #[prost(message, repeated, tag="999")]
+    #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceOptions {
-    // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
-    //    framework.  We apologize for hoarding these numbers to ourselves, but
-    //    we were already using them long before we decided to release Protocol
-    //    Buffers.
-
     /// Is this service deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for the service, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating services.
-    #[prost(bool, optional, tag="33", default="false")]
+    #[prost(bool, optional, tag = "33", default = "false")]
     pub deprecated: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
-    #[prost(message, repeated, tag="999")]
+    #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodOptions {
-    // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
-    //    framework.  We apologize for hoarding these numbers to ourselves, but
-    //    we were already using them long before we decided to release Protocol
-    //    Buffers.
-
     /// Is this method deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for the method, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating methods.
-    #[prost(bool, optional, tag="33", default="false")]
+    #[prost(bool, optional, tag = "33", default = "false")]
     pub deprecated: ::core::option::Option<bool>,
-    #[prost(enumeration="method_options::IdempotencyLevel", optional, tag="34", default="IdempotencyUnknown")]
+    #[prost(
+        enumeration = "method_options::IdempotencyLevel",
+        optional,
+        tag = "34",
+        default = "IdempotencyUnknown"
+    )]
     pub idempotency_level: ::core::option::Option<i32>,
     /// The parser stores options it doesn't recognize here. See above.
-    #[prost(message, repeated, tag="999")]
+    #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 /// Nested message and enum types in `MethodOptions`.
@@ -777,7 +888,17 @@ pub mod method_options {
     /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
     /// or neither? HTTP based RPC implementation may choose GET verb for safe
     /// methods, and PUT verb for idempotent methods instead of the default POST.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum IdempotencyLevel {
         IdempotencyUnknown = 0,
@@ -798,6 +919,15 @@ pub mod method_options {
                 IdempotencyLevel::Idempotent => "IDEMPOTENT",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "IDEMPOTENCY_UNKNOWN" => Some(Self::IdempotencyUnknown),
+                "NO_SIDE_EFFECTS" => Some(Self::NoSideEffects),
+                "IDEMPOTENT" => Some(Self::Idempotent),
+                _ => None,
+            }
+        }
     }
 }
 /// A message representing a option the parser does not recognize. This only
@@ -807,23 +937,24 @@ pub mod method_options {
 /// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 /// in them.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UninterpretedOption {
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub name: ::prost::alloc::vec::Vec<uninterpreted_option::NamePart>,
     /// The value of the uninterpreted option, in whatever type the tokenizer
     /// identified it as during parsing. Exactly one of these should be set.
-    #[prost(string, optional, tag="3")]
+    #[prost(string, optional, tag = "3")]
     pub identifier_value: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(uint64, optional, tag="4")]
+    #[prost(uint64, optional, tag = "4")]
     pub positive_int_value: ::core::option::Option<u64>,
-    #[prost(int64, optional, tag="5")]
+    #[prost(int64, optional, tag = "5")]
     pub negative_int_value: ::core::option::Option<i64>,
-    #[prost(double, optional, tag="6")]
+    #[prost(double, optional, tag = "6")]
     pub double_value: ::core::option::Option<f64>,
-    #[prost(bytes="vec", optional, tag="7")]
+    #[prost(bytes = "vec", optional, tag = "7")]
     pub string_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
-    #[prost(string, optional, tag="8")]
+    #[prost(string, optional, tag = "8")]
     pub aggregate_value: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `UninterpretedOption`.
@@ -831,22 +962,21 @@ pub mod uninterpreted_option {
     /// The name of the uninterpreted option.  Each string represents a segment in
     /// a dot-separated name.  is_extension is true iff a segment represents an
     /// extension (denoted with parentheses in options specs in .proto files).
-    /// E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
-    /// "foo.(bar.baz).moo".
+    /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+    /// "foo.(bar.baz).qux".
     #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NamePart {
-        #[prost(string, required, tag="1")]
+        #[prost(string, required, tag = "1")]
         pub name_part: ::prost::alloc::string::String,
-        #[prost(bool, required, tag="2")]
+        #[prost(bool, required, tag = "2")]
         pub is_extension: bool,
     }
 }
-// ===================================================================
-// Optional source code info
-
 /// Encapsulates information about the original source file from which a
 /// FileDescriptorProto was generated.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SourceCodeInfo {
     /// A Location identifies a piece of source code in a .proto file which
@@ -892,11 +1022,12 @@ pub struct SourceCodeInfo {
     /// - Code which tries to interpret locations should probably be designed to
     ///    ignore those that it doesn't understand, as more types of locations could
     ///    be recorded in the future.
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub location: ::prost::alloc::vec::Vec<source_code_info::Location>,
 }
 /// Nested message and enum types in `SourceCodeInfo`.
 pub mod source_code_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Location {
         /// Identifies which part of the FileDescriptorProto was defined at this
@@ -922,14 +1053,14 @@ pub mod source_code_info {
         ///    [ 4, 3, 2, 7 ]
         /// this path refers to the whole field declaration (from the beginning
         /// of the label to the terminating semicolon).
-        #[prost(int32, repeated, tag="1")]
+        #[prost(int32, repeated, tag = "1")]
         pub path: ::prost::alloc::vec::Vec<i32>,
         /// Always has exactly three or four elements: start line, start column,
         /// end line (optional, otherwise assumed same as start line), end column.
         /// These are packed into a single field for efficiency.  Note that line
         /// and column numbers are zero-based -- typically you will want to add
         /// 1 to each before displaying to a user.
-        #[prost(int32, repeated, tag="2")]
+        #[prost(int32, repeated, tag = "2")]
         pub span: ::prost::alloc::vec::Vec<i32>,
         /// If this SourceCodeInfo represents a complete declaration, these are any
         /// comments appearing before and after the declaration which appear to be
@@ -958,13 +1089,13 @@ pub mod source_code_info {
         ///    // Comment attached to baz.
         ///    // Another line attached to baz.
         ///
-        ///    // Comment attached to moo.
+        ///    // Comment attached to qux.
         ///    //
-        ///    // Another line attached to moo.
-        ///    optional double moo = 4;
+        ///    // Another line attached to qux.
+        ///    optional double qux = 4;
         ///
         ///    // Detached comment for corge. This is not leading or trailing comments
-        ///    // to moo or corge because there are blank lines separating it from
+        ///    // to qux or corge because there are blank lines separating it from
         ///    // both.
         ///
         ///    // Detached comment for corge paragraph 2.
@@ -978,43 +1109,47 @@ pub mod source_code_info {
         ///    optional int32 grault = 6;
         ///
         ///    // ignored detached comments.
-        #[prost(string, optional, tag="3")]
+        #[prost(string, optional, tag = "3")]
         pub leading_comments: ::core::option::Option<::prost::alloc::string::String>,
-        #[prost(string, optional, tag="4")]
+        #[prost(string, optional, tag = "4")]
         pub trailing_comments: ::core::option::Option<::prost::alloc::string::String>,
-        #[prost(string, repeated, tag="6")]
-        pub leading_detached_comments: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+        #[prost(string, repeated, tag = "6")]
+        pub leading_detached_comments: ::prost::alloc::vec::Vec<
+            ::prost::alloc::string::String,
+        >,
     }
 }
 /// Describes the relationship between generated code and its original source
 /// file. A GeneratedCodeInfo message is associated with only one generated
 /// source file, but may contain references to different source .proto files.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
     /// of its generating .proto file.
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub annotation: ::prost::alloc::vec::Vec<generated_code_info::Annotation>,
 }
 /// Nested message and enum types in `GeneratedCodeInfo`.
 pub mod generated_code_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Annotation {
         /// Identifies the element in the original source .proto file. This field
         /// is formatted the same as SourceCodeInfo.Location.path.
-        #[prost(int32, repeated, tag="1")]
+        #[prost(int32, repeated, tag = "1")]
         pub path: ::prost::alloc::vec::Vec<i32>,
         /// Identifies the filesystem path to the original source .proto.
-        #[prost(string, optional, tag="2")]
+        #[prost(string, optional, tag = "2")]
         pub source_file: ::core::option::Option<::prost::alloc::string::String>,
         /// Identifies the starting offset in bytes in the generated code
         /// that relates to the identified object.
-        #[prost(int32, optional, tag="3")]
+        #[prost(int32, optional, tag = "3")]
         pub begin: ::core::option::Option<i32>,
         /// Identifies the ending offset in bytes in the generated code that
         /// relates to the identified offset. The end offset should be one past
         /// the last relevant byte (so the length of the text = end - begin).
-        #[prost(int32, optional, tag="4")]
+        #[prost(int32, optional, tag = "4")]
         pub end: ::core::option::Option<i32>,
     }
 }

--- a/cli/src/proto/sdk/options/v1/mod.rs
+++ b/cli/src/proto/sdk/options/v1/mod.rs
@@ -1,20 +1,21 @@
 /// Configuration for Trinsic SDK Services
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrinsicOptions {
     /// Trinsic API endpoint. Defaults to `prod.trinsic.cloud`
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub server_endpoint: ::prost::alloc::string::String,
     /// Trinsic API port; defaults to `443`
-    #[prost(int32, tag="2")]
+    #[prost(int32, tag = "2")]
     pub server_port: i32,
     /// Whether TLS is enabled between SDK and Trinsic API; defaults to `true`
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub server_use_tls: bool,
     /// Authentication token for SDK calls; defaults to empty string (unauthenticated)
     ///
     /// Default ecosystem ID to use for various SDK calls; defaults to `default`
     /// string default_ecosystem = 5;
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub auth_token: ::prost::alloc::string::String,
 }

--- a/cli/src/proto/services/account/v1/mod.rs
+++ b/cli/src/proto/services/account/v1/mod.rs
@@ -1,32 +1,31 @@
 /// Request for creating or signing into an account
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignInRequest {
     /// Account registration details
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub details: ::core::option::Option<AccountDetails>,
-    /// DEPRECATED, will be removed April 1st 2023
-    /// Invitation code associated with this registration
-    #[deprecated]
-    #[prost(string, tag="2")]
-    pub invitation_code: ::prost::alloc::string::String,
     /// ID of Ecosystem to use
     /// Ignored if `invitation_code` is passed
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub ecosystem_id: ::prost::alloc::string::String,
 }
 /// Account registration details
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountDetails {
     /// Account name
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    /// Email address of account
-    #[prost(string, tag="2")]
+    /// Email address of account.
+    #[deprecated]
+    #[prost(string, tag = "2")]
     pub email: ::prost::alloc::string::String,
     /// SMS number including country code
-    #[prost(string, tag="3")]
+    #[deprecated]
+    #[prost(string, tag = "3")]
     pub sms: ::prost::alloc::string::String,
 }
 /// Response for creating new account
@@ -34,191 +33,161 @@ pub struct AccountDetails {
 /// was sent to one of the users two-factor methods
 /// like email, SMS, etc.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignInResponse {
     /// Indicates if confirmation of account is required.
-    #[prost(enumeration="ConfirmationMethod", tag="3")]
+    #[prost(enumeration = "ConfirmationMethod", tag = "3")]
     pub confirmation_method: i32,
     /// Contains authentication data for use with the current device.
     /// This object must be stored in a secure place. It can also be
     /// protected with a PIN, but this is optional.
     /// See the docs at <https://docs.trinsic.id> for more information
     /// on working with authentication data.
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub profile: ::core::option::Option<AccountProfile>,
 }
 /// Device profile containing sensitive authentication data.
 /// This information should be stored securely
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountProfile {
     /// The type of profile, used to differentiate between
     /// protocol schemes or versions
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub profile_type: ::prost::alloc::string::String,
     /// Auth data containg information about the current device access
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub auth_data: ::prost::alloc::vec::Vec<u8>,
     /// Secure token issued by server used to generate zero-knowledge proofs
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes = "vec", tag = "3")]
     pub auth_token: ::prost::alloc::vec::Vec<u8>,
     /// Token security information about the token.
     /// If token protection is enabled, implementations must supply
     /// protection secret before using the token for authentication.
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub protection: ::core::option::Option<TokenProtection>,
 }
 /// Token protection info
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TokenProtection {
     /// Indicates if token is protected using a PIN,
     /// security code, HSM secret, etc.
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub enabled: bool,
     /// The method used to protect the token
-    #[prost(enumeration="ConfirmationMethod", tag="2")]
+    #[prost(enumeration = "ConfirmationMethod", tag = "2")]
     pub method: i32,
 }
 /// Request for information about the account used to make the request
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AccountInfoRequest {
-}
+pub struct AccountInfoRequest {}
 /// Information about the account used to make the request
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountInfoResponse {
     /// The account details associated with
     /// the calling request context
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub details: ::core::option::Option<AccountDetails>,
-    /// DEPRECATED, will be removed April 1st 2023
-    /// Use `ecosystem_id` instead
-    #[deprecated]
-    #[prost(message, repeated, tag="2")]
-    pub ecosystems: ::prost::alloc::vec::Vec<AccountEcosystem>,
     /// The wallet ID associated with this account
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub wallet_id: ::prost::alloc::string::String,
     /// The device ID associated with this account session
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub device_id: ::prost::alloc::string::String,
     /// The ecosystem ID within which this account resides
-    #[prost(string, tag="5")]
+    #[prost(string, tag = "5")]
     pub ecosystem_id: ::prost::alloc::string::String,
     /// The public DID associated with this account.
     /// This DID is used as the `issuer` when signing verifiable credentials
-    #[prost(string, tag="6")]
+    #[prost(string, tag = "6")]
     pub public_did: ::prost::alloc::string::String,
     /// List of active authentication tokens for this wallet.
     /// This list does not contain the issued token, only metadata
     /// such as ID, description, and creation date.
-    #[prost(message, repeated, tag="8")]
+    #[prost(message, repeated, tag = "8")]
     pub auth_tokens: ::prost::alloc::vec::Vec<WalletAuthToken>,
 }
-/// Deprecated
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AccountEcosystem {
-    #[prost(string, tag="1")]
-    pub id: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub name: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
-    pub description: ::prost::alloc::string::String,
-    #[prost(string, tag="4")]
-    pub uri: ::prost::alloc::string::String,
-}
-// Login
-
 /// Request to begin login flow
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LoginRequest {
     /// Email address of account. If unspecified, an anonymous account will be created.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub email: ::prost::alloc::string::String,
-    /// DEPRECATED, will be removed April 1st 2023
-    /// Invitation code associated with this registration
-    #[deprecated]
-    #[prost(string, tag="2")]
-    pub invitation_code: ::prost::alloc::string::String,
     /// ID of Ecosystem to sign into.
-    /// Ignored if `invitation_code` is passed.
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub ecosystem_id: ::prost::alloc::string::String,
 }
 /// Response to `LoginRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LoginResponse {
-    #[prost(oneof="login_response::Response", tags="1, 2")]
+    #[prost(oneof = "login_response::Response", tags = "1, 2")]
     pub response: ::core::option::Option<login_response::Response>,
 }
 /// Nested message and enum types in `LoginResponse`.
 pub mod login_response {
     #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Response {
         /// Random byte sequence unique to this login request.
         /// If present, two-factor confirmation of login is required.
         /// Must be sent back, unaltered, in `LoginConfirm`.
-        #[prost(bytes, tag="1")]
+        #[prost(bytes, tag = "1")]
         Challenge(::prost::alloc::vec::Vec<u8>),
         /// Account profile response. If present, no confirmation of login is required.
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         Profile(super::AccountProfile),
     }
 }
 /// Request to finalize login flow
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LoginConfirmRequest {
     /// Challenge received from `Login`
-    #[prost(bytes="vec", tag="1")]
+    #[prost(bytes = "vec", tag = "1")]
     pub challenge: ::prost::alloc::vec::Vec<u8>,
     /// Two-factor confirmation code sent to account email or phone,
     /// hashed using Blake3. Our SDKs will handle this hashing process for you.
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub confirmation_code_hashed: ::prost::alloc::vec::Vec<u8>,
 }
 /// Response to `LoginConfirmRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LoginConfirmResponse {
     /// Profile response; must be unprotected using unhashed confirmation code.
     /// Our SDKs will handle this process for you, and return to you an authentication token string.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub profile: ::core::option::Option<AccountProfile>,
 }
-/// Request to authorize Ecosystem provider to receive webhooks for events
-/// which occur on this wallet.
+/// Information about authentication tokens for a wallet
 #[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AuthorizeWebhookRequest {
-    /// Events to authorize access to. Default is "*" (all events)
-    #[prost(string, repeated, tag="1")]
-    pub events: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-/// Response to `AuthorizeWebhookRequest`
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AuthorizeWebhookResponse {
-}
-/// Information about authenticaton tokens for a wallet
-#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WalletAuthToken {
     /// Unique identifier for the token.
     /// This field will match the `DeviceId` in the WalletAuthData
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
     /// Device name/description
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub description: ::core::option::Option<::prost::alloc::string::String>,
     /// Date when the token was created in ISO 8601 format
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub date_created: ::prost::alloc::string::String,
 }
 /// Confirmation method type for two-factor workflows
@@ -249,6 +218,17 @@ impl ConfirmationMethod {
             ConfirmationMethod::Sms => "Sms",
             ConfirmationMethod::ConnectedDevice => "ConnectedDevice",
             ConfirmationMethod::Other => "Other",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "None" => Some(Self::None),
+            "Email" => Some(Self::Email),
+            "Sms" => Some(Self::Sms),
+            "ConnectedDevice" => Some(Self::ConnectedDevice),
+            "Other" => Some(Self::Other),
+            _ => None,
         }
     }
 }
@@ -398,26 +378,6 @@ pub mod account_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/services.account.v1.Account/Info",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// Authorize Ecosystem to receive webhook events
-        pub async fn authorize_webhook(
-            &mut self,
-            request: impl tonic::IntoRequest<super::AuthorizeWebhookRequest>,
-        ) -> Result<tonic::Response<super::AuthorizeWebhookResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/services.account.v1.Account/AuthorizeWebhook",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cli/src/proto/services/common/v1/mod.rs
+++ b/cli/src/proto/services/common/v1/mod.rs
@@ -1,12 +1,13 @@
 /// Nonce used to generate an oberon proof
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Nonce {
     /// UTC unix millisecond timestamp the request was made
-    #[prost(int64, tag="1")]
+    #[prost(int64, tag = "1")]
     pub timestamp: i64,
     /// blake3256 hash of the request body
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub request_hash: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -35,6 +36,18 @@ impl ResponseStatus {
             ResponseStatus::UnknownError => "UNKNOWN_ERROR",
         }
     }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SUCCESS" => Some(Self::Success),
+            "WALLET_ACCESS_DENIED" => Some(Self::WalletAccessDenied),
+            "WALLET_EXISTS" => Some(Self::WalletExists),
+            "ITEM_NOT_FOUND" => Some(Self::ItemNotFound),
+            "SERIALIZATION_ERROR" => Some(Self::SerializationError),
+            "UNKNOWN_ERROR" => Some(Self::UnknownError),
+            _ => None,
+        }
+    }
 }
 /// Enum of all supported DID Methods
 /// <https://docs.godiddy.com/en/supported-methods>
@@ -59,6 +72,15 @@ impl SupportedDidMethod {
             SupportedDidMethod::Key => "KEY",
             SupportedDidMethod::Ion => "ION",
             SupportedDidMethod::Indy => "INDY",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "KEY" => Some(Self::Key),
+            "ION" => Some(Self::Ion),
+            "INDY" => Some(Self::Indy),
+            _ => None,
         }
     }
 }

--- a/cli/src/proto/services/provider/v1/mod.rs
+++ b/cli/src/proto/services/provider/v1/mod.rs
@@ -1,448 +1,228 @@
-/// Request to invite a participant to an ecosystem
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InviteRequest {
-    /// Type of participant being invited (individual/organization)
-    #[prost(enumeration="ParticipantType", tag="1")]
-    pub participant: i32,
-    /// Description of invitation
-    #[prost(string, tag="2")]
-    pub description: ::prost::alloc::string::String,
-    /// Account details of invitee
-    #[prost(message, optional, tag="3")]
-    pub details: ::core::option::Option<super::super::account::v1::AccountDetails>,
-}
-/// Nested message and enum types in `InviteRequest`.
-pub mod invite_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct DidCommInvitation {
-    }
-}
-/// DEPRECATED, will be removed April 1st 2023
-/// Response to `InviteRequest`
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InviteResponse {
-    /// ID of created invitation
-    #[prost(string, tag="10")]
-    pub invitation_id: ::prost::alloc::string::String,
-    /// Invitation code -- must be passed back in `LoginRequest`
-    #[prost(string, tag="11")]
-    pub invitation_code: ::prost::alloc::string::String,
-}
-/// DEPRECATED, will be removed April 1st 2023
-/// Request details for the status of an invitation
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InvitationStatusRequest {
-    /// ID of invitation, received from `InviteResponse`
-    #[prost(string, tag="1")]
-    pub invitation_id: ::prost::alloc::string::String,
-}
-/// DEPRECATED, will be removed April 1st 2023
-/// Response to `InvitationStatusRequest`
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InvitationStatusResponse {
-    /// Status of invitation
-    #[prost(enumeration="invitation_status_response::Status", tag="1")]
-    pub status: i32,
-    /// Human-readable string with details about invitation status
-    #[prost(string, tag="2")]
-    pub status_details: ::prost::alloc::string::String,
-}
-/// Nested message and enum types in `InvitationStatusResponse`.
-pub mod invitation_status_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-    #[repr(i32)]
-    pub enum Status {
-        /// Onboarding resulted in error
-        Error = 0,
-        /// The participant has been invited
-        InvitationSent = 1,
-        /// The participant has been onboarded
-        Completed = 2,
-        /// The invite has expired
-        Expired = 3,
-    }
-    impl Status {
-        /// String value of the enum field names used in the ProtoBuf definition.
-        ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn as_str_name(&self) -> &'static str {
-            match self {
-                Status::Error => "Error",
-                Status::InvitationSent => "InvitationSent",
-                Status::Completed => "Completed",
-                Status::Expired => "Expired",
-            }
-        }
-    }
-}
 /// Details of an ecosystem
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Ecosystem {
     /// URN of the ecosystem
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
     /// Globally unique name for the ecosystem
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub name: ::prost::alloc::string::String,
     /// Ecosystem description
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub description: ::prost::alloc::string::String,
-    /// DEPRECATED, will be removed April 1st 2023
-    /// External URL associated with the organization or ecosystem entity
-    #[deprecated]
-    #[prost(string, tag="4")]
-    pub uri: ::prost::alloc::string::String,
-    /// Display details
-    #[prost(message, optional, tag="6")]
-    pub display: ::core::option::Option<EcosystemDisplay>,
-    /// Domain
-    #[prost(string, tag="7")]
-    pub domain: ::prost::alloc::string::String,
-}
-/// DEPRECATED, will be removed April 1st 2023
-/// Webhook configured on an ecosystem
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct WebhookConfig {
-    /// UUID of the webhook
-    #[prost(string, tag="1")]
-    pub id: ::prost::alloc::string::String,
-    /// HTTPS URL to POST webhook calls to
-    #[prost(string, tag="2")]
-    pub destination_url: ::prost::alloc::string::String,
-    /// Events the webhook is subscribed to
-    #[prost(string, repeated, tag="4")]
-    pub events: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Last known status of webhook (whether or not Trinsic can successfully reach destination)
-    #[prost(string, tag="5")]
-    pub status: ::prost::alloc::string::String,
 }
 /// Request to create an ecosystem
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateEcosystemRequest {
     /// Globally unique name for the Ecosystem. This name will be
     /// part of the ecosystem-specific URLs and namespaces.
     /// Allowed characters are lowercase letters, numbers, underscore and hyphen.
     /// If not passed, ecosystem name will be auto-generated.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Ecosystem description
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub description: ::prost::alloc::string::String,
-    /// DEPRECATED, will be removed April 1st 2023
-    /// External URL associated with your organization or ecosystem entity
-    #[deprecated]
-    #[prost(string, tag="3")]
-    pub uri: ::prost::alloc::string::String,
     /// The account details of the owner of the ecosystem
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub details: ::core::option::Option<super::super::account::v1::AccountDetails>,
     /// New domain URL
-    #[prost(string, tag="5")]
+    #[prost(string, tag = "5")]
     pub domain: ::prost::alloc::string::String,
 }
 /// Response to `CreateEcosystemRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateEcosystemResponse {
     /// Details of the created ecosystem
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub ecosystem: ::core::option::Option<Ecosystem>,
     /// Account profile for auth of the owner of the ecosystem
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub profile: ::core::option::Option<super::super::account::v1::AccountProfile>,
     /// Indicates if confirmation of account is required.
-    #[prost(enumeration="super::super::account::v1::ConfirmationMethod", tag="3")]
+    #[prost(enumeration = "super::super::account::v1::ConfirmationMethod", tag = "3")]
     pub confirmation_method: i32,
-}
-/// Request to update an ecosystem's metadata
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UpdateEcosystemRequest {
-    /// New description of the ecosystem
-    #[prost(string, tag="1")]
-    pub description: ::prost::alloc::string::String,
-    /// DEPRECATED, will be removed April 1st 2023
-    /// New external URL associated with the organization or ecosystem entity
-    #[deprecated]
-    #[prost(string, tag="2")]
-    pub uri: ::prost::alloc::string::String,
-    /// New domain URL
-    #[prost(string, tag="3")]
-    pub domain: ::prost::alloc::string::String,
-    // The below display can be removed only once the Dashboard is updating this itself - currently it uses this request
-    // DEPRECATED, will be removed June 1st 2023
-
-    /// Display details
-    #[deprecated]
-    #[prost(message, optional, tag="5")]
-    pub display: ::core::option::Option<EcosystemDisplayRequest>,
-}
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct EcosystemDisplayRequest {
-    /// Removed the Dark after discussion with team, as we don't provide a dark UI anywhere (yet) in our platform.
-    /// EcosystemDisplayDetailsRequest dark = 1;
-    #[prost(message, optional, tag="2")]
-    pub light: ::core::option::Option<EcosystemDisplayDetailsRequest>,
-}
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct EcosystemDisplayDetailsRequest {
-    #[prost(string, tag="4")]
-    pub color: ::prost::alloc::string::String,
-    #[prost(bytes="vec", tag="5")]
-    pub logo_data: ::prost::alloc::vec::Vec<u8>,
-    /// MIME type of the file
-    #[prost(string, tag="6")]
-    pub logo_format: ::prost::alloc::string::String,
-}
-/// Response to `UpdateEcosystemRequest`
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UpdateEcosystemResponse {
-    /// Current ecosystem metadata, post-update
-    #[prost(message, optional, tag="1")]
-    pub ecosystem: ::core::option::Option<Ecosystem>,
-}
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct EcosystemDisplay {
-    ///     Removed the Dark after discussion with team, as we don't provide a dark UI anywhere (yet) in our platform.
-    ///     EcosystemDisplayDetails dark = 1;
-    #[prost(message, optional, tag="2")]
-    pub light: ::core::option::Option<EcosystemDisplayDetails>,
-}
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct EcosystemDisplayDetails {
-    #[prost(string, tag="3")]
-    pub logo_url: ::prost::alloc::string::String,
-    #[prost(string, tag="4")]
-    pub color: ::prost::alloc::string::String,
-}
-/// DEPRECATED, will be removed April 1st 2023
-/// Request to add a webhook to an ecosystem
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AddWebhookRequest {
-    /// Destination to post webhook calls to.
-    /// Must be a reachable HTTPS URL.
-    #[prost(string, tag="1")]
-    pub destination_url: ::prost::alloc::string::String,
-    /// Secret string used for HMAC-SHA256 signing of webhook payloads
-    /// to verify that a webhook comes from Trinsic
-    #[prost(string, tag="2")]
-    pub secret: ::prost::alloc::string::String,
-    /// Events to subscribe to. Default is "*" (all events)
-    #[prost(string, repeated, tag="3")]
-    pub events: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-/// DEPRECATED, will be removed April 1st 2023
-/// Response to `AddWebhookRequest`
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AddWebhookResponse {
-    /// Ecosystem data with new webhook
-    #[prost(message, optional, tag="1")]
-    pub ecosystem: ::core::option::Option<Ecosystem>,
-}
-/// DEPRECATED, will be removed April 1st 2023
-/// Request to delete a webhook from an ecosystem
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DeleteWebhookRequest {
-    /// ID of webhook to delete
-    #[prost(string, tag="1")]
-    pub webhook_id: ::prost::alloc::string::String,
-}
-/// DEPRECATED, will be removed April 1st 2023
-/// Response to `DeleteWebhookRequest`
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DeleteWebhookResponse {
-    /// Ecosystem data after removal of webhook
-    #[prost(message, optional, tag="1")]
-    pub ecosystem: ::core::option::Option<Ecosystem>,
 }
 /// Request to fetch information about an ecosystem
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct EcosystemInfoRequest {
-}
+pub struct EcosystemInfoRequest {}
 /// Response to `InfoRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EcosystemInfoResponse {
     /// Ecosystem corresponding to current ecosystem in the account token
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub ecosystem: ::core::option::Option<Ecosystem>,
-}
-/// DEPRECATED, will be removed April 1st 2023
-/// Request to fetch information about an ecosystem
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetPublicEcosystemInfoRequest {
-    #[prost(string, tag="1")]
-    pub ecosystem_id: ::prost::alloc::string::String,
-}
-/// DEPRECATED, will be removed April 1st 2023
-/// Response to `InfoRequest`
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetPublicEcosystemInfoResponse {
-    /// Ecosystem corresponding to requested `ecosystem_id`
-    #[prost(message, optional, tag="1")]
-    pub ecosystem: ::core::option::Option<PublicEcosystemInformation>,
-}
-/// DEPRECATED, will be removed April 1st 2023
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PublicEcosystemInformation {
-    /// Public name of this ecosystem
-    #[prost(string, tag="1")]
-    pub name: ::prost::alloc::string::String,
-    /// Public domain for the owner of this ecosystem
-    #[prost(string, tag="2")]
-    pub domain: ::prost::alloc::string::String,
-    /// Trinsic verified the domain is owned by the owner of this ecosystem
-    #[prost(bool, tag="3")]
-    pub domain_verified: bool,
-    /// Style display information
-    #[prost(message, optional, tag="4")]
-    pub style_display: ::core::option::Option<EcosystemDisplay>,
-    /// Description of the ecosystem
-    #[prost(string, tag="5")]
-    pub description: ::prost::alloc::string::String,
 }
 /// Request to fetch the Trinsic public key used
 /// to verify authentication token validity
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetOberonKeyRequest {
-}
+pub struct GetOberonKeyRequest {}
 /// Response to `GetOberonKeyRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetOberonKeyResponse {
     /// Oberon Public Key as RAW base64-url encoded string
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub key: ::prost::alloc::string::String,
 }
 /// The below display can be removed only once the Dashboard is updating this itself - currently it uses this request
 /// DEPRECATED, will be removed June 1st 2023
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RetrieveDomainVerificationRecordRequest {
-}
+pub struct RetrieveDomainVerificationRecordRequest {}
 /// The below display can be removed only once the Dashboard is updating this itself - currently it uses this request
 /// DEPRECATED, will be removed June 1st 2023
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RetrieveDomainVerificationRecordResponse {
     /// TXT record name to use for domain verification
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub verification_record_name: ::prost::alloc::string::String,
     /// TXT code for domain verification
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub verification_record_value: ::prost::alloc::string::String,
 }
 /// The below display can be removed only once the Dashboard is updating this itself - currently it uses this request
 /// DEPRECATED, will be removed June 1st 2023
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RefreshDomainVerificationStatusRequest {
-}
+pub struct RefreshDomainVerificationStatusRequest {}
 /// The below display can be removed only once the Dashboard is updating this itself - currently it uses this request
 /// DEPRECATED, will be removed June 1st 2023
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RefreshDomainVerificationStatusResponse {
     /// Domain URL verified
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub domain: ::prost::alloc::string::String,
     /// Specifies if the above `domain` was successfully verified
-    #[prost(bool, tag="2")]
+    #[prost(bool, tag = "2")]
     pub domain_verified: bool,
 }
 /// Search for issuers/holders/verifiers
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchWalletConfigurationsRequest {
-    /// SQL filter to execute. `SELECT * FROM _ WHERE \[**queryFilter**\]`
-    #[prost(string, tag="1")]
+    /// SQL filter to execute. `SELECT * FROM c WHERE \[**queryFilter**\]`
+    #[prost(string, tag = "1")]
     pub query_filter: ::prost::alloc::string::String,
     /// Token provided by previous `SearchResponse`
     /// if more data is available for query
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub continuation_token: ::prost::alloc::string::String,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchWalletConfigurationResponse {
     /// Results matching the search query
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub results: ::prost::alloc::vec::Vec<WalletConfiguration>,
     /// Whether more results are available for this query via `continuation_token`
-    #[prost(bool, tag="2")]
+    #[prost(bool, tag = "2")]
     pub has_more_results: bool,
     /// Token to fetch next set of results via `SearchRequest`
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub continuation_token: ::prost::alloc::string::String,
 }
 /// Strongly typed information about wallet configurations
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WalletConfiguration {
     /// Name/description of the wallet
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    /// Deprecated and will be removed on August 1, 2023 -- use external_identities.
+    /// This field is set to the first email address present in `external_identities`, if any.
+    #[deprecated]
+    #[prost(string, tag = "2")]
     pub email: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
+    /// Deprecated -- use external_identities
+    #[deprecated]
+    #[prost(string, tag = "3")]
     pub sms: ::prost::alloc::string::String,
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub wallet_id: ::prost::alloc::string::String,
     /// The DID of the wallet
-    #[prost(string, tag="5")]
+    #[prost(string, tag = "5")]
     pub public_did: ::prost::alloc::string::String,
-    #[prost(string, tag="6")]
+    #[prost(string, tag = "6")]
     pub config_type: ::prost::alloc::string::String,
     /// List of active authentication tokens for this wallet.
     /// This list does not contain the issued token, only metadata
     /// such as ID, description, and creation date.
-    #[prost(message, repeated, tag="7")]
-    pub auth_tokens: ::prost::alloc::vec::Vec<super::super::account::v1::WalletAuthToken>,
-    /// List of external identities associated with this wallet.
-    #[prost(string, repeated, tag="8")]
-    pub external_identities: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag = "7")]
+    pub auth_tokens: ::prost::alloc::vec::Vec<
+        super::super::account::v1::WalletAuthToken,
+    >,
+    /// List of external identity IDs (email addresses, phone numbers, etc.) associated with this wallet.
+    /// This is deprecated; use `external_identities` instead.
+    #[deprecated]
+    #[prost(string, repeated, tag = "8")]
+    pub external_identity_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Ecosystem in which this wallet is contained.
-    #[prost(string, tag="9")]
+    #[prost(string, tag = "9")]
     pub ecosystem_id: ::prost::alloc::string::String,
-    #[prost(string, tag="10")]
+    #[prost(string, tag = "10")]
     pub description: ::prost::alloc::string::String,
+    /// List of external identities associated with this wallet.
+    #[prost(message, repeated, tag = "11")]
+    pub external_identities: ::prost::alloc::vec::Vec<WalletExternalIdentity>,
+}
+/// An external identity (email address, phone number, etc.) associated with a wallet for authentication purposes.
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WalletExternalIdentity {
+    /// The type of this identity (whether this identity is an email address, phone number, etc.)
+    #[prost(enumeration = "IdentityProvider", tag = "1")]
+    pub provider: i32,
+    /// The actual email address/phone number/etc. for this identity
+    #[prost(string, tag = "2")]
+    pub id: ::prost::alloc::string::String,
 }
 /// Options for creation of DID on the ION network
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IonOptions {
     /// ION network on which DID should be published
-    #[prost(enumeration="ion_options::IonNetwork", tag="1")]
+    #[prost(enumeration = "ion_options::IonNetwork", tag = "1")]
     pub network: i32,
 }
 /// Nested message and enum types in `IonOptions`.
 pub mod ion_options {
     #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum IonNetwork {
         TestNet = 0,
@@ -459,20 +239,39 @@ pub mod ion_options {
                 IonNetwork::MainNet => "MainNet",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "TestNet" => Some(Self::TestNet),
+                "MainNet" => Some(Self::MainNet),
+                _ => None,
+            }
+        }
     }
 }
 /// Options for creation of DID on the SOV network
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IndyOptions {
     /// SOV network on which DID should be published
-    #[prost(enumeration="indy_options::IndyNetwork", tag="1")]
+    #[prost(enumeration = "indy_options::IndyNetwork", tag = "1")]
     pub network: i32,
 }
 /// Nested message and enum types in `IndyOptions`.
 pub mod indy_options {
     #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum IndyNetwork {
         Danube = 0,
@@ -503,77 +302,106 @@ pub mod indy_options {
                 IndyNetwork::Indicio => "Indicio",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "Danube" => Some(Self::Danube),
+                "SovrinBuilder" => Some(Self::SovrinBuilder),
+                "SovrinStaging" => Some(Self::SovrinStaging),
+                "Sovrin" => Some(Self::Sovrin),
+                "IdUnionTest" => Some(Self::IdUnionTest),
+                "IdUnion" => Some(Self::IdUnion),
+                "IndicioTest" => Some(Self::IndicioTest),
+                "IndicioDemo" => Some(Self::IndicioDemo),
+                "Indicio" => Some(Self::Indicio),
+                _ => None,
+            }
+        }
     }
 }
 /// Request to upgrade a wallet
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpgradeDidRequest {
     /// DID Method to which wallet should be upgraded
-    #[prost(enumeration="super::super::common::v1::SupportedDidMethod", tag="3")]
+    #[prost(enumeration = "super::super::common::v1::SupportedDidMethod", tag = "3")]
     pub method: i32,
-    #[prost(oneof="upgrade_did_request::Account", tags="1, 2, 6")]
+    #[prost(oneof = "upgrade_did_request::Account", tags = "1, 2, 6")]
     pub account: ::core::option::Option<upgrade_did_request::Account>,
-    #[prost(oneof="upgrade_did_request::Options", tags="4, 5")]
+    #[prost(oneof = "upgrade_did_request::Options", tags = "4, 5")]
     pub options: ::core::option::Option<upgrade_did_request::Options>,
 }
 /// Nested message and enum types in `UpgradeDidRequest`.
 pub mod upgrade_did_request {
     #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Account {
         /// Email address of account to upgrade.
         /// Mutually exclusive with `walletId` and `didUri`.
-        #[prost(string, tag="1")]
+        #[prost(string, tag = "1")]
         Email(::prost::alloc::string::String),
         /// Wallet ID of account to upgrade.
         /// Mutually exclusive with `email` and `didUri`.
-        #[prost(string, tag="2")]
+        #[prost(string, tag = "2")]
         WalletId(::prost::alloc::string::String),
         /// DID URI of the account to upgrade.
         /// Mutually exclusive with `email` and `walletId`.
-        #[prost(string, tag="6")]
+        #[prost(string, tag = "6")]
         DidUri(::prost::alloc::string::String),
     }
     #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Options {
         /// Configuration for creation of DID on ION network
-        #[prost(message, tag="4")]
+        #[prost(message, tag = "4")]
         IonOptions(super::IonOptions),
         /// Configuration for creation of DID on INDY network
-        #[prost(message, tag="5")]
+        #[prost(message, tag = "5")]
         IndyOptions(super::IndyOptions),
     }
 }
 /// Response to `UpgradeDIDRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpgradeDidResponse {
     /// New DID of wallet
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub did: ::prost::alloc::string::String,
 }
-/// DEPRECATED, will be removed April 1st 2023
-/// Type of participant being invited to ecosystem
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
-pub enum ParticipantType {
-    /// Participant is an individual
-    Individual = 0,
-    /// Participant is an organization
-    Organization = 1,
+pub enum IdentityProvider {
+    /// Identity provider is unknown
+    Unknown = 0,
+    /// Identity provider is email
+    Email = 1,
+    /// Identity provider is phone
+    Phone = 2,
 }
-impl ParticipantType {
+impl IdentityProvider {
     /// String value of the enum field names used in the ProtoBuf definition.
     ///
     /// The values are not transformed in any way and thus are considered stable
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            ParticipantType::Individual => "participant_type_individual",
-            ParticipantType::Organization => "participant_type_organization",
+            IdentityProvider::Unknown => "Unknown",
+            IdentityProvider::Email => "Email",
+            IdentityProvider::Phone => "Phone",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "Unknown" => Some(Self::Unknown),
+            "Email" => Some(Self::Email),
+            "Phone" => Some(Self::Phone),
+            _ => None,
         }
     }
 }
@@ -666,154 +494,6 @@ pub mod provider_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// The below display can be removed only once the Dashboard is updating this itself - currently it uses this request
-        /// DEPRECATED, will be removed June 1st 2023
-        pub async fn update_ecosystem(
-            &mut self,
-            request: impl tonic::IntoRequest<super::UpdateEcosystemRequest>,
-        ) -> Result<tonic::Response<super::UpdateEcosystemResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/services.provider.v1.Provider/UpdateEcosystem",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// The below display can be removed only once the Dashboard is updating this itself - currently it uses this request
-        /// DEPRECATED, will be removed April 1st 2023
-        pub async fn add_webhook(
-            &mut self,
-            request: impl tonic::IntoRequest<super::AddWebhookRequest>,
-        ) -> Result<tonic::Response<super::AddWebhookResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/services.provider.v1.Provider/AddWebhook",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// The below display can be removed only once the Dashboard is updating this itself - currently it uses this request
-        /// DEPRECATED, will be removed April 1st 2023
-        pub async fn delete_webhook(
-            &mut self,
-            request: impl tonic::IntoRequest<super::DeleteWebhookRequest>,
-        ) -> Result<tonic::Response<super::DeleteWebhookResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/services.provider.v1.Provider/DeleteWebhook",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// The below display can be removed only once the Dashboard is updating this itself - currently it uses this request
-        /// DEPRECATED, will be removed June 1st 2023
-        pub async fn ecosystem_info(
-            &mut self,
-            request: impl tonic::IntoRequest<super::EcosystemInfoRequest>,
-        ) -> Result<tonic::Response<super::EcosystemInfoResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/services.provider.v1.Provider/EcosystemInfo",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// The below display can be removed only once the Dashboard is updating this itself - currently it uses this request
-        /// DEPRECATED, will be removed June 1st 2023
-        pub async fn get_public_ecosystem_info(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetPublicEcosystemInfoRequest>,
-        ) -> Result<
-            tonic::Response<super::GetPublicEcosystemInfoResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/services.provider.v1.Provider/GetPublicEcosystemInfo",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// DEPRECATED, will be removed April 1st 2023
-        pub async fn invite(
-            &mut self,
-            request: impl tonic::IntoRequest<super::InviteRequest>,
-        ) -> Result<tonic::Response<super::InviteResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/services.provider.v1.Provider/Invite",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// DEPRECATED, will be removed April 1st 2023
-        pub async fn invitation_status(
-            &mut self,
-            request: impl tonic::IntoRequest<super::InvitationStatusRequest>,
-        ) -> Result<tonic::Response<super::InvitationStatusResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/services.provider.v1.Provider/InvitationStatus",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
         /// Returns the public key being used to create/verify oberon tokens
         pub async fn get_oberon_key(
             &mut self,
@@ -851,56 +531,6 @@ pub mod provider_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/services.provider.v1.Provider/UpgradeDID",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// Retrieve a random hash TXT that can be used to verify domain ownership
-        pub async fn retrieve_domain_verification_record(
-            &mut self,
-            request: impl tonic::IntoRequest<
-                super::RetrieveDomainVerificationRecordRequest,
-            >,
-        ) -> Result<
-            tonic::Response<super::RetrieveDomainVerificationRecordResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/services.provider.v1.Provider/RetrieveDomainVerificationRecord",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// Call to verify domain
-        pub async fn refresh_domain_verification_status(
-            &mut self,
-            request: impl tonic::IntoRequest<
-                super::RefreshDomainVerificationStatusRequest,
-            >,
-        ) -> Result<
-            tonic::Response<super::RefreshDomainVerificationStatusResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/services.provider.v1.Provider/RefreshDomainVerificationStatus",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cli/src/proto/services/trustregistry/v1/mod.rs
+++ b/cli/src/proto/services/trustregistry/v1/mod.rs
@@ -1,182 +1,249 @@
 /// Request to register a new ecosystem governance framework in the current ecosystem
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddFrameworkRequest {
     /// URI of governance framework organization
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub governance_framework_uri: ::prost::alloc::string::String,
     /// Name of governance framework organization
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub name: ::prost::alloc::string::String,
     /// Description of governance framework
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub description: ::prost::alloc::string::String,
 }
 /// Response to `AddFrameworkRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddFrameworkResponse {
     /// Unique framework identifier
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
     /// DID URI of Trinsic account which created the governance framework
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub governing_authority: ::prost::alloc::string::String,
     /// URN of trust registry for governance framework
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub trust_registry: ::prost::alloc::string::String,
 }
 /// Request to remove a governance framework from the current ecosystem
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoveFrameworkRequest {
     /// ID of governance framework to remove
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
 /// Response to `RemoveFrameworkRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RemoveFrameworkResponse {
-}
+pub struct RemoveFrameworkResponse {}
 /// Request to search all governance frameworks within ecosystem
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchRegistryRequest {
     /// SQL query to execute against frameworks. Example: `SELECT c from c where c.type == 'GovernanceFramework'`
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub query: ::prost::alloc::string::String,
     /// Token to fetch next set of results, from previous `SearchRegistryResponse`
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub continuation_token: ::prost::alloc::string::String,
 }
 /// Response to `SearchRegistryRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchRegistryResponse {
     /// JSON string containing array of resultant objects
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub items_json: ::prost::alloc::string::String,
     /// Whether more data is available to fetch for query
-    #[prost(bool, tag="2")]
+    #[prost(bool, tag = "2")]
     pub has_more_results: bool,
     /// Token to fetch next set of results via `SearchRegistryRequest`
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub continuation_token: ::prost::alloc::string::String,
 }
 /// Ecosystem Governance Framework
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GovernanceFramework {
     /// URI of governance framework organization
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub governance_framework_uri: ::prost::alloc::string::String,
     /// URI of trust registry associated with governance framework
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub trust_registry_uri: ::prost::alloc::string::String,
     /// Description of governance framework
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub description: ::prost::alloc::string::String,
 }
 /// Request to register a member as a valid issuer of a specific credential schema.
 /// Only one of `did_uri`, `wallet_id`, or `email` may be specified.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterMemberRequest {
     /// URI of credential schema to register member as authorized issuer of
-    #[prost(string, tag="10")]
+    #[prost(string, tag = "10")]
     pub schema_uri: ::prost::alloc::string::String,
     /// Unix Timestamp member is valid from. Member will not be considered valid before this timestamp.
-    #[prost(uint64, tag="11")]
+    #[prost(uint64, tag = "11")]
     pub valid_from_utc: u64,
     /// Unix Timestamp member is valid until. Member will not be considered valid after this timestamp.
-    #[prost(uint64, tag="12")]
+    #[prost(uint64, tag = "12")]
     pub valid_until_utc: u64,
     /// ID of the governance framework that member is being added to
-    #[prost(string, tag="30")]
+    #[prost(string, tag = "30")]
     pub framework_id: ::prost::alloc::string::String,
-    #[prost(oneof="register_member_request::Member", tags="1, 3, 4")]
+    #[prost(oneof = "register_member_request::Member", tags = "1, 3, 4")]
     pub member: ::core::option::Option<register_member_request::Member>,
 }
 /// Nested message and enum types in `RegisterMemberRequest`.
 pub mod register_member_request {
     #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Member {
         /// DID URI of member to register
-        #[prost(string, tag="1")]
+        #[prost(string, tag = "1")]
         DidUri(::prost::alloc::string::String),
         /// Trinsic Wallet ID of member to register
-        #[prost(string, tag="3")]
+        #[prost(string, tag = "3")]
         WalletId(::prost::alloc::string::String),
         /// Email address of member to register. Must be associated with an existing Trinsic account.
-        #[prost(string, tag="4")]
+        #[prost(string, tag = "4")]
         Email(::prost::alloc::string::String),
     }
 }
 /// Response to `RegisterMemberRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RegisterMemberResponse {
-}
+pub struct RegisterMemberResponse {}
 /// Request to unregister a member as a valid issuer of a specific credential schema.
 /// Only one of `did_uri`, `wallet_id`, or `email` may be specified.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnregisterMemberRequest {
     /// URI of credential schema to unregister member as authorized issuer of
-    #[prost(string, tag="10")]
+    #[prost(string, tag = "10")]
     pub schema_uri: ::prost::alloc::string::String,
     /// ID of the governance framework that member is being removed from
-    #[prost(string, tag="20")]
+    #[prost(string, tag = "20")]
     pub framework_id: ::prost::alloc::string::String,
-    #[prost(oneof="unregister_member_request::Member", tags="1, 3, 4")]
+    #[prost(oneof = "unregister_member_request::Member", tags = "1, 3, 4")]
     pub member: ::core::option::Option<unregister_member_request::Member>,
 }
 /// Nested message and enum types in `UnregisterMemberRequest`.
 pub mod unregister_member_request {
     #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Member {
         /// DID URI of member to unregister
-        #[prost(string, tag="1")]
+        #[prost(string, tag = "1")]
         DidUri(::prost::alloc::string::String),
         /// Trinsic Wallet ID of member to unregister
-        #[prost(string, tag="3")]
+        #[prost(string, tag = "3")]
         WalletId(::prost::alloc::string::String),
         /// Email address of member to unregister. Must be associated with an existing Trinsic account.
-        #[prost(string, tag="4")]
+        #[prost(string, tag = "4")]
         Email(::prost::alloc::string::String),
     }
 }
 /// Response to `UnregisterMemberRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UnregisterMemberResponse {
-}
+pub struct UnregisterMemberResponse {}
 /// Request to fetch membership status in governance framework for a specific credential schema.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetMembershipStatusRequest {
     /// The ID of the ecosystem governance framework.
     /// This ID may be found in the 'trustRegistry' field in the
     /// verifiable credential model
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub framework_id: ::prost::alloc::string::String,
     /// DID URI of member
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub did_uri: ::prost::alloc::string::String,
     /// URI of credential schema associated with membership
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub schema_uri: ::prost::alloc::string::String,
 }
 /// Response to `GetMembershipStatusRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetMembershipStatusResponse {
     /// Status of member for given credential schema
-    #[prost(enumeration="RegistrationStatus", tag="1")]
+    #[prost(enumeration = "RegistrationStatus", tag = "1")]
     pub status: i32,
+}
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListAuthorizedMembersRequest {
+    /// The ID of the ecosystem governance framework.
+    /// This ID may be found in the 'trustRegistry' field in the
+    /// verifiable credential model
+    #[prost(string, tag = "1")]
+    pub framework_id: ::prost::alloc::string::String,
+    /// id of schema that needs to be checked
+    #[prost(string, optional, tag = "2")]
+    pub schema_uri: ::core::option::Option<::prost::alloc::string::String>,
+    /// Token to fetch next set of results, from previous `SearchRegistryResponse`
+    #[prost(string, optional, tag = "3")]
+    pub continuation_token: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// Response to `ListAuthorizedMembersRequest`
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListAuthorizedMembersResponse {
+    /// JSON string containing array of resultant objects
+    #[prost(message, repeated, tag = "1")]
+    pub authorized_members: ::prost::alloc::vec::Vec<AuthorizedMember>,
+    /// Whether more data is available to fetch for query
+    #[prost(bool, tag = "2")]
+    pub has_more_results: bool,
+    /// Token to fetch next set of results via `ListAuthorizedMembersRequest`
+    #[prost(string, tag = "3")]
+    pub continuation_token: ::prost::alloc::string::String,
+}
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthorizedMember {
+    #[prost(string, tag = "1")]
+    pub did: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub authorized_member_schemas: ::prost::alloc::vec::Vec<AuthorizedMemberSchema>,
+}
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthorizedMemberSchema {
+    #[prost(string, tag = "1")]
+    pub schema_uri: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub status: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub status_details: ::prost::alloc::string::String,
+    #[prost(uint64, tag = "4")]
+    pub valid_from: u64,
+    #[prost(uint64, tag = "5")]
+    pub valid_until: u64,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -205,6 +272,17 @@ impl RegistrationStatus {
             RegistrationStatus::Terminated => "TERMINATED",
             RegistrationStatus::Revoked => "REVOKED",
             RegistrationStatus::NotFound => "NOT_FOUND",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CURRENT" => Some(Self::Current),
+            "EXPIRED" => Some(Self::Expired),
+            "TERMINATED" => Some(Self::Terminated),
+            "REVOKED" => Some(Self::Revoked),
+            "NOT_FOUND" => Some(Self::NotFound),
+            _ => None,
         }
     }
 }
@@ -394,6 +472,29 @@ pub mod trust_registry_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/services.trustregistry.v1.TrustRegistry/GetMembershipStatus",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Fetch the ecosystem's authorized issuers and the respective templates against which it can issue
+        pub async fn list_authorized_members(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListAuthorizedMembersRequest>,
+        ) -> Result<
+            tonic::Response<super::ListAuthorizedMembersResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/services.trustregistry.v1.TrustRegistry/ListAuthorizedMembers",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cli/src/proto/services/universalwallet/v1/mod.rs
+++ b/cli/src/proto/services/universalwallet/v1/mod.rs
@@ -1,340 +1,373 @@
-// Search
-
 /// Request to search items in wallet
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchRequest {
     /// SQL Query to execute against items in wallet
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub query: ::prost::alloc::string::String,
     /// Token provided by previous `SearchResponse`
     /// if more data is available for query
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub continuation_token: ::prost::alloc::string::String,
 }
 /// Response to `SearchRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchResponse {
     /// Array of query results, as JSON strings
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub items: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Whether more results are available for this query via `continuation_token`
-    #[prost(bool, tag="2")]
+    #[prost(bool, tag = "2")]
     pub has_more_results: bool,
     /// Token to fetch next set of results via `SearchRequest`
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub continuation_token: ::prost::alloc::string::String,
 }
-// Get Item
-
 /// Request to fetch an item from wallet
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetItemRequest {
     /// ID of item in wallet
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub item_id: ::prost::alloc::string::String,
 }
 /// Response to `GetItemRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetItemResponse {
     /// Item data as a JSON string
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub item_json: ::prost::alloc::string::String,
     /// Type of item specified when item was inserted into wallet
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub item_type: ::prost::alloc::string::String,
 }
-// Update Item
-
 /// Request to update item in wallet
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateItemRequest {
     /// ID of item in wallet
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub item_id: ::prost::alloc::string::String,
     /// Item type (ex. "VerifiableCredential")
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub item_type: ::prost::alloc::string::String,
 }
 /// Response to `UpdateItemRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UpdateItemResponse {
-}
-// InsertItem
-
+pub struct UpdateItemResponse {}
 /// Request to insert a JSON document into a wallet
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InsertItemRequest {
     /// Document to insert; must be stringified JSON
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub item_json: ::prost::alloc::string::String,
     /// Item type (ex. "VerifiableCredential")
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub item_type: ::prost::alloc::string::String,
 }
 /// Response to `InsertItemRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InsertItemResponse {
     /// ID of item inserted into wallet
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub item_id: ::prost::alloc::string::String,
 }
 /// Request to delete an item in a wallet
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteItemRequest {
     /// ID of item to delete
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub item_id: ::prost::alloc::string::String,
 }
 /// Response to `DeleteItemRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DeleteItemResponse {
-}
+pub struct DeleteItemResponse {}
 /// Request to delete a wallet
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteWalletRequest {
-    #[prost(oneof="delete_wallet_request::Account", tags="1, 2, 4")]
+    #[prost(oneof = "delete_wallet_request::Account", tags = "1, 2, 4")]
     pub account: ::core::option::Option<delete_wallet_request::Account>,
 }
 /// Nested message and enum types in `DeleteWalletRequest`.
 pub mod delete_wallet_request {
     #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Account {
         /// Email address of account to delete.
         /// Mutually exclusive with `walletId` and `didUri`.
-        #[prost(string, tag="1")]
+        #[prost(string, tag = "1")]
         Email(::prost::alloc::string::String),
         /// Wallet ID of account to delete.
         /// Mutually exclusive with `email` and `didUri`.
-        #[prost(string, tag="2")]
+        #[prost(string, tag = "2")]
         WalletId(::prost::alloc::string::String),
         /// DID URI of the account to delete.
         /// Mutually exclusive with `email` and `walletId`.
-        #[prost(string, tag="4")]
+        #[prost(string, tag = "4")]
         DidUri(::prost::alloc::string::String),
     }
 }
 /// Response to `DeleteWalletRequest`. Empty payload.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DeleteWalletResponse {
-}
+pub struct DeleteWalletResponse {}
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateWalletRequest {
     /// Ecosystem ID of the wallet to create
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub ecosystem_id: ::prost::alloc::string::String,
     /// Wallet name or description.
     /// Use this field to add vendor specific information about this wallet,
     /// such as email, phone, internal ID, or anything you'd like to associate
     /// with this wallet. This field is searchable.
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub description: ::core::option::Option<::prost::alloc::string::String>,
+    /// Optional identity to add to the wallet (email or sms).
+    /// Use this field when inviting participants into an ecosystem.
+    /// If this field is set, an auth token will not be sent in the response.
+    #[prost(message, optional, tag = "3")]
+    pub identity: ::core::option::Option<create_wallet_request::ExternalIdentity>,
+}
+/// Nested message and enum types in `CreateWalletRequest`.
+pub mod create_wallet_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ExternalIdentity {
+        /// The user identity to add to the wallet
+        /// This can be an email address or phone number (formatted as +[country code][phone number])
+        #[prost(string, tag = "1")]
+        pub identity: ::prost::alloc::string::String,
+        /// The type of identity provider, like EMAIL or PHONE
+        #[prost(
+            enumeration = "super::super::super::provider::v1::IdentityProvider",
+            tag = "2"
+        )]
+        pub provider: i32,
+    }
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateWalletResponse {
     /// Auth token for the newly created wallet
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub auth_token: ::prost::alloc::string::String,
     /// Token ID of the newly generated token
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub token_id: ::prost::alloc::string::String,
     /// Wallet configuration
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub wallet: ::core::option::Option<super::super::provider::v1::WalletConfiguration>,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenerateAuthTokenRequest {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub wallet_id: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub token_description: ::prost::alloc::string::String,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenerateAuthTokenResponse {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub token_id: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub auth_token: ::prost::alloc::string::String,
 }
 /// Request to retrieve wallet information about a given wallet identified by its wallet ID
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetWalletInfoRequest {
     /// Wallet ID of the wallet to retrieve
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub wallet_id: ::prost::alloc::string::String,
 }
 /// Response to `GetWalletInfoRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetWalletInfoResponse {
     /// Wallet configuration
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub wallet: ::core::option::Option<super::super::provider::v1::WalletConfiguration>,
 }
 /// Request to retrieve wallet information about the currently authenticated wallet
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetMyInfoRequest {
-}
+pub struct GetMyInfoRequest {}
 /// Response to `GetMyInfoRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetMyInfoResponse {
     /// Wallet configuration
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub wallet: ::core::option::Option<super::super::provider::v1::WalletConfiguration>,
 }
 /// Request to revoke a previously issued auth token
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RevokeAuthTokenRequest {
     /// Wallet ID of the wallet to from which to revoke the token
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub wallet_id: ::prost::alloc::string::String,
     /// Token ID of the token to revoke
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub token_id: ::prost::alloc::string::String,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RevokeAuthTokenResponse {
-}
+pub struct RevokeAuthTokenResponse {}
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListWalletsRequest {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub filter: ::prost::alloc::string::String,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListWalletsResponse {
-    #[prost(message, repeated, tag="1")]
-    pub wallets: ::prost::alloc::vec::Vec<super::super::provider::v1::WalletConfiguration>,
+    #[prost(message, repeated, tag = "1")]
+    pub wallets: ::prost::alloc::vec::Vec<
+        super::super::provider::v1::WalletConfiguration,
+    >,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddExternalIdentityInitRequest {
     /// The user identity to add to the wallet
     /// This can be an email address or phone number (formatted as +[country code][phone number])
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub identity: ::prost::alloc::string::String,
     /// The type of identity provider, like EMAIL or PHONE
-    #[prost(enumeration="IdentityProvider", tag="2")]
+    #[prost(enumeration = "super::super::provider::v1::IdentityProvider", tag = "2")]
     pub provider: i32,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddExternalIdentityInitResponse {
     /// Challenge or reference to the challenge to be used in the `AddExternalIdentityConfirm` endpoint
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub challenge: ::prost::alloc::string::String,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddExternalIdentityConfirmRequest {
     /// The challenge received from the `AddExternalIdentityInit` endpoint
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub challenge: ::prost::alloc::string::String,
     /// The response to the challenge. If using Email or Phone,
     /// this is the OTP code sent to the user's email or phone
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub response: ::prost::alloc::string::String,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AddExternalIdentityConfirmResponse {
-}
+pub struct AddExternalIdentityConfirmResponse {}
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoveExternalIdentityRequest {
     /// The user identity to remove from the wallet
     /// This can be an email address or phone number (formatted as +[country code][phone number])
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub identity: ::prost::alloc::string::String,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RemoveExternalIdentityResponse {
-}
+pub struct RemoveExternalIdentityResponse {}
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthenticateInitRequest {
     /// Identity to add to the wallet
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub identity: ::prost::alloc::string::String,
     /// Identity provider
-    #[prost(enumeration="IdentityProvider", tag="2")]
+    #[prost(enumeration = "super::super::provider::v1::IdentityProvider", tag = "2")]
     pub provider: i32,
     /// Ecosystem ID to which the wallet belongs
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub ecosystem_id: ::prost::alloc::string::String,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthenticateInitResponse {
     /// The challenge received from the `AcquireAuthTokenInit` endpoint
     /// Pass this challenge back to the `AcquireAuthTokenConfirm` endpoint
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub challenge: ::prost::alloc::string::String,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthenticateResendCodeRequest {
+    /// Challenge for the code you want resent.
+    #[prost(string, tag = "1")]
+    pub challenge: ::prost::alloc::string::String,
+}
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthenticateResendCodeResponse {}
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthenticateConfirmRequest {
     /// The challenge received from the `AcquireAuthTokenInit` endpoint
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub challenge: ::prost::alloc::string::String,
     /// The response to the challenge. If using Email or Phone,
     /// this is the OTP code sent to the user's email or phone
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub response: ::prost::alloc::string::String,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthenticateConfirmResponse {
     /// Auth token for the wallet
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub auth_token: ::prost::alloc::string::String,
-}
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
-pub enum IdentityProvider {
-    /// Identity provider is unknown
-    Unknown = 0,
-    /// Identity provider is email
-    Email = 1,
-    /// Identity provider is phone
-    Phone = 2,
-}
-impl IdentityProvider {
-    /// String value of the enum field names used in the ProtoBuf definition.
-    ///
-    /// The values are not transformed in any way and thus are considered stable
-    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-    pub fn as_str_name(&self) -> &'static str {
-        match self {
-            IdentityProvider::Unknown => "UNKNOWN",
-            IdentityProvider::Email => "EMAIL",
-            IdentityProvider::Phone => "PHONE",
-        }
-    }
 }
 /// Generated client implementations.
 pub mod universal_wallet_client {
@@ -738,6 +771,29 @@ pub mod universal_wallet_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/services.universalwallet.v1.UniversalWallet/AuthenticateConfirm",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Resend previous authentication code
+        pub async fn authenticate_resend_code(
+            &mut self,
+            request: impl tonic::IntoRequest<super::AuthenticateResendCodeRequest>,
+        ) -> Result<
+            tonic::Response<super::AuthenticateResendCodeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/services.universalwallet.v1.UniversalWallet/AuthenticateResendCode",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cli/src/proto/services/verifiablecredentials/templates/v1/mod.rs
+++ b/cli/src/proto/services/verifiablecredentials/templates/v1/mod.rs
@@ -1,287 +1,314 @@
 /// Request to fetch a template by ID
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCredentialTemplateRequest {
     /// ID of template to fetch
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
 /// Response to `GetCredentialTemplateRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCredentialTemplateResponse {
     /// Template fetched by ID
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub template: ::core::option::Option<TemplateData>,
 }
 /// Request to search templates using a SQL query
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchCredentialTemplatesRequest {
     /// SQL query to execute. Example: `SELECT * FROM c WHERE c.name = 'Diploma'`
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub query: ::prost::alloc::string::String,
     /// Token provided by previous `SearchCredentialTemplatesResponse`
     /// if more data is available for query
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub continuation_token: ::prost::alloc::string::String,
 }
 /// Response to `SearchCredentialTemplatesRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchCredentialTemplatesResponse {
     /// Raw JSON data returned from query
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub items_json: ::prost::alloc::string::String,
     /// Whether more results are available for this query via `continuation_token`
-    #[prost(bool, tag="2")]
+    #[prost(bool, tag = "2")]
     pub has_more_results: bool,
     /// Token to fetch next set of results via `SearchCredentialTemplatesRequest`
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub continuation_token: ::prost::alloc::string::String,
 }
 /// Request to list templates using a SQL query
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListCredentialTemplatesRequest {
     /// SQL query to execute. Example: `SELECT * FROM c WHERE c.name = 'Diploma'`
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub query: ::prost::alloc::string::String,
     /// Token provided by previous `ListCredentialTemplatesResponse`
     /// if more data is available for query
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub continuation_token: ::prost::alloc::string::String,
 }
 /// Response to `ListCredentialTemplatesRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListCredentialTemplatesResponse {
     /// Templates found by query
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub templates: ::prost::alloc::vec::Vec<TemplateData>,
     /// Whether more results are available for this query via `continuation_token`
-    #[prost(bool, tag="2")]
+    #[prost(bool, tag = "2")]
     pub has_more_results: bool,
     /// Token to fetch next set of resuts via `ListCredentialTemplatesRequest`
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub continuation_token: ::prost::alloc::string::String,
 }
 /// Request to delete a template by ID
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteCredentialTemplateRequest {
     /// ID of template to delete
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
 /// Response to `DeleteCredentialTemplateRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DeleteCredentialTemplateResponse {
-}
+pub struct DeleteCredentialTemplateResponse {}
 /// Request to create a new template
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateCredentialTemplateRequest {
     /// Name of new template. Must be a unique identifier within its ecosystem.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Fields which compose the template
-    #[prost(map="string, message", tag="2")]
-    pub fields: ::std::collections::HashMap<::prost::alloc::string::String, TemplateField>,
+    #[prost(map = "string, message", tag = "2")]
+    pub fields: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        TemplateField,
+    >,
     /// Whether credentials may be issued against this template which have fields
     /// not specified in `fields`
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub allow_additional_fields: bool,
     /// Human-readable name of template
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub title: ::prost::alloc::string::String,
     /// Human-readable description of template
-    #[prost(string, tag="5")]
+    #[prost(string, tag = "5")]
     pub description: ::prost::alloc::string::String,
     /// Optional map describing how to order and categorize the fields within the template. The key of this map is the field `name`.
     /// If not provided, this will be auto-generated.
-    #[prost(map="string, message", tag="6")]
-    pub field_ordering: ::std::collections::HashMap<::prost::alloc::string::String, FieldOrdering>,
+    #[prost(map = "string, message", tag = "6")]
+    pub field_ordering: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        FieldOrdering,
+    >,
     /// Options for rendering the template in Apple Wallet
-    #[prost(message, optional, tag="7")]
+    #[prost(message, optional, tag = "7")]
     pub apple_wallet_options: ::core::option::Option<AppleWalletOptions>,
 }
 /// Response to `CreateCredentialTemplateRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateCredentialTemplateResponse {
     /// Created template
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub data: ::core::option::Option<TemplateData>,
 }
 /// Request to update display information for a template
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateCredentialTemplateRequest {
     /// ID of Template to update
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
     /// New human-readable title of Template
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub title: ::core::option::Option<::prost::alloc::string::String>,
     /// New human-readable description of Template
-    #[prost(string, optional, tag="3")]
+    #[prost(string, optional, tag = "3")]
     pub description: ::core::option::Option<::prost::alloc::string::String>,
     /// Fields to update within the Template
-    #[prost(map="string, message", tag="4")]
-    pub fields: ::std::collections::HashMap<::prost::alloc::string::String, TemplateFieldPatch>,
+    #[prost(map = "string, message", tag = "4")]
+    pub fields: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        TemplateFieldPatch,
+    >,
     /// New field ordering options. See documentation for template creation for usage information.
-    #[prost(map="string, message", tag="5")]
-    pub field_ordering: ::std::collections::HashMap<::prost::alloc::string::String, FieldOrdering>,
+    #[prost(map = "string, message", tag = "5")]
+    pub field_ordering: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        FieldOrdering,
+    >,
     /// New Apple Wallet configuration
-    #[prost(message, optional, tag="6")]
+    #[prost(message, optional, tag = "6")]
     pub apple_wallet_options: ::core::option::Option<AppleWalletOptions>,
 }
 /// Response to `UpdateCredentialTemplateRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateCredentialTemplateResponse {
     /// The Template after the update has been applied
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub updated_template: ::core::option::Option<TemplateData>,
 }
 /// Credential Template
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TemplateData {
     /// Template ID
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
     /// Template name
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub name: ::prost::alloc::string::String,
     /// Template version number
-    #[prost(int32, tag="3")]
+    #[prost(int32, tag = "3")]
     pub version: i32,
     /// Fields defined for the template
-    #[prost(map="string, message", tag="4")]
-    pub fields: ::std::collections::HashMap<::prost::alloc::string::String, TemplateField>,
+    #[prost(map = "string, message", tag = "4")]
+    pub fields: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        TemplateField,
+    >,
     /// Whether credentials issued against this template may
     /// contain fields not defined by template
-    #[prost(bool, tag="5")]
+    #[prost(bool, tag = "5")]
     pub allow_additional_fields: bool,
     /// URI pointing to template JSON schema document
-    #[prost(string, tag="6")]
+    #[prost(string, tag = "6")]
     pub schema_uri: ::prost::alloc::string::String,
-    /// DEPRECATED, will be removed April 1st 2023
-    #[deprecated]
-    #[prost(string, tag="7")]
-    pub context_uri: ::prost::alloc::string::String,
     /// ID of ecosystem in which template resides
-    #[prost(string, tag="8")]
+    #[prost(string, tag = "8")]
     pub ecosystem_id: ::prost::alloc::string::String,
     /// Template type (`VerifiableCredential`)
-    #[prost(string, tag="9")]
+    #[prost(string, tag = "9")]
     pub r#type: ::prost::alloc::string::String,
     /// ID of template creator
-    #[prost(string, tag="10")]
+    #[prost(string, tag = "10")]
     pub created_by: ::prost::alloc::string::String,
     /// Date when template was created as ISO 8601 utc string
-    #[prost(string, tag="11")]
+    #[prost(string, tag = "11")]
     pub date_created: ::prost::alloc::string::String,
     /// Human-readable template title
-    #[prost(string, tag="12")]
+    #[prost(string, tag = "12")]
     pub title: ::prost::alloc::string::String,
     /// Human-readable template description
-    #[prost(string, tag="13")]
+    #[prost(string, tag = "13")]
     pub description: ::prost::alloc::string::String,
     /// Map describing how to order and categorize the fields within the template. The key of this map is the field `name`.
-    #[prost(map="string, message", tag="14")]
-    pub field_ordering: ::std::collections::HashMap<::prost::alloc::string::String, FieldOrdering>,
+    #[prost(map = "string, message", tag = "14")]
+    pub field_ordering: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        FieldOrdering,
+    >,
     /// Options for rendering the template in Apple Wallet
-    #[prost(message, optional, tag="15")]
+    #[prost(message, optional, tag = "15")]
     pub apple_wallet_options: ::core::option::Option<AppleWalletOptions>,
 }
 /// Configuration options for Apple Wallet when
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AppleWalletOptions {
     /// Background color, in hex format, of credential when stored in an Apple Wallet.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub background_color: ::prost::alloc::string::String,
     /// Foreground color, in hex format, of credential when stored in an Apple Wallet.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub foreground_color: ::prost::alloc::string::String,
     /// Label color, in hex format, of credential when stored in an Apple Wallet.
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub label_color: ::prost::alloc::string::String,
     /// The ID of the template field which should be used as the primary field of a credential.
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub primary_field: ::prost::alloc::string::String,
     /// The secondary fields of the credential. This is a mapping between the order of a secondary field (0 or 1) and the field name.
-    #[prost(string, repeated, tag="5")]
+    #[prost(string, repeated, tag = "5")]
     pub secondary_fields: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// The auxiliary fields of the credential. This is a mapping between the order of an auxiliary field (0 or 1) and the field name.
-    #[prost(string, repeated, tag="6")]
+    #[prost(string, repeated, tag = "6")]
     pub auxiliary_fields: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Ordering information for a template field
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldOrdering {
     /// The order of the field; must be unique within the Template. Fields are sorted by order ascending when displaying a credential.
     /// Field orders must be contiguous from `0` to the number of fields minus 1.
-    #[prost(int32, tag="1")]
+    #[prost(int32, tag = "1")]
     pub order: i32,
     /// The human-readable name of the section this field appears in; used to group together fields when displaying a credential.
     /// Sections must be contiguous with respect to `order`.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub section: ::prost::alloc::string::String,
 }
 /// A field defined in a template
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TemplateField {
     /// Human-readable name of the field
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub title: ::prost::alloc::string::String,
     /// Human-readable description of the field
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub description: ::prost::alloc::string::String,
     /// Whether this field may be omitted when a credential is issued against the template
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub optional: bool,
     /// The type of the field
-    #[prost(enumeration="FieldType", tag="4")]
+    #[prost(enumeration = "FieldType", tag = "4")]
     pub r#type: i32,
-    /// Do not use.
-    /// Annotations for the field that may be used to add additional information.
-    #[prost(map="string, string", tag="5")]
-    pub annotations: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// How to deal with this URI field when rendering credential. Only use if `type` is `URI`.
-    #[prost(message, optional, tag="6")]
+    #[prost(message, optional, tag = "6")]
     pub uri_data: ::core::option::Option<UriFieldData>,
 }
 /// A patch to apply to an existing template field
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TemplateFieldPatch {
     /// Human-readable name of the field
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub title: ::core::option::Option<::prost::alloc::string::String>,
     /// Human-readable description of the field
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub description: ::core::option::Option<::prost::alloc::string::String>,
     /// How to deal with this URI field when rendering credential. Only use if `type` is `URI`.
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub uri_data: ::core::option::Option<UriFieldData>,
 }
 /// Data pertaining to a URI Field
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UriFieldData {
     /// Expected MIME Type of content pointed to by URI. Can be generic (eg, "image/") or specific ("image/png").
     /// Defaults to "application/octet-stream".
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub mime_type: ::prost::alloc::string::String,
     /// How to display the URI value when rendering a credential.
-    #[prost(enumeration="UriRenderMethod", tag="2")]
+    #[prost(enumeration = "UriRenderMethod", tag = "2")]
     pub render_method: i32,
 }
 /// Valid types for credential fields
@@ -309,6 +336,17 @@ impl FieldType {
             FieldType::Uri => "URI",
         }
     }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "STRING" => Some(Self::String),
+            "NUMBER" => Some(Self::Number),
+            "BOOL" => Some(Self::Bool),
+            "DATETIME" => Some(Self::Datetime),
+            "URI" => Some(Self::Uri),
+            _ => None,
+        }
+    }
 }
 /// How to display a URI value when rendering a credential.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -332,6 +370,15 @@ impl UriRenderMethod {
             UriRenderMethod::Text => "TEXT",
             UriRenderMethod::Link => "LINK",
             UriRenderMethod::InlineImage => "INLINE_IMAGE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "TEXT" => Some(Self::Text),
+            "LINK" => Some(Self::Link),
+            "INLINE_IMAGE" => Some(Self::InlineImage),
+            _ => None,
         }
     }
 }

--- a/cli/src/proto/services/verifiablecredentials/v1/mod.rs
+++ b/cli/src/proto/services/verifiablecredentials/v1/mod.rs
@@ -1,71 +1,62 @@
-/// DEPRECATED, will be removed May 1st 2023
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct IssueRequest {
-    /// Valid JSON-LD Credential document to be signed, in string form
-    #[prost(string, tag="1")]
-    pub document_json: ::prost::alloc::string::String,
-}
-/// DEPRECATED, will be removed May 1st 2023
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct IssueResponse {
-    /// Verifiable Credential document, signed with public key
-    /// tied to caller of `IssueRequest`
-    #[prost(string, tag="1")]
-    pub signed_document_json: ::prost::alloc::string::String,
-}
 /// Request to create and sign a JSON-LD Verifiable Credential from a template using public key tied to caller
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IssueFromTemplateRequest {
     /// ID of template to use
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub template_id: ::prost::alloc::string::String,
     /// JSON document string with keys corresponding to the fields of
     /// the template referenced by `template_id`
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub values_json: ::prost::alloc::string::String,
     /// Governance framework ID to use with issuance of this credential.
     /// If specified, the issued credential will contain extended issuer
     /// metadata with membership info for the given ecosystem governance framework (EGF)
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub framework_id: ::prost::alloc::string::String,
     /// Save a copy of the issued credential to this user's wallet. This copy will only contain
     /// the credential data, but not the secret proof value. Issuers may use this data to
     /// keep track of the details for revocation status.
-    #[prost(bool, tag="4")]
+    #[prost(bool, tag = "4")]
     pub save_copy: bool,
+    /// The ISO8601 expiration UTC date of the credential. This is a reserved field in the VC specification.
+    /// If specified, the issued credential will contain an expiration date.
+    /// <https://www.w3.org/TR/vc-data-model/#expiration>
+    #[prost(string, tag = "5")]
+    pub expiration_date: ::prost::alloc::string::String,
 }
 /// Response to `IssueFromTemplateRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IssueFromTemplateResponse {
     /// Verifiable Credential document, in JSON-LD form,
     /// constructed from the specified template and values; signed
     /// with public key tied to caller of `IssueFromTemplateRequest`
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub document_json: ::prost::alloc::string::String,
 }
 /// Request to create a proof for a Verifiable Credential using public key tied to caller.
 /// Either `item_id` or `document_json` may be provided, not both.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateProofRequest {
     /// Wrap the output in a verifiable presentation
-    #[prost(bool, tag="4")]
+    #[prost(bool, tag = "4")]
     pub use_verifiable_presentation: bool,
     /// Nonce value used to derive the proof. If not specified, a random nonce will be generated.
     /// This value may be represented in base64 format in the proof model.
-    #[prost(bytes="vec", tag="10")]
+    #[prost(bytes = "vec", tag = "10")]
     pub nonce: ::prost::alloc::vec::Vec<u8>,
     /// Selective disclosure specification. If nothing is provided, the entire proof is returned.
     /// Either a custom JSON-LD frame is provided, or a list of attributes is provided for selective disclosure
-    #[prost(oneof="create_proof_request::Disclosure", tags="1, 11")]
+    #[prost(oneof = "create_proof_request::Disclosure", tags = "1, 11")]
     pub disclosure: ::core::option::Option<create_proof_request::Disclosure>,
     /// Specify the input to be used to derive this proof.
     /// Input can be an existing item in the wallet or an input document
-    #[prost(oneof="create_proof_request::Proof", tags="2, 3")]
+    #[prost(oneof = "create_proof_request::Proof", tags = "2, 3")]
     pub proof: ::core::option::Option<create_proof_request::Proof>,
 }
 /// Nested message and enum types in `CreateProofRequest`.
@@ -73,150 +64,161 @@ pub mod create_proof_request {
     /// Selective disclosure specification. If nothing is provided, the entire proof is returned.
     /// Either a custom JSON-LD frame is provided, or a list of attributes is provided for selective disclosure
     #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Disclosure {
         /// A valid JSON-LD frame describing which fields should be
         /// revealed in the generated proof.
         /// If unspecified, all fields in the document will be revealed
-        #[prost(string, tag="1")]
+        #[prost(string, tag = "1")]
         RevealDocumentJson(::prost::alloc::string::String),
         /// Information about what sections of the document to reveal
-        #[prost(message, tag="11")]
+        #[prost(message, tag = "11")]
         RevealTemplate(super::RevealTemplateAttributes),
     }
     /// Specify the input to be used to derive this proof.
     /// Input can be an existing item in the wallet or an input document
     #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Proof {
         /// ID of wallet item stored in a Trinsic cloud wallet
-        #[prost(string, tag="2")]
+        #[prost(string, tag = "2")]
         ItemId(::prost::alloc::string::String),
         /// A valid JSON-LD Verifiable Credential document string
         /// with an unbound signature. The proof will be derived from this
         /// document directly. The document will not be stored in the wallet.
-        #[prost(string, tag="3")]
+        #[prost(string, tag = "3")]
         DocumentJson(::prost::alloc::string::String),
     }
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RevealTemplateAttributes {
     /// A list of document attributes to reveal. If unset, all attributes will be returned.
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub template_attributes: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Response to `CreateProofRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateProofResponse {
     /// Valid JSON-LD proof for the specified credential
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub proof_document_json: ::prost::alloc::string::String,
 }
 /// Request to verify a proof
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VerifyProofRequest {
     /// JSON-LD proof document string to verify
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub proof_document_json: ::prost::alloc::string::String,
 }
 /// Response to `VerifyProofRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VerifyProofResponse {
     /// Whether all validations in `validation_results` passed
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub is_valid: bool,
-    /// Use `validation_results` instead
-    #[deprecated]
-    #[prost(string, repeated, tag="2")]
-    pub validation_messages: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Results of each validation check performed,
     /// such as schema conformance, revocation status, signature, etc.
     /// Detailed results are provided for failed validations.
-    #[prost(map="string, message", tag="3")]
-    pub validation_results: ::std::collections::HashMap<::prost::alloc::string::String, ValidationMessage>,
+    #[prost(map = "string, message", tag = "3")]
+    pub validation_results: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ValidationMessage,
+    >,
 }
 /// Result of a validation check on a proof
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidationMessage {
     /// Whether this validation check passed
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub is_valid: bool,
     /// If validation failed, contains messages explaining why
-    #[prost(string, repeated, tag="2")]
+    #[prost(string, repeated, tag = "2")]
     pub messages: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Request to send a document to another user's wallet
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendRequest {
     /// Send email notification that credential has been sent to a wallet
-    #[prost(bool, tag="4")]
+    #[prost(bool, tag = "4")]
     pub send_notification: bool,
     /// JSON document to send to recipient
-    #[prost(string, tag="100")]
+    #[prost(string, tag = "100")]
     pub document_json: ::prost::alloc::string::String,
-    #[prost(oneof="send_request::DeliveryMethod", tags="1, 5, 6, 7")]
+    #[prost(oneof = "send_request::DeliveryMethod", tags = "1, 5, 6, 7")]
     pub delivery_method: ::core::option::Option<send_request::DeliveryMethod>,
 }
 /// Nested message and enum types in `SendRequest`.
 pub mod send_request {
     #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum DeliveryMethod {
         /// Email address of user to whom you'll send the item
-        #[prost(string, tag="1")]
+        #[prost(string, tag = "1")]
         Email(::prost::alloc::string::String),
         /// Wallet ID of the recipient within the ecosystem
-        #[prost(string, tag="5")]
+        #[prost(string, tag = "5")]
         WalletId(::prost::alloc::string::String),
         /// DID URI of the recipient
-        #[prost(string, tag="6")]
+        #[prost(string, tag = "6")]
         DidUri(::prost::alloc::string::String),
         /// SMS of user to whom you'll send the item
-        #[prost(string, tag="7")]
+        #[prost(string, tag = "7")]
         PhoneNumber(::prost::alloc::string::String),
     }
 }
 /// Response to `SendRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SendResponse {
-}
+pub struct SendResponse {}
 /// Request to update a credential's revocation status
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateStatusRequest {
     /// Credential Status ID to update. This is not the same as the credential's ID.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub credential_status_id: ::prost::alloc::string::String,
     /// New revocation status of credential
-    #[prost(bool, tag="2")]
+    #[prost(bool, tag = "2")]
     pub revoked: bool,
 }
 /// Response to `UpdateStatusRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UpdateStatusResponse {
-}
+pub struct UpdateStatusResponse {}
 /// Request to check a credential's revocation status
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckStatusRequest {
     /// Credential Status ID to check. This is not the same as the credential's ID.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub credential_status_id: ::prost::alloc::string::String,
 }
 /// Response to `CheckStatusRequest`
 #[derive(::serde::Serialize, ::serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckStatusResponse {
     /// The credential's revocation status
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub revoked: bool,
 }
 /// Generated client implementations.
@@ -287,28 +289,6 @@ pub mod verifiable_credential_client {
         pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.accept_compressed(encoding);
             self
-        }
-        /// Sign and issue a verifiable credential from a submitted document.
-        /// The document must be a valid JSON-LD document.
-        /// DEPRECATED, will be removed June 1st 2023
-        pub async fn issue(
-            &mut self,
-            request: impl tonic::IntoRequest<super::IssueRequest>,
-        ) -> Result<tonic::Response<super::IssueResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/services.verifiablecredentials.v1.VerifiableCredential/Issue",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
         }
         /// Sign and issue a verifiable credential from a pre-defined template.
         /// This process will also add schema validation and

--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -29,7 +29,7 @@ pub(crate) fn execute(args: &Service, config: CliConfig) -> Result<Output, Error
 pub(crate) enum Service<'a> {
     Wallet(crate::parser::wallet::Command<'a>),
     VerifiableCredential(crate::parser::vc::Command<'a>),
-    Provider(crate::parser::provider::Command<'a>),
+    Provider(crate::parser::provider::Command),
     Config(crate::parser::config::ConfigCommand),
     TrustRegistry(crate::parser::trustregistry::TrustRegistryCommand),
     Template(crate::parser::template::TemplateCommand),

--- a/cli/src/services/provider.rs
+++ b/cli/src/services/provider.rs
@@ -3,7 +3,7 @@ use super::{super::parser::provider::*, Item};
 use crate::proto::services::common::v1::SupportedDidMethod;
 use crate::proto::services::provider::v1::ion_options::IonNetwork;
 use crate::proto::services::provider::v1::{
-    upgrade_did_request, AddWebhookRequest, DeleteWebhookRequest, EcosystemInfoRequest, IonOptions, UpdateEcosystemRequest, UpgradeDidRequest,
+    upgrade_did_request, IonOptions, UpgradeDidRequest,
 };
 use crate::utils::to_value;
 use crate::{
@@ -12,7 +12,7 @@ use crate::{
     grpc_channel, grpc_client, grpc_client_with_auth, parser,
     proto::services::{
         account::v1::AccountDetails,
-        provider::v1::{provider_client::ProviderClient, CreateEcosystemRequest, InviteRequest},
+        provider::v1::{provider_client::ProviderClient, CreateEcosystemRequest},
     },
     services::config::*,
 };
@@ -23,13 +23,7 @@ use tonic::transport::Channel;
 #[allow(clippy::unit_arg)]
 pub(crate) fn execute(args: &Command, config: CliConfig) -> Result<Output, Error> {
     match args {
-        Command::Invite(args) => invite(args, &config),
         Command::CreateEcosystem(args) => create_ecosystem(args, &config),
-        Command::UpdateEcosystem(args) => update_ecosystem(args, &config),
-        Command::EcosystemInfo => ecosystem_info(&config),
-        Command::AddWebhook(args) => add_webhook(args, &config),
-        Command::DeleteWebhook(args) => delete_webhook(args, &config),
-        Command::InvitationStatus => todo!(),
         Command::UpgradeDid(args) => upgrade_did(args, &config),
     }
 }
@@ -66,27 +60,6 @@ async fn upgrade_did(args: &UpgradeDidArgs, config: &CliConfig) -> Result<Output
 }
 
 #[tokio::main]
-async fn invite(args: &InviteArgs, config: &CliConfig) -> Result<Output, Error> {
-    let mut client = grpc_client_with_auth!(ProviderClient<Channel>, config.to_owned());
-
-    let request = tonic::Request::new(InviteRequest {
-        participant: match args.participant_type {
-            parser::provider::ParticipantType::Individual => crate::proto::services::provider::v1::ParticipantType::Individual as i32,
-            parser::provider::ParticipantType::Organization => crate::proto::services::provider::v1::ParticipantType::Organization as i32,
-        },
-        description: args.description.map_or(String::default(), |x| x.to_string()),
-        details: Some(AccountDetails { ..Default::default() }),
-    });
-
-    let response = client.invite(request).await?.into_inner();
-
-    Ok(dict! {
-        "invitation id".into() => Item::String(response.invitation_id),
-        "security code".into() => Item::String(response.invitation_code),
-    })
-}
-
-#[tokio::main]
 async fn create_ecosystem(args: &CreateEcosystemArgs, config: &CliConfig) -> Result<Output, Error> {
     let req = CreateEcosystemRequest {
         name: args.name.as_ref().map_or(String::default(), |x| x.to_owned()),
@@ -113,74 +86,5 @@ async fn create_ecosystem(args: &CreateEcosystemArgs, config: &CliConfig) -> Res
         "ecosystem".into() => Item::Json(to_value(&response.ecosystem
             .ok_or(Error::InvalidArgument("expected ecosystem object in response".to_string()))?)?),
         "auth token".into() => Item::String(auth_token)
-    })
-}
-
-#[tokio::main]
-async fn update_ecosystem(args: &UpdateEcosystemArgs, config: &CliConfig) -> Result<Output, Error> {
-    let mut client = grpc_client_with_auth!(ProviderClient<Channel>, config.to_owned());
-
-    let request = tonic::Request::new(UpdateEcosystemRequest {
-        description: args.description.as_ref().map_or(String::default(), |x| x.to_owned()),
-        uri: args.uri.as_ref().map_or(String::default(), |x| x.to_owned()),
-        ..Default::default()
-    });
-
-    let response = client.update_ecosystem(request).await?.into_inner();
-
-    Ok(dict! {
-        "ecosystem".into() => Item::Json(to_value(
-                &response.ecosystem.ok_or(Error::InvalidArgument("expected ecosystem object in response".to_string()))?
-        )?)
-    })
-}
-
-#[tokio::main]
-async fn ecosystem_info(config: &CliConfig) -> Result<Output, Error> {
-    let mut client = grpc_client_with_auth!(ProviderClient<Channel>, config.to_owned());
-
-    let request = tonic::Request::new(EcosystemInfoRequest {});
-    let response = client.ecosystem_info(request).await?.into_inner();
-
-    Ok(dict! {
-        "ecosystem".into() => Item::Json(to_value(
-                &response.ecosystem.ok_or(Error::InvalidArgument("expected ecosystem object in response".to_string()))?
-        )?)
-    })
-}
-
-#[tokio::main]
-async fn add_webhook(args: &AddWebhookArgs, config: &CliConfig) -> Result<Output, Error> {
-    let mut client = grpc_client_with_auth!(ProviderClient<Channel>, config.to_owned());
-
-    let request = tonic::Request::new(AddWebhookRequest {
-        events: args.events.clone(),
-        destination_url: args.url.clone(),
-        secret: args.secret.clone(),
-    });
-
-    let response = client.add_webhook(request).await?.into_inner();
-
-    Ok(dict! {
-        "ecosystem".into() => Item::Json(to_value(
-                &response.ecosystem.ok_or(Error::InvalidArgument("expected ecosystem object in response".to_string()))?
-        )?)
-    })
-}
-
-#[tokio::main]
-async fn delete_webhook(args: &DeleteWebhookArgs, config: &CliConfig) -> Result<Output, Error> {
-    let mut client = grpc_client_with_auth!(ProviderClient<Channel>, config.to_owned());
-
-    let request = tonic::Request::new(DeleteWebhookRequest {
-        webhook_id: args.webhook_id.clone(),
-    });
-
-    let response = client.delete_webhook(request).await?.into_inner();
-
-    Ok(dict! {
-        "ecosystem".into() => Item::Json(to_value(
-                &response.ecosystem.ok_or(Error::InvalidArgument("expected ecosystem object in response".to_string()))?
-        )?)
     })
 }

--- a/cli/src/services/trustregistry.rs
+++ b/cli/src/services/trustregistry.rs
@@ -15,8 +15,6 @@ pub(crate) fn execute(args: &TrustRegistryCommand, config: &CliConfig) -> Result
         TrustRegistryCommand::RegisterMember(args) => register_member(args, config),
         TrustRegistryCommand::UnregisterMember(args) => unregister_member(args, config),
         TrustRegistryCommand::GetMembershipStatus(args) => get_status(args, config),
-        TrustRegistryCommand::AddFramework(args) => add_framework(args, config),
-        TrustRegistryCommand::RemoveFramework(args) => remove_framework(args, config),
         TrustRegistryCommand::FetchData(args) => fetch_data(args, config),
     }
 }
@@ -122,34 +120,4 @@ async fn get_status(args: &GetMembershipStatusArgs, config: &CliConfig) -> Resul
     Ok(dict! {
         "status".into() => Item::String(format!("{:?}", RegistrationStatus::from_i32(response.status).ok_or(Error::SerializationError)?)),
     })
-}
-
-#[tokio::main]
-async fn add_framework(args: &AddFrameworkArgs, config: &CliConfig) -> Result<Output, Error> {
-    let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
-
-    let request = tonic::Request::new(AddFrameworkRequest {
-        governance_framework_uri: args.governance_framework_uri.clone(),
-        description: args.description.clone().unwrap_or_default(),
-        name: args.name.clone(),
-    });
-
-    let response = client.add_framework(request).await?.into_inner();
-
-    Ok(dict! {
-        "response".into() => Item::Json(to_value(&response)?)
-    })
-}
-
-#[tokio::main]
-async fn remove_framework(args: &RemoveFrameworkArgs, config: &CliConfig) -> Result<Output, Error> {
-    let mut client = grpc_client_with_auth!(TrustRegistryClient<Channel>, config.to_owned());
-
-    let request = tonic::Request::new(RemoveFrameworkRequest {
-        id: args.framework_id.clone(),
-    });
-
-    let _response = client.remove_framework(request).await?.into_inner();
-
-    Ok(Output::new())
 }

--- a/cli/test/Run-Demo.ps1
+++ b/cli/test/Run-Demo.ps1
@@ -70,13 +70,13 @@ $PublicDid = Invoke-Expression "$trinsic wallet my-info"
 | ForEach-Object { $_.wallet.public_did }
 Stop-OnError
 
-Invoke-Expression "$trinsic trust-registry register-member --schema $($Template.SchemaUri) --framework-id $FrameworkId --did $PublicDid" | Out-Null
+Invoke-Expression "$trinsic trust-registry register-member --schema $($Template.SchemaUri) --did $PublicDid" | Out-Null
 Stop-OnError
 
 #>
 
 Write-Output "✅ Issuing credential for drivers license"
-Invoke-Expression "$trinsic vc issue-from-template --template-id $($Template.Id) --framework-id $FrameworkId --values-file $PSScriptRoot/state-id-values.json"
+Invoke-Expression "$trinsic vc issue-from-template --template-id $($Template.Id) --values-file $PSScriptRoot/state-id-values.json" #--use-trust-registry
 | ConvertFrom-Json
 | ForEach-Object { $_.'signed document' }
 | Set-Content -Path $PSScriptRoot/state-id-signed-document.json

--- a/cli/test/Run-Demo.ps1
+++ b/cli/test/Run-Demo.ps1
@@ -63,12 +63,7 @@ Write-Output "`tTemplate ID = $($Template.Id)"
 Write-Output "`tSchema URI = $($Template.SchemaUri)"
 Write-Output "`tContext URI = $($Template.ContextUri)"
 
-Write-Output "✅ Create trust registry for authorized issuers"
-$FrameworkId = Invoke-Expression "$trinsic trust-registry add-framework --name 'Authorized State ID Issuers' --uri 'https://state.gov/authorized-issuers'"
-| ConvertFrom-Json
-| ForEach-Object { $_.response.id }
-Stop-OnError
-
+<#
 Write-Output "✅ Adding trusted issuer to framework"
 $PublicDid = Invoke-Expression "$trinsic wallet my-info"
 | ConvertFrom-Json
@@ -77,6 +72,8 @@ Stop-OnError
 
 Invoke-Expression "$trinsic trust-registry register-member --schema $($Template.SchemaUri) --framework-id $FrameworkId --did $PublicDid" | Out-Null
 Stop-OnError
+
+#>
 
 Write-Output "✅ Issuing credential for drivers license"
 Invoke-Expression "$trinsic vc issue-from-template --template-id $($Template.Id) --framework-id $FrameworkId --values-file $PSScriptRoot/state-id-values.json"
@@ -104,6 +101,7 @@ Invoke-Expression "$trinsic vc verify-proof --proof-document $PSScriptRoot/state
 | Format-List
 Stop-OnError
 
+<#
 Write-Output "✅ Remove trusted issuer from framework"
 Invoke-Expression "$trinsic trust-registry unregister-member --schema $($Template.SchemaUri) --framework-id $FrameworkId --did $PublicDid" | Out-Null
 Stop-OnError
@@ -114,5 +112,7 @@ Invoke-Expression "$trinsic vc verify-proof --proof-document $PSScriptRoot/state
 | Select-Object -ExpandProperty 'validation results'
 | Format-List
 Stop-OnError
+
+#>
 
 Write-Output "🎉 Demo complete!"


### PR DESCRIPTION
- Removes deprecated CLI commands
	- `vc`
		- `issue`
	- `provider`
		- `update-ecosystem`
		- `ecosystem-info`
		- `add-webhook`
		- `delete-webhook`
		- `invite`
		- `invitation-status`
	- `trust-registry`
		- `add-framework`
		- `remove-framework`