### PR TITLE
Use webpack for bundling. Fix popup callback.

### DIFF
--- a/web/index.browser.ts
+++ b/web/index.browser.ts
@@ -1,3 +1,0 @@
-// This allows us to set the default aliasing
-export * from "./src";
-export * from "./src/browser";

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@trinsic/trinsic",
-    "version": "1.11.3-pre.5",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@trinsic/trinsic",
-            "version": "1.11.3-pre.5",
+            "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
                 "@azure/core-asynciterator-polyfill": "1.0.2",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@trinsic/trinsic",
-    "version": "1.0.0",
+    "version": "1.11.3-pre.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@trinsic/trinsic",
-            "version": "1.0.0",
+            "version": "1.11.3-pre.5",
             "license": "ISC",
             "dependencies": {
                 "@azure/core-asynciterator-polyfill": "1.0.2",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,10 +11,8 @@
             "dependencies": {
                 "@azure/core-asynciterator-polyfill": "1.0.2",
                 "buffer": "6.0.3",
-                "fastestsmallesttextencoderdecoder": "1.0.22",
                 "google-protobuf": "3.21.2",
                 "js-base64": "3.7.5",
-                "long": "5.2.3",
                 "nice-grpc-web": "3.2.4",
                 "oidc-client-ts": "2.2.5",
                 "protobufjs": "7.2.4"
@@ -5240,11 +5238,6 @@
             "engines": {
                 "node": ">= 4.9.1"
             }
-        },
-        "node_modules/fastestsmallesttextencoderdecoder": {
-            "version": "1.0.22",
-            "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-            "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
         },
         "node_modules/fastq": {
             "version": "1.15.0",
@@ -15676,11 +15669,6 @@
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
             "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
             "dev": true
-        },
-        "fastestsmallesttextencoderdecoder": {
-            "version": "1.0.22",
-            "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-            "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
         },
         "fastq": {
             "version": "1.15.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,9 +1,8 @@
 {
     "name": "@trinsic/trinsic",
-    "version": "1.11.3-pre.5",
+    "version": "1.0.0",
     "description": "Node and Browser wrapper for the Trinsic services",
     "main": "lib/index.js",
-    "browser": "lib/index.browser.js",
     "types": "lib/index.d.ts",
     "files": [
         "lib/**/*",
@@ -40,10 +39,8 @@
     "dependencies": {
         "@azure/core-asynciterator-polyfill": "1.0.2",
         "buffer": "6.0.3",
-        "fastestsmallesttextencoderdecoder": "1.0.22",
         "google-protobuf": "3.21.2",
         "js-base64": "3.7.5",
-        "long": "5.2.3",
         "nice-grpc-web": "3.2.4",
         "oidc-client-ts": "2.2.5",
         "protobufjs": "7.2.4"

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trinsic/trinsic",
-    "version": "1.0.0",
+    "version": "1.11.3-pre.5",
     "description": "Node and Browser wrapper for the Trinsic services",
     "main": "lib/index.js",
     "browser": "lib/index.browser.js",
@@ -9,20 +9,12 @@
         "lib/**/*",
         "dist/**/*"
     ],
-    "exports": {
-        ".": {
-            "import": {
-                "browser": "./lib/index.browser.js",
-                "default": "./lib/index.js"
-            },
-            "require": "./lib/index.js"
-        }
-    },
     "scripts": {
-        "build": "npm run build:proto && npm run build:typescript && npm run build:vite",
+        "build": "npm run build:proto && npm run build:typescript && npm run build:webpack",
         "build:proto": "pwsh Generate-Proto.ps1",
         "build:prettier": "npx prettier ./src ./test --write",
         "build:vite": "vite build",
+        "build:webpack": "webpack --mode production",
         "build:typescript": "npx tsc",
         "test:node": "jest --config .config/jest.config.cjs --no-cache",
         "test:browser": "karma start .config/karma.conf.cjs",

--- a/web/src/ConnectClient.ts
+++ b/web/src/ConnectClient.ts
@@ -1,4 +1,4 @@
-import { UserManager } from "oidc-client-ts";
+import { UserManager, WebStorageStateStore } from "oidc-client-ts";
 
 export class ConnectClient {
     public async requestVerifiableCredential(
@@ -33,11 +33,18 @@ export class ConnectClient {
                 "trinsic:schema": request.schema,
                 "trinsic:mode": "popup",
             },
+            userStore: new WebStorageStateStore({ store: window.localStorage }),
         };
 
         var manager = new UserManager(config);
 
-        return await manager.signinPopup();
+        window.open("", "trinsic-oidc-window")?.addEventListener("message", (e) => {
+            manager.signinPopupCallback();
+        });
+
+        return await manager.signinPopup({
+            popupWindowTarget: "trinsic-oidc-window",
+        });
     }
 
     public async identityVerification(): Promise<any> {

--- a/web/src/ConnectClient.ts
+++ b/web/src/ConnectClient.ts
@@ -1,7 +1,7 @@
 import { UserManager } from "oidc-client-ts";
 
 export class ConnectClient {
-    public static async requestVerifiableCredential(
+    public async requestVerifiableCredential(
         request: IVerifiableCredentialRequest,
     ): Promise<any> {
         if (!request || !request.ecosystem || !request.schema) {
@@ -30,19 +30,17 @@ export class ConnectClient {
 
             extraQueryParams: {
                 "trinsic:ecosystem": request.ecosystem,
-                "trinsic:schema": encodeURIComponent(request.schema),
+                "trinsic:schema": request.schema,
                 "trinsic:mode": "popup",
             },
         };
 
         var manager = new UserManager(config);
 
-        var result = await manager.signinPopup();
-
-        return result;
+        return await manager.signinPopup();
     }
 
-    public static async identityVerification(): Promise<any> {
+    public async identityVerification(): Promise<any> {
         console.log("not implemented");
         return Promise.resolve({});
     }

--- a/web/src/browser/ConnectClient.ts
+++ b/web/src/browser/ConnectClient.ts
@@ -1,9 +1,12 @@
 import { UserManager } from "oidc-client-ts";
 
-export class ConnecClient {
-    public static async requestVerifableCredential(
+export class ConnectClient {
+    public static async requestVerifiableCredential(
         request: IVerifiableCredentialRequest,
     ): Promise<any> {
+        if (!request || !request.ecosystem || !request.schema) {
+            throw new Error("ecosystem and schema are required");
+        }
         var config = {
             authority: "https://connect.trinsic.cloud/",
             client_id: "http://localhost:8080/",

--- a/web/src/browser/index.ts
+++ b/web/src/browser/index.ts
@@ -1,1 +1,0 @@
-export * from "./ConnectClient";

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,6 +1,5 @@
 // Force polyfill to prevent React Native/Expo errors:
 import "@azure/core-asynciterator-polyfill";
-import "fastestsmallesttextencoderdecoder";
 
 import { WalletService } from "./WalletService";
 import { ProviderService } from "./ProviderService";
@@ -14,6 +13,7 @@ export * from "./proto/index";
 export * from "./providers";
 export * from "./FetchReactNativeTransport";
 export * from "./XHRTransport";
+export * from "./ConnectClient";
 
 export {
     TrinsicService,

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "ES2017",
-        "module": "commonjs",
+        "module": "CommonJS",
         "moduleResolution": "node",
         "declaration": true,
         "sourceMap": true,
@@ -12,5 +12,5 @@
         "forceConsistentCasingInFileNames": true
     },
     "include": ["./**/*.ts"],
-    "exclude": ["node_modules", "lib"]
+    "exclude": ["node_modules", "lib", "dist"]
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     plugins: [dts()],
     build: {
         lib: {
-            entry: path.resolve(__dirname, "index.browser.ts"),
+            entry: path.resolve(__dirname, "index.ts"),
             name: "Trinsic",
             formats: ["es", "umd"],
         },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,17 +1,29 @@
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import path from "path";
 
 // https://vitejs.dev/config/
+// export default defineConfig({
+//     plugins: [dts()],
+//     build: {
+//         outDir: "dist",
+//         rollupOptions: {},
+//         sourcemap: true,
+//         target: "esnext",
+//     },
+// });
+
 export default defineConfig({
     plugins: [dts()],
     build: {
-        rollupOptions: {},
         lib: {
-            entry: "index.browser.ts",
-            name: "trinsic",
-            formats: ["umd", "es"],
+            entry: path.resolve(__dirname, "index.browser.ts"),
+            name: "Trinsic",
+            formats: ["es", "umd"],
         },
-        sourcemap: true,
-        target: "es2020",
+        rollupOptions: {
+            // Make sure to externalize dependencies that shouldn't be bundled
+            // into your library
+        },
     },
 });

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require("path");
 
 module.exports = {
-    entry: "./index.browser.ts",
+    entry: "./index.ts",
     devtool: "source-map",
     module: {
         rules: [

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -1,0 +1,30 @@
+const path = require("path");
+
+module.exports = {
+    entry: "./index.browser.ts",
+    devtool: "source-map",
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                use: "ts-loader",
+                exclude: /node_modules/,
+            },
+        ],
+    },
+    resolve: {
+        extensions: [".tsx", ".ts", ".js"],
+    },
+    output: {
+        filename: "trinsic.min.js",
+        path: path.resolve(__dirname, "dist"),
+        library: "trinsic",
+        libraryTarget: "umd",
+        globalObject: "this",
+    },
+    externals: {
+        // Optionally externalize some dependencies to reduce bundle size
+        // react: 'React',
+        // 'react-dom': 'ReactDOM'
+    },
+};


### PR DESCRIPTION
For some reason, I couldn't get vite to properly bundle without erroring at runtime. Webpack seemed to work, so going with that for now.
`vite` assets are still configured if anyone wants to take a stab at it.