### PR TITLE
fix: Allow Mewmba to run actions

### DIFF
--- a/.github/workflows/build-proto.yml
+++ b/.github/workflows/build-proto.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
           submodules: recursive
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SDK_REPO_PUSH_TOKEN }}
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Configure git credentials
         uses: OleksiyRudenko/gha-git-credentials@v2
         with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
+          token: '${{ secrets.SDK_REPO_PUSH_TOKEN }}'
 
       - uses: trinsic-id/protoc-gen-sdk@main
         id: buildsdkwrappers

--- a/.github/workflows/build-proto.yml
+++ b/.github/workflows/build-proto.yml
@@ -23,7 +23,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
           submodules: recursive
-          token: ${{ secrets.SDK_REPO_PUSH_TOKEN }}
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This has to do with GHA limitations set by github on the default `GITHUB_TOKEN`. https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the token used for configuring git credentials. 

### Detailed summary:
- Updated the token for configuring git credentials from '${{ secrets.GITHUB_TOKEN }}' to '${{ secrets.SDK_REPO_PUSH_TOKEN }}'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->