### PR TITLE
build: Run full suite of `grpc-web` tests

### DIFF
--- a/.github/workflows/test-infrastructure.yml
+++ b/.github/workflows/test-infrastructure.yml
@@ -64,7 +64,7 @@ jobs:
         name: "Install packages"
         shell: pwsh
         working-directory: ./sdk/web
-      - run: npm run test:grpc-web-tests -- --trinsic_environment="${{ inputs.environment }}"
+      - run: npm run test:browser -- --trinsic_environment="${{ inputs.environment }}"
         name: "Run grpc-web tests"
         shell: pwsh
         working-directory: ./sdk/web


### PR DESCRIPTION
Now that we have a longer timeout for `did:web` `fetch()`, we should see if these tests are actually flaky.