### PR TITLE
CLI Release / windows installation docs changes

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./cli/target/debian/trinsic_${{ steps.setversion.outputs.packageVersion }}_amd64.deb
-          asset_name: trinsic_${{ steps.setversion.outputs.packageVersion }}_amd64.deb
+          asset_name: trinsic_cli_${{ steps.setversion.outputs.packageVersion }}_amd64.deb
           tag: ${{ steps.setversion.outputs.releaseVersion }}
           overwrite: false
           body: "Trinsic CLI Debian Package"
@@ -174,7 +174,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./cli/target/wix/trinsic-${{ steps.setversion.outputs.packageVersion }}-x86_64.msi
-          asset_name: trinsic-${{ steps.setversion.outputs.packageVersion }}-x86_64.msi
+          asset_name: trinsic-cli-${{ steps.setversion.outputs.packageVersion }}-x86_64.msi
           tag: ${{ steps.setversion.outputs.releaseVersion }}
           overwrite: false
           body: "trinsic cli bundle for windows installer"

--- a/cli/src/cli.yaml
+++ b/cli/src/cli.yaml
@@ -1,5 +1,5 @@
 name: trinsic
-version: 1.1.0
+version: 1.0.0
 author: Trinsic Technologies Inc.
 about: |-
   ┌┬┐┬─┐┬┌┐┌┌─┐┬┌─┐

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -19,10 +19,9 @@ You can get the CLI on homebrew or build the CLI from source on [Github](https:/
     ```
 
 === "Windows"
-    The CLI can be installed using [Winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/)
-    ```
-    winget install trinsic.cli
-    ```
+    Download the latest CLI installer from our [Releases <small>:material-open-in-new:</small>](https://github.com/trinsic-id/sdk/releases){target=_blank}.
+
+    Select the latest `trinsic-cli-X.YY.Z-x86_64.msi` and install it.
 
 === "From source"
     The CLI can also be built from source.


### PR DESCRIPTION
- Reverts the version in `cli.yaml` to `1.0.0` as release actions depend on this constant
- Sets the asset value attached to the GitHub Release for Windows and Debian CLI Installers to include `cli` in the name
- Updates the docs to not recommend installing CLI from `winget` as we do not seem to be pushing to it anymore