### PR TITLE
Fix docs preview action

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "docs/**/*"
+      - ".github/workflows/test-docs.yml"
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -62,7 +62,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         run: |
           echo "Deploying site ${{ env.DOCS_BRANCH_NAME }}"
-          netlify deploy --site "${{ env.DOCS_BRANCH_NAME }}" --dir ./ --prod
+          netlify deploy --site "${{ env.DOCS_BRANCH_NAME }}" --dir ./docs-site --prod
       - name: Get Changed Docs
         id: docsite
         run: |


### PR DESCRIPTION
- Fixes docs preview action
	- The preview was being deployed with `/docs-site` as the root instead of `/`, meaning that a link to `/` would 404.
		- I've not been able to figure out when/how this changed -- the last successful preview build was deployed on August 14th, and I cannot find any relevant commits since that time that reasonably would impact any of this.