### PR TITLE
Fix docs PR preview

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -63,7 +63,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         run: |
           echo "Deploying site ${{ env.DOCS_BRANCH_NAME }}"
-          netlify deploy --site "${{ env.DOCS_BRANCH_NAME }}" --dir ./docs-site --prod
+          netlify deploy --site "${{ env.DOCS_BRANCH_NAME }}" --dir ./ --prod
       - name: Get Changed Docs
         id: docsite
         run: |


### PR DESCRIPTION
- This originally broke out of the blue around August 14; I created #1494 to fix
	- This restored proper functionality until September 15, when it broke again
- I've narrowed this down to a `netlify-cli` bug regarding how the `--dir` flag was handled
	- My #1494 worked around this introduced bug, though I didn't know where the actual issue was coming from at the time
	- `netlify-cli` was recently [patched](https://github.com/netlify/cli/releases/tag/v16.3.3) to fix the underlying bug, meaning that my workaround became a bug itself