### PR TITLE
Add necessary `allow` attributes to Trinsic Connect iFrame

### DIFF
--- a/web/src/ConnectClient.ts
+++ b/web/src/ConnectClient.ts
@@ -330,7 +330,7 @@ export class ConnectClient {
 
         const iframe = document.createElement("iframe");
         iframe.className = "h-full w-full bg-transparent";
-        iframe.allow = "camera *; microphone *; display-capture *";
+        iframe.allow = "camera *; microphone *; display-capture *; publickey-credentials-get *; publickey-credentials-create *";
         iframe.src = `${this.baseUrl}/connect/verify?clientToken=${clientToken}`;
 
         modalContainer.append(iframe);


### PR DESCRIPTION
- Adds `publickey-credentials-create *` and `publickey-credentials-get *` to `allow` attribute of iframe created to render Trinsic Connect flow