### PR TITLE
Set client_id and redirect_uri to the calling context

### DIFF
--- a/web/src/ConnectClient.ts
+++ b/web/src/ConnectClient.ts
@@ -381,7 +381,11 @@ export class ConnectClient {
             throw new Error("ecosystem and schema are required");
         }
 
-        const settings = { ...this.oidcConfig };
+        const settings = {
+            ...this.oidcConfig,
+            client_id: window.location.href,
+            redirect_uri: window.location.href,
+        };
         settings.extraQueryParams!["trinsic:ecosystem"] = request.ecosystem;
         settings.extraQueryParams!["trinsic:schema"] = request.schema;
 


### PR DESCRIPTION
Ensure the client_id and redirect_uri parameters in OIDC match the calling context, to ensure correct display of verifier information